### PR TITLE
feat: derive pod resources and PVC sizing from node mode

### DIFF
--- a/internal/controller/node/labels.go
+++ b/internal/controller/node/labels.go
@@ -10,8 +10,6 @@ const (
 	nodeLabel           = "sei.io/node"
 	dataDir             = "/sei"
 	nodeServiceAccount  = "seid-node"
-	defaultStorageSize  = "1000Gi"
-	defaultStorageClass = ""
 	defaultSidecarImage = "ghcr.io/sei-protocol/seictl@sha256:ad50d546c3aa4bfa220b3148ffc40b59d34d7c8d09522fa1ff25f635f2f1e710"
 )
 

--- a/internal/controller/node/resources.go
+++ b/internal/controller/node/resources.go
@@ -129,6 +129,7 @@ func buildSidecarContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 func buildSidecarMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	container := buildNodeMainContainer(node)
 	container.Command, container.Args = sidecarWaitCommand(node)
+	container.Resources = defaultResourcesForMode(node.Spec.Mode)
 	container.StartupProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -264,6 +265,8 @@ func generateNodeHeadlessService(node *seiv1alpha1.SeiNode) *corev1.Service {
 }
 
 func generateNodeDataPVC(node *seiv1alpha1.SeiNode) *corev1.PersistentVolumeClaim {
+	sc, size := defaultStorageForMode(node.Spec.Mode)
+
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodeDataPVCName(node),
@@ -271,18 +274,14 @@ func generateNodeDataPVC(node *seiv1alpha1.SeiNode) *corev1.PersistentVolumeClai
 			Labels:    resourceLabelsForNode(node),
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &sc,
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(defaultStorageSize),
+					corev1.ResourceStorage: resource.MustParse(size),
 				},
 			},
 		},
-	}
-
-	if defaultStorageClass != "" {
-		sc := defaultStorageClass
-		pvc.Spec.StorageClassName = &sc
 	}
 
 	return pvc

--- a/internal/controller/node/sizing.go
+++ b/internal/controller/node/sizing.go
@@ -1,0 +1,69 @@
+package node
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	modeArchive   = "archive"
+	modeRPC       = "rpc"
+	modeFull      = "full"
+	modeValidator = "validator"
+	modeSeed      = "seed"
+
+	storageClassPerf    = "gp3-perf"
+	storageClassDefault = "gp3"
+)
+
+// defaultResourcesForMode returns CPU and memory requests for the seid
+// container based on the node's operating mode. These requests drive
+// Karpenter's instance selection — the scheduler places the pod on a node
+// whose allocatable resources satisfy the request.
+//
+// Values are derived from sei-infra production sizing, scaled down for
+// staging parity while remaining large enough for SeiDB's memIAVL page
+// cache to function without constant disk reads.
+func defaultResourcesForMode(mode string) corev1.ResourceRequirements {
+	switch mode {
+	case modeArchive:
+		return makeResources("8", "48Gi")
+	case modeRPC:
+		return makeResources("8", "48Gi")
+	case modeFull:
+		return makeResources("4", "32Gi")
+	case modeValidator:
+		return makeResources("4", "32Gi")
+	case modeSeed:
+		return makeResources("2", "8Gi")
+	default:
+		return makeResources("4", "32Gi")
+	}
+}
+
+// defaultStorageForMode returns the StorageClass name and PVC size for a
+// node based on its operating mode. Heavier modes use the gp3-perf class
+// with provisioned IOPS; lightweight modes fall back to baseline gp3.
+func defaultStorageForMode(mode string) (storageClass string, size string) {
+	switch mode {
+	case modeArchive:
+		return storageClassPerf, "2000Gi"
+	case modeRPC:
+		return storageClassPerf, "1500Gi"
+	case modeFull, modeValidator:
+		return storageClassPerf, "1000Gi"
+	case modeSeed:
+		return storageClassDefault, "500Gi"
+	default:
+		return storageClassDefault, "1000Gi"
+	}
+}
+
+func makeResources(cpu, memory string) corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(cpu),
+			corev1.ResourceMemory: resource.MustParse(memory),
+		},
+	}
+}

--- a/internal/controller/node/task_builders.go
+++ b/internal/controller/node/task_builders.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultSnapshotUploadCron = "0 0 * * *"
 	defaultSnapshotInterval   = int64(2000)
-	defaultMode               = "full"
+	defaultMode               = modeFull
 
 	valNothing = "nothing"
 )


### PR DESCRIPTION
## Summary
- Add `sizing.go` with `defaultResourcesForMode()` and `defaultStorageForMode()` that derive CPU/memory requests and StorageClass/size from `spec.mode`
- Wire mode-based resources into the seid container in `buildSidecarMainContainer()`
- Wire mode-based storage class and size into `generateNodeDataPVC()`, replacing the hardcoded `defaultStorageSize` / `defaultStorageClass` constants
- Mode defaults derived from sei-infra production sizing (scaled for staging):
  - archive/rpc: 8 CPU, 48Gi RAM, gp3-perf 2TB/1.5TB
  - full/validator: 4 CPU, 32Gi RAM, gp3-perf 1TB
  - seed: 2 CPU, 8Gi RAM, gp3 500Gi

Companion platform changes (Karpenter NodePool + gp3-perf StorageClass) are in the `ftr-agent` branch of the platform repo.

## Test plan
- [x] `golangci-lint` passes with 0 issues
- [x] `go test ./...` passes
- [ ] Deploy to brandon cluster and verify Karpenter provisions r-family instances
- [ ] Verify PVCs are created with gp3-perf StorageClass and mode-appropriate sizes