### PR TITLE
feat: bump seictl to use S3 transfer manager for parallel snapshot downloads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.38.2
 	github.com/sei-protocol/sei-config v0.0.5
-	github.com/sei-protocol/seictl v0.0.13
+	github.com/sei-protocol/seictl v0.0.14-0.20260315153226-9123721cd49e
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sei-protocol/sei-config v0.0.5 h1:edMsQk0/WijGwbZIccSGC2FtPkw0N9XIWDSGgsDeAFw=
 github.com/sei-protocol/sei-config v0.0.5/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
-github.com/sei-protocol/seictl v0.0.13 h1:AoJNfA8lo0cQLbqyWJVCKRIauAoDvi4UOnJwfux7S/I=
-github.com/sei-protocol/seictl v0.0.13/go.mod h1:Tf6AISrbFK0i9/BYHB4pkDrLrk5KAfuFuTkz/fKfY9w=
+github.com/sei-protocol/seictl v0.0.14-0.20260315153226-9123721cd49e h1:7c6pOpzGXu55cip2+pYFe2D+fVibcTkZVA5pIl4s0YI=
+github.com/sei-protocol/seictl v0.0.14-0.20260315153226-9123721cd49e/go.mod h1:Tf6AISrbFK0i9/BYHB4pkDrLrk5KAfuFuTkz/fKfY9w=
 github.com/spf13/cobra v1.10.0 h1:a5/WeUlSDCvV5a45ljW2ZFtV0bTDpkfSAj3uqB6Sc+0=
 github.com/spf13/cobra v1.10.0/go.mod h1:9dhySC7dnTtEiqzmqfkLj47BslqLCUPMXjG2lj/NgoE=
 github.com/spf13/pflag v1.0.8/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/internal/controller/node/labels.go
+++ b/internal/controller/node/labels.go
@@ -12,7 +12,7 @@ const (
 	nodeServiceAccount  = "seid-node"
 	defaultStorageSize  = "1000Gi"
 	defaultStorageClass = ""
-	defaultSidecarImage = "ghcr.io/sei-protocol/seictl@sha256:7d8e2ec17317ddfce679ce454518716192ad134dfc7e45c078e49b659283ed41"
+	defaultSidecarImage = "ghcr.io/sei-protocol/seictl@sha256:ad50d546c3aa4bfa220b3148ffc40b59d34d7c8d09522fa1ff25f635f2f1e710"
 )
 
 func resourceLabelsForNode(node *seiv1alpha1.SeiNode) map[string]string {

--- a/manifests/samples/pacific-1-replay.yaml
+++ b/manifests/samples/pacific-1-replay.yaml
@@ -9,7 +9,7 @@ spec:
   image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:837ba922db3f5313a474fbe0c7bba4cbec466cdc
 
   sidecar:
-    image: ghcr.io/sei-protocol/seictl@sha256:f47f680d220b191e4934343819923b0501b9dd72f2b5c315782a524efc7b8a1b
+    image: ghcr.io/sei-protocol/seictl@sha256:ad50d546c3aa4bfa220b3148ffc40b59d34d7c8d09522fa1ff25f635f2f1e710
 
   entrypoint:
     command: ["seid"]

--- a/manifests/samples/pacific-1-snapshotter.yaml
+++ b/manifests/samples/pacific-1-snapshotter.yaml
@@ -9,7 +9,7 @@ spec:
   image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-chain:837ba922db3f5313a474fbe0c7bba4cbec466cdc
 
   sidecar:
-    image: ghcr.io/sei-protocol/seictl@sha256:f47f680d220b191e4934343819923b0501b9dd72f2b5c315782a524efc7b8a1b
+    image: ghcr.io/sei-protocol/seictl@sha256:ad50d546c3aa4bfa220b3148ffc40b59d34d7c8d09522fa1ff25f635f2f1e710
 
   entrypoint:
     command: ["seid"]


### PR DESCRIPTION
## Summary
- Bumps `seictl` dependency to pick up [sei-protocol/seictl#27](https://github.com/sei-protocol/seictl/pull/27) which integrates the AWS S3 transfer manager for parallel byte-range downloads during snapshot restore
- Updates `defaultSidecarImage` in `labels.go` and sample manifests (`pacific-1-snapshotter`, `pacific-1-replay`) to the new container digest (`sha256:ad50d546c3aa...`)

## Test plan
- [ ] Verify controller builds cleanly with updated dependency
- [ ] Deploy to brandon cluster and confirm snapshot restore uses parallel downloads
- [ ] Monitor snapshotter and replay nodes through full state-sync cycle