### PR TITLE
feat: add config/ kustomize base for self-contained controller deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Binaries
 bin/
-manager
 *.exe
 *.dll
 *.so

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ lint: ## Run golangci-lint.
 	$(GOLANGCI_LINT) run
 
 manifests: ## Generate CRD and RBAC manifests.
-	controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=manifests output:rbac:artifacts:config=manifests
+	controller-gen rbac:roleName=sei-k8s-manager-role crd webhook paths="./..." \
+		output:crd:artifacts:config=config/crd \
+		output:rbac:artifacts:config=config/rbac
+	cp config/crd/sei.io_seinodes.yaml config/crd/sei.io_seinodepools.yaml manifests/
+	cp config/rbac/role.yaml manifests/
 
 generate: ## Generate DeepCopy implementations.
 	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint: ## Run golangci-lint.
 	$(GOLANGCI_LINT) run
 
 manifests: ## Generate CRD and RBAC manifests.
-	controller-gen rbac:roleName=sei-k8s-manager-role crd webhook paths="./..." \
+	controller-gen rbac:roleName=manager-role crd webhook paths="./..." \
 		output:crd:artifacts:config=config/crd \
 		output:rbac:artifacts:config=config/rbac
 	cp config/crd/sei.io_seinodes.yaml config/crd/sei.io_seinodepools.yaml manifests/

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - sei.io_seinodes.yaml
+  - sei.io_seinodepools.yaml

--- a/config/crd/sei.io_seinodepools.yaml
+++ b/config/crd/sei.io_seinodepools.yaml
@@ -1,0 +1,213 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: seinodepools.sei.io
+spec:
+  group: sei.io
+  names:
+    kind: SeiNodePool
+    listKind: SeiNodePoolList
+    plural: seinodepools
+    shortNames:
+    - snp
+    singular: seinodepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.readyNodes
+      name: Ready
+      type: integer
+    - jsonPath: .status.totalNodes
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SeiNodePool is the Schema for the seinodepools API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SeiNodePoolSpec defines the desired state of a genesis Sei
+              node pool.
+            properties:
+              chainId:
+                description: ChainID of the genesis network.
+                minLength: 1
+                type: string
+              nodeConfiguration:
+                description: |-
+                  NodeConfiguration defines the node class for the genesis network.
+                  All nodes share the same image and entrypoint; NodeCount controls how many are deployed.
+                properties:
+                  entrypoint:
+                    description: EntrypointConfig defines the command and arguments
+                      for the node process.
+                    properties:
+                      args:
+                        items:
+                          type: string
+                        maxItems: 64
+                        type: array
+                      command:
+                        items:
+                          type: string
+                        maxItems: 16
+                        minItems: 1
+                        type: array
+                    required:
+                    - command
+                    type: object
+                  image:
+                    maxLength: 512
+                    minLength: 1
+                    type: string
+                  nodeCount:
+                    default: 1
+                    description: NodeCount is the number of nodes in the genesis network.
+                    format: int32
+                    maximum: 64
+                    minimum: 1
+                    type: integer
+                required:
+                - entrypoint
+                - image
+                type: object
+              storage:
+                description: StorageConfig defines storage parameters for node data
+                  volumes.
+                properties:
+                  retainOnDelete:
+                    default: false
+                    description: RetainOnDelete prevents data PVCs from being deleted
+                      when the SeiNodePool is deleted.
+                    type: boolean
+                type: object
+            required:
+            - chainId
+            - nodeConfiguration
+            type: object
+          status:
+            description: SeiNodePoolStatus defines the observed state of a SeiNodePool
+              deployment.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              nodeStatuses:
+                items:
+                  description: NodeStatus reports the observed state of a single node.
+                  properties:
+                    blockHeight:
+                      format: int64
+                      type: integer
+                    name:
+                      type: string
+                    ready:
+                      type: boolean
+                    stateRootHash:
+                      type: string
+                  required:
+                  - name
+                  - ready
+                  type: object
+                type: array
+              phase:
+                enum:
+                - Pending
+                - Running
+                - Failed
+                - Terminating
+                type: string
+              readyNodes:
+                format: int32
+                type: integer
+              totalNodes:
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/sei.io_seinodes.yaml
+++ b/config/crd/sei.io_seinodes.yaml
@@ -1,0 +1,804 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: seinodes.sei.io
+spec:
+  group: sei.io
+  names:
+    kind: SeiNode
+    listKind: SeiNodeList
+    plural: seinodes
+    shortNames:
+    - snode
+    singular: seinode
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SeiNode is the Schema for the seinodes API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              SeiNodeSpec defines the desired state of a standalone Sei node.
+              Exactly one mode sub-spec (fullNode, archive, replayer, validator) must be set;
+              the populated field determines the node's operating mode.
+            properties:
+              archive:
+                description: Archive configures an archive node with full history
+                  and no pruning.
+                properties:
+                  peers:
+                    description: Peers configures how the archive node discovers peers
+                      for block sync.
+                    items:
+                      description: PeerSource is a union type — exactly one field
+                        must be set.
+                      properties:
+                        ec2Tags:
+                          description: |-
+                            EC2Tags discovers peers by querying EC2 for running instances
+                            matching the specified tags.
+                          properties:
+                            region:
+                              description: Region is the AWS region to query for EC2
+                                instances.
+                              minLength: 1
+                              type: string
+                            tags:
+                              additionalProperties:
+                                type: string
+                              description: Tags are the EC2 instance tags to filter
+                                on.
+                              minProperties: 1
+                              type: object
+                          required:
+                          - region
+                          - tags
+                          type: object
+                        static:
+                          description: Static provides a fixed list of peer addresses.
+                          properties:
+                            addresses:
+                              description: Addresses is a list of peer addresses in
+                                "nodeId@host:port" format.
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          required:
+                          - addresses
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: exactly one of ec2Tags or static must be set
+                        rule: '(has(self.ec2Tags) ? 1 : 0) + (has(self.static) ? 1
+                          : 0) == 1'
+                    type: array
+                  snapshotGeneration:
+                    description: SnapshotGeneration configures periodic snapshot creation
+                      and optional upload.
+                    properties:
+                      destination:
+                        description: |-
+                          Destination configures where generated snapshots are uploaded.
+                          When set, the controller submits a scheduled upload task to the sidecar.
+                        properties:
+                          s3:
+                            description: S3 uploads snapshots to an S3 bucket.
+                            properties:
+                              bucket:
+                                description: Bucket is the S3 bucket name.
+                                minLength: 1
+                                type: string
+                              prefix:
+                                description: Prefix is an optional key prefix within
+                                  the bucket (e.g. "state-sync/").
+                                type: string
+                              region:
+                                description: Region is the AWS region of the bucket.
+                                minLength: 1
+                                type: string
+                            required:
+                            - bucket
+                            - region
+                            type: object
+                        required:
+                        - s3
+                        type: object
+                      keepRecent:
+                        description: |-
+                          KeepRecent is the number of recent snapshots to retain on disk.
+                          Must be at least 2 so the upload algorithm can select the
+                          second-to-latest completed snapshot.
+                        format: int32
+                        minimum: 2
+                        type: integer
+                    required:
+                    - keepRecent
+                    type: object
+                type: object
+              chainId:
+                description: ChainID of the chain this node belongs to.
+                minLength: 1
+                type: string
+              entrypoint:
+                description: Entrypoint overrides the image command for the running
+                  node process.
+                properties:
+                  args:
+                    items:
+                      type: string
+                    maxItems: 64
+                    type: array
+                  command:
+                    items:
+                      type: string
+                    maxItems: 16
+                    minItems: 1
+                    type: array
+                required:
+                - command
+                type: object
+              fullNode:
+                description: FullNode configures a chain-following full node (absorbs
+                  the "rpc" role).
+                properties:
+                  peers:
+                    description: Peers configures how this node discovers and connects
+                      to peers.
+                    items:
+                      description: PeerSource is a union type — exactly one field
+                        must be set.
+                      properties:
+                        ec2Tags:
+                          description: |-
+                            EC2Tags discovers peers by querying EC2 for running instances
+                            matching the specified tags.
+                          properties:
+                            region:
+                              description: Region is the AWS region to query for EC2
+                                instances.
+                              minLength: 1
+                              type: string
+                            tags:
+                              additionalProperties:
+                                type: string
+                              description: Tags are the EC2 instance tags to filter
+                                on.
+                              minProperties: 1
+                              type: object
+                          required:
+                          - region
+                          - tags
+                          type: object
+                        static:
+                          description: Static provides a fixed list of peer addresses.
+                          properties:
+                            addresses:
+                              description: Addresses is a list of peer addresses in
+                                "nodeId@host:port" format.
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          required:
+                          - addresses
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: exactly one of ec2Tags or static must be set
+                        rule: '(has(self.ec2Tags) ? 1 : 0) + (has(self.static) ? 1
+                          : 0) == 1'
+                    type: array
+                  snapshot:
+                    description: |-
+                      Snapshot configures how the node obtains its initial chain state.
+                      When absent the node block-syncs from genesis.
+                    properties:
+                      backfillBlocks:
+                        description: |-
+                          BackfillBlocks is the number of historical blocks to fetch from peers
+                          after snapshot restore.
+                        format: int64
+                        type: integer
+                      s3:
+                        description: S3 downloads a snapshot archive from an S3 bucket.
+                        properties:
+                          region:
+                            default: us-east-1
+                            description: Region is the AWS region for S3 access.
+                            type: string
+                          uri:
+                            description: URI of the snapshot archive in s3://bucket/prefix
+                              format.
+                            minLength: 1
+                            type: string
+                        required:
+                        - uri
+                        type: object
+                      stateSync:
+                        description: StateSync fetches snapshot chunks from peers
+                          via Tendermint state sync.
+                        type: object
+                      trustPeriod:
+                        description: |-
+                          TrustPeriod is the window during which the snapshot's block validators
+                          are considered trustworthy. Must be long enough to cover the age of
+                          the snapshot (e.g. "9999h0m0s" for old S3 snapshots).
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of s3 or stateSync must be set
+                      rule: '(has(self.s3) ? 1 : 0) + (has(self.stateSync) ? 1 : 0)
+                        == 1'
+                  snapshotGeneration:
+                    description: |-
+                      SnapshotGeneration configures periodic snapshot creation and optional upload.
+                      When set, the controller disables pruning and enables snapshot intervals.
+                    properties:
+                      destination:
+                        description: |-
+                          Destination configures where generated snapshots are uploaded.
+                          When set, the controller submits a scheduled upload task to the sidecar.
+                        properties:
+                          s3:
+                            description: S3 uploads snapshots to an S3 bucket.
+                            properties:
+                              bucket:
+                                description: Bucket is the S3 bucket name.
+                                minLength: 1
+                                type: string
+                              prefix:
+                                description: Prefix is an optional key prefix within
+                                  the bucket (e.g. "state-sync/").
+                                type: string
+                              region:
+                                description: Region is the AWS region of the bucket.
+                                minLength: 1
+                                type: string
+                            required:
+                            - bucket
+                            - region
+                            type: object
+                        required:
+                        - s3
+                        type: object
+                      keepRecent:
+                        description: |-
+                          KeepRecent is the number of recent snapshots to retain on disk.
+                          Must be at least 2 so the upload algorithm can select the
+                          second-to-latest completed snapshot.
+                        format: int32
+                        minimum: 2
+                        type: integer
+                    required:
+                    - keepRecent
+                    type: object
+                type: object
+              genesis:
+                description: |-
+                  Genesis configures the chain's genesis identity and where the
+                  genesis configuration is sourced from.
+                properties:
+                  pvc:
+                    description: PVC references a pre-provisioned PVC populated by
+                      SeiNodePool's genesis ceremony.
+                    properties:
+                      dataPVC:
+                        description: DataPVC is the name of the pre-populated PVC
+                          in the same namespace.
+                        minLength: 1
+                        type: string
+                    required:
+                    - dataPVC
+                    type: object
+                  s3:
+                    description: S3 configures the sidecar to download genesis.json
+                      from an S3 bucket.
+                    properties:
+                      region:
+                        description: Region is the AWS region for S3 access.
+                        type: string
+                      uri:
+                        description: URI is the S3 URI of the genesis.json file (s3://bucket/key
+                          format).
+                        minLength: 1
+                        type: string
+                    required:
+                    - uri
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: at most one of pvc or s3 may be set
+                  rule: '(has(self.pvc) ? 1 : 0) + (has(self.s3) ? 1 : 0) <= 1'
+              image:
+                description: Image is the seid container image.
+                maxLength: 512
+                minLength: 1
+                type: string
+              replayer:
+                description: Replayer configures an ephemeral replay workload that
+                  restores from a snapshot.
+                properties:
+                  peers:
+                    description: |-
+                      Peers configures how the replayer discovers peers for block sync
+                      after restoring from the snapshot.
+                    items:
+                      description: PeerSource is a union type — exactly one field
+                        must be set.
+                      properties:
+                        ec2Tags:
+                          description: |-
+                            EC2Tags discovers peers by querying EC2 for running instances
+                            matching the specified tags.
+                          properties:
+                            region:
+                              description: Region is the AWS region to query for EC2
+                                instances.
+                              minLength: 1
+                              type: string
+                            tags:
+                              additionalProperties:
+                                type: string
+                              description: Tags are the EC2 instance tags to filter
+                                on.
+                              minProperties: 1
+                              type: object
+                          required:
+                          - region
+                          - tags
+                          type: object
+                        static:
+                          description: Static provides a fixed list of peer addresses.
+                          properties:
+                            addresses:
+                              description: Addresses is a list of peer addresses in
+                                "nodeId@host:port" format.
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          required:
+                          - addresses
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: exactly one of ec2Tags or static must be set
+                        rule: '(has(self.ec2Tags) ? 1 : 0) + (has(self.static) ? 1
+                          : 0) == 1'
+                    minItems: 1
+                    type: array
+                  snapshot:
+                    description: Snapshot identifies the snapshot to restore from
+                      before replay begins.
+                    properties:
+                      backfillBlocks:
+                        description: |-
+                          BackfillBlocks is the number of historical blocks to fetch from peers
+                          after snapshot restore.
+                        format: int64
+                        type: integer
+                      s3:
+                        description: S3 downloads a snapshot archive from an S3 bucket.
+                        properties:
+                          region:
+                            default: us-east-1
+                            description: Region is the AWS region for S3 access.
+                            type: string
+                          uri:
+                            description: URI of the snapshot archive in s3://bucket/prefix
+                              format.
+                            minLength: 1
+                            type: string
+                        required:
+                        - uri
+                        type: object
+                      stateSync:
+                        description: StateSync fetches snapshot chunks from peers
+                          via Tendermint state sync.
+                        type: object
+                      trustPeriod:
+                        description: |-
+                          TrustPeriod is the window during which the snapshot's block validators
+                          are considered trustworthy. Must be long enough to cover the age of
+                          the snapshot (e.g. "9999h0m0s" for old S3 snapshots).
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of s3 or stateSync must be set
+                      rule: '(has(self.s3) ? 1 : 0) + (has(self.stateSync) ? 1 : 0)
+                        == 1'
+                required:
+                - peers
+                - snapshot
+                type: object
+              sidecar:
+                description: Sidecar configures the sei-sidecar container.
+                properties:
+                  image:
+                    description: Image overrides the sidecar container image.
+                    type: string
+                  port:
+                    default: 7777
+                    description: Port is the HTTP port the sidecar listens on.
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Resources defines CPU/memory requests and limits
+                      for the sidecar container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              storage:
+                description: Storage controls PVC lifecycle.
+                properties:
+                  retainOnDelete:
+                    default: false
+                    description: |-
+                      RetainOnDelete prevents the data PVC from being deleted when the
+                      SeiNode is deleted.
+                    type: boolean
+                type: object
+              validator:
+                description: Validator configures a consensus-participating validator
+                  node.
+                properties:
+                  peers:
+                    description: Peers configures how this node discovers and connects
+                      to peers.
+                    items:
+                      description: PeerSource is a union type — exactly one field
+                        must be set.
+                      properties:
+                        ec2Tags:
+                          description: |-
+                            EC2Tags discovers peers by querying EC2 for running instances
+                            matching the specified tags.
+                          properties:
+                            region:
+                              description: Region is the AWS region to query for EC2
+                                instances.
+                              minLength: 1
+                              type: string
+                            tags:
+                              additionalProperties:
+                                type: string
+                              description: Tags are the EC2 instance tags to filter
+                                on.
+                              minProperties: 1
+                              type: object
+                          required:
+                          - region
+                          - tags
+                          type: object
+                        static:
+                          description: Static provides a fixed list of peer addresses.
+                          properties:
+                            addresses:
+                              description: Addresses is a list of peer addresses in
+                                "nodeId@host:port" format.
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          required:
+                          - addresses
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: exactly one of ec2Tags or static must be set
+                        rule: '(has(self.ec2Tags) ? 1 : 0) + (has(self.static) ? 1
+                          : 0) == 1'
+                    type: array
+                  snapshot:
+                    description: |-
+                      Snapshot configures how the node obtains its initial chain state.
+                      When absent the node block-syncs from genesis.
+                    properties:
+                      backfillBlocks:
+                        description: |-
+                          BackfillBlocks is the number of historical blocks to fetch from peers
+                          after snapshot restore.
+                        format: int64
+                        type: integer
+                      s3:
+                        description: S3 downloads a snapshot archive from an S3 bucket.
+                        properties:
+                          region:
+                            default: us-east-1
+                            description: Region is the AWS region for S3 access.
+                            type: string
+                          uri:
+                            description: URI of the snapshot archive in s3://bucket/prefix
+                              format.
+                            minLength: 1
+                            type: string
+                        required:
+                        - uri
+                        type: object
+                      stateSync:
+                        description: StateSync fetches snapshot chunks from peers
+                          via Tendermint state sync.
+                        type: object
+                      trustPeriod:
+                        description: |-
+                          TrustPeriod is the window during which the snapshot's block validators
+                          are considered trustworthy. Must be long enough to cover the age of
+                          the snapshot (e.g. "9999h0m0s" for old S3 snapshots).
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of s3 or stateSync must be set
+                      rule: '(has(self.s3) ? 1 : 0) + (has(self.stateSync) ? 1 : 0)
+                        == 1'
+                type: object
+            required:
+            - chainId
+            - genesis
+            - image
+            type: object
+            x-kubernetes-validations:
+            - message: exactly one of fullNode, archive, replayer, or validator must
+                be set
+              rule: '(has(self.fullNode) ? 1 : 0) + (has(self.archive) ? 1 : 0) +
+                (has(self.replayer) ? 1 : 0) + (has(self.validator) ? 1 : 0) == 1'
+          status:
+            description: SeiNodeStatus defines the observed state of a SeiNode.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configStatus:
+                description: ConfigStatus reports the observed configuration state
+                  from the sidecar.
+                properties:
+                  diagnostics:
+                    description: Diagnostics contains validation findings from the
+                      last config-validate task.
+                    items:
+                      description: ConfigDiagnostic is a single finding from config
+                        validation.
+                      properties:
+                        field:
+                          description: Field is the config key path that the diagnostic
+                            applies to.
+                          type: string
+                        message:
+                          description: Message describes the finding.
+                          type: string
+                        severity:
+                          description: 'Severity is the diagnostic level: ERROR, WARNING,
+                            or INFO.'
+                          type: string
+                      required:
+                      - field
+                      - message
+                      - severity
+                      type: object
+                    type: array
+                  driftDetected:
+                    description: DriftDetected is true when the on-disk config diverges
+                      from the CRD-desired state.
+                    type: boolean
+                  lastAppliedAt:
+                    description: LastAppliedAt is the timestamp of the last successful
+                      config-apply task.
+                    format: date-time
+                    type: string
+                  lastValidatedAt:
+                    description: LastValidatedAt is the timestamp of the last successful
+                      config-validate task.
+                    format: date-time
+                    type: string
+                  mode:
+                    description: Mode is the config mode that was applied.
+                    type: string
+                  version:
+                    description: Version is the on-disk config schema version.
+                    type: integer
+                type: object
+              initPlan:
+                description: InitPlan tracks the initialization task sequence for
+                  this node.
+                properties:
+                  phase:
+                    description: Phase is the overall state of the plan.
+                    enum:
+                    - Active
+                    - Complete
+                    - Failed
+                    type: string
+                  tasks:
+                    description: Tasks is the ordered list of tasks to execute.
+                    items:
+                      description: PlannedTask is a single task within a TaskPlan.
+                      properties:
+                        error:
+                          description: Error is the error message if the task failed.
+                          type: string
+                        status:
+                          description: Status is the current state of this task.
+                          enum:
+                          - Pending
+                          - Submitted
+                          - Complete
+                          - Failed
+                          type: string
+                        taskID:
+                          description: TaskID is the UUID assigned by the sidecar
+                            when the task was submitted.
+                          type: string
+                        type:
+                          description: Type identifies the sidecar task (e.g. "snapshot-restore",
+                            "config-patch").
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                required:
+                - phase
+                - tasks
+                type: object
+              phase:
+                description: Phase is the high-level lifecycle state.
+                enum:
+                - Pending
+                - Running
+                - Failed
+                - Terminating
+                type: string
+              scheduledTasks:
+                additionalProperties:
+                  type: string
+                description: |-
+                  ScheduledTasks maps task type to the sidecar-assigned UUID of its
+                  scheduled task.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../crd
+  - ../rbac
+  - ../manager
+  - ../network-policy

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namePrefix: sei-k8s-
+
 resources:
   - ../crd
   - ../rbac

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - manager.yaml
+  - metrics_service.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sei-k8s-controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: sei-k8s-controller
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: sei-k8s-controller
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+        app.kubernetes.io/name: sei-k8s-controller
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - command:
+        - /manager
+        args:
+          - --metrics-bind-address=:8443
+          - --leader-elect
+          - --health-probe-bind-address=:8081
+        image: controller:latest
+        name: manager
+        ports: []
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+        volumeMounts: []
+      volumes: []
+      serviceAccountName: sei-k8s-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sei-k8s-controller-manager
+  name: controller-manager
   namespace: system
   labels:
     control-plane: controller-manager
@@ -59,5 +59,5 @@ spec:
             memory: 128Mi
         volumeMounts: []
       volumes: []
-      serviceAccountName: sei-k8s-controller-manager
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/manager/metrics_service.yaml
+++ b/config/manager/metrics_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: sei-k8s-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: sei-k8s-controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: sei-k8s-controller

--- a/config/manager/metrics_service.yaml
+++ b/config/manager/metrics_service.yaml
@@ -5,7 +5,7 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: sei-k8s-controller
     app.kubernetes.io/managed-by: kustomize
-  name: sei-k8s-controller-manager-metrics-service
+  name: controller-manager-metrics-service
   namespace: system
 spec:
   ports:

--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: sei-k8s-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: sei-k8s-allow-metrics-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: sei-k8s-controller
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: 8443
+          protocol: TCP

--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: sei-k8s-controller
     app.kubernetes.io/managed-by: kustomize
-  name: sei-k8s-allow-metrics-traffic
+  name: allow-metrics-traffic
   namespace: system
 spec:
   podSelector:

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - allow-metrics-traffic.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service_account.yaml
+  - role.yaml
+  - role_binding.yaml
+  - leader_election_role.yaml
+  - leader_election_role_binding.yaml
+  - metrics_auth_role.yaml
+  - metrics_auth_role_binding.yaml
+  - metrics_reader_role.yaml

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: sei-k8s-controller
     app.kubernetes.io/managed-by: kustomize
-  name: sei-k8s-leader-election-role
+  name: leader-election-role
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -1,0 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: sei-k8s-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: sei-k8s-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     app.kubernetes.io/name: sei-k8s-controller
     app.kubernetes.io/managed-by: kustomize
-  name: sei-k8s-leader-election-rolebinding
+  name: leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: sei-k8s-leader-election-role
+  name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: sei-k8s-controller-manager
+  name: controller-manager
   namespace: system

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: sei-k8s-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: sei-k8s-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sei-k8s-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: sei-k8s-controller-manager
+  namespace: system

--- a/config/rbac/metrics_auth_role.yaml
+++ b/config/rbac/metrics_auth_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sei-k8s-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/config/rbac/metrics_auth_role.yaml
+++ b/config/rbac/metrics_auth_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: sei-k8s-metrics-auth-role
+  name: metrics-auth-role
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/config/rbac/metrics_auth_role_binding.yaml
+++ b/config/rbac/metrics_auth_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sei-k8s-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sei-k8s-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: sei-k8s-controller-manager
+  namespace: system

--- a/config/rbac/metrics_auth_role_binding.yaml
+++ b/config/rbac/metrics_auth_role_binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: sei-k8s-metrics-auth-rolebinding
+  name: metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: sei-k8s-metrics-auth-role
+  name: metrics-auth-role
 subjects:
 - kind: ServiceAccount
-  name: sei-k8s-controller-manager
+  name: controller-manager
   namespace: system

--- a/config/rbac/metrics_reader_role.yaml
+++ b/config/rbac/metrics_reader_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: sei-k8s-metrics-reader
+  name: metrics-reader
 rules:
 - nonResourceURLs:
   - "/metrics"

--- a/config/rbac/metrics_reader_role.yaml
+++ b/config/rbac/metrics_reader_role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sei-k8s-metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sei-k8s-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - persistentvolumeclaims
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sei.io
+  resources:
+  - seinodepools
+  - seinodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sei.io
+  resources:
+  - seinodepools/finalizers
+  - seinodes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - sei.io
+  resources:
+  - seinodepools/status
+  - seinodes/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: sei-k8s-manager-role
+  name: manager-role
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     app.kubernetes.io/name: sei-k8s-controller
     app.kubernetes.io/managed-by: kustomize
-  name: sei-k8s-manager-rolebinding
+  name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: sei-k8s-manager-role
+  name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: sei-k8s-controller-manager
+  name: controller-manager
   namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: sei-k8s-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: sei-k8s-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sei-k8s-manager-role
+subjects:
+- kind: ServiceAccount
+  name: sei-k8s-controller-manager
+  namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -4,5 +4,5 @@ metadata:
   labels:
     app.kubernetes.io/name: sei-k8s-controller
     app.kubernetes.io/managed-by: kustomize
-  name: sei-k8s-controller-manager
+  name: controller-manager
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: sei-k8s-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: sei-k8s-controller-manager
+  namespace: system


### PR DESCRIPTION
## Summary

- Adds a `config/` directory following the standard kubebuilder convention with subdirectories for `crd/`, `rbac/`, `manager/`, `network-policy/`, and `default/`
- All resource names are explicitly prefixed with `sei-k8s-` so manifests are self-descriptive without relying on kustomize `namePrefix` transforms
- Updates Makefile to output `controller-gen` artifacts directly into `config/` (with a copy back to `manifests/` for `kubectl apply -f` convenience)

## Context

The platform repo currently duplicates all controller deployment artifacts (CRDs, RBAC, Deployment, etc.). With this change, the controller repo provides a self-contained kustomize base at `config/default/`, and the platform repo can reference it as a remote base — only overlaying environment-specific values like namespace, image digest, and replica count.

## Test plan

- [x] `kubectl kustomize config/default` builds successfully and produces correct output
- [x] CI passes (lint, test, build)
- [ ] Platform overlay referencing this base via `github.com/sei-protocol/sei-k8s-controller/config/default?ref=<sha>` resolves and builds correctly
