### PR TITLE
feat: use explicit task status from sidecar for polling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.25.6
 require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.38.2
-	github.com/sei-protocol/sei-config v0.0.5
-	github.com/sei-protocol/seictl v0.0.14
+	github.com/sei-protocol/sei-config v0.0.7
+	github.com/sei-protocol/seictl v0.0.15
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
@@ -54,6 +54,7 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/sei-protocol/seilog v0.0.2 // indirect
 	github.com/spf13/cobra v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,10 +126,12 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sei-protocol/sei-config v0.0.5 h1:edMsQk0/WijGwbZIccSGC2FtPkw0N9XIWDSGgsDeAFw=
-github.com/sei-protocol/sei-config v0.0.5/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
-github.com/sei-protocol/seictl v0.0.14 h1:NVvMHpaVhRS+SIXBOy5rjS4AVtOLSif3DbNg6IUdcd0=
-github.com/sei-protocol/seictl v0.0.14/go.mod h1:Tf6AISrbFK0i9/BYHB4pkDrLrk5KAfuFuTkz/fKfY9w=
+github.com/sei-protocol/sei-config v0.0.7 h1:ysNBOrhbIA3RXAmNBxw++m5nvBWPUDOm6cN7g/9H1Ec=
+github.com/sei-protocol/sei-config v0.0.7/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/seictl v0.0.15 h1:VIbIj9Nc4nEjOQjqqYhJg5fOx1ztB7K0e1xfdzsAic8=
+github.com/sei-protocol/seictl v0.0.15/go.mod h1:CHKMT7b7n6wUaPnWajOgqs8mEZA8NchLa7ct+KgQPcw=
+github.com/sei-protocol/seilog v0.0.2 h1:xDWNr1LUHLnOER1o/5f3rq2TQZFCv/mG1ANBaQcw24s=
+github.com/sei-protocol/seilog v0.0.2/go.mod h1:CKg58wraWnB3gRxWQ0v1rIVr0gmDHjkfP1bM2giKFFU=
 github.com/spf13/cobra v1.10.0 h1:a5/WeUlSDCvV5a45ljW2ZFtV0bTDpkfSAj3uqB6Sc+0=
 github.com/spf13/cobra v1.10.0/go.mod h1:9dhySC7dnTtEiqzmqfkLj47BslqLCUPMXjG2lj/NgoE=
 github.com/spf13/pflag v1.0.8/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/internal/controller/node/plan_execution.go
+++ b/internal/controller/node/plan_execution.go
@@ -154,24 +154,30 @@ func (r *SeiNodeReconciler) pollTask(
 		return ctrl.Result{RequeueAfter: bootstrapPollInterval}, nil
 	}
 
-	// Still running.
-	if result.CompletedAt == nil {
+	switch result.Status {
+	case sidecar.TaskResultStatusRunning:
+		log.FromContext(ctx).V(1).Info("task still running", "task", task.Type)
+		return ctrl.Result{RequeueAfter: bootstrapPollInterval}, nil
+
+	case sidecar.TaskResultStatusFailed:
+		errMsg := "unknown error"
+		if result.Error != nil && *result.Error != "" {
+			errMsg = *result.Error
+		}
+		return r.failTask(ctx, node, task, errMsg)
+
+	case sidecar.TaskResultStatusCompleted:
+		patch := client.MergeFrom(node.DeepCopy())
+		task.Status = seiv1alpha1.PlannedTaskComplete
+		if err := r.Status().Patch(ctx, node, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("marking task complete: %w", err)
+		}
+		return ctrl.Result{RequeueAfter: 1}, nil
+
+	default:
+		log.FromContext(ctx).Info("unexpected task status, will retry", "task", task.Type, "status", result.Status)
 		return ctrl.Result{RequeueAfter: bootstrapPollInterval}, nil
 	}
-
-	// Failed.
-	if result.Error != nil && *result.Error != "" {
-		return r.failTask(ctx, node, task, *result.Error)
-	}
-
-	// Completed successfully — mark and let the next reconcile advance.
-	patch := client.MergeFrom(node.DeepCopy())
-	task.Status = seiv1alpha1.PlannedTaskComplete
-	if err := r.Status().Patch(ctx, node, patch); err != nil {
-		return ctrl.Result{}, fmt.Errorf("marking task complete: %w", err)
-	}
-
-	return ctrl.Result{RequeueAfter: 1}, nil
 }
 
 // failTask marks an individual task and the overall plan as Failed.

--- a/internal/controller/node/plan_execution_test.go
+++ b/internal/controller/node/plan_execution_test.go
@@ -55,9 +55,14 @@ func strPtr(s string) *string { return &s }
 
 func completedResult(id uuid.UUID, taskType string, taskErr *string) *sidecar.TaskResult {
 	now := time.Now()
+	status := sidecar.TaskResultStatusCompleted
+	if taskErr != nil && *taskErr != "" {
+		status = sidecar.TaskResultStatusFailed
+	}
 	return &sidecar.TaskResult{
 		Id:          id,
 		Type:        taskType,
+		Status:      status,
 		SubmittedAt: now.Add(-10 * time.Second),
 		CompletedAt: &now,
 		Error:       taskErr,
@@ -68,6 +73,7 @@ func runningResult(id uuid.UUID, taskType string) *sidecar.TaskResult {
 	return &sidecar.TaskResult{
 		Id:          id,
 		Type:        taskType,
+		Status:      sidecar.TaskResultStatusRunning,
 		SubmittedAt: time.Now(),
 	}
 }


### PR DESCRIPTION
## Summary

- **Bump seictl to v0.0.15**: Picks up in-progress task tracking -- the sidecar now returns 200 with `status: "running"` instead of 404 for in-flight tasks.
- **Switch pollTask to status-based dispatch**: Replaces the `CompletedAt == nil` / `Error != ""` inference chain with an explicit `switch result.Status` over `running`, `failed`, `completed`. Unknown statuses requeue gracefully.
- **Update test helpers**: `completedResult` and `runningResult` now set the `Status` field on `TaskResult` to match the new sidecar contract.

## Test plan

- [x] All existing controller node tests pass with updated helpers
- [x] `pollTask` routes correctly for running, completed, and failed statuses
- [x] Unknown status falls through to default requeue