### PR TITLE
feat: parameterize storage classes, sizes, and resource requests

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -124,6 +124,30 @@ func main() {
 	if v := os.Getenv("SEI_SERVICE_ACCOUNT"); v != "" {
 		platform.ServiceAccount = v
 	}
+	if v := os.Getenv("SEI_STORAGE_CLASS_PERF"); v != "" {
+		platform.StorageClassPerf = v
+	}
+	if v := os.Getenv("SEI_STORAGE_CLASS_DEFAULT"); v != "" {
+		platform.StorageClassDefault = v
+	}
+	if v := os.Getenv("SEI_STORAGE_SIZE_DEFAULT"); v != "" {
+		platform.StorageSizeDefault = v
+	}
+	if v := os.Getenv("SEI_STORAGE_SIZE_ARCHIVE"); v != "" {
+		platform.StorageSizeArchive = v
+	}
+	if v := os.Getenv("SEI_RESOURCE_CPU_ARCHIVE"); v != "" {
+		platform.ResourceCPUArchive = v
+	}
+	if v := os.Getenv("SEI_RESOURCE_MEM_ARCHIVE"); v != "" {
+		platform.ResourceMemArchive = v
+	}
+	if v := os.Getenv("SEI_RESOURCE_CPU_DEFAULT"); v != "" {
+		platform.ResourceCPUDefault = v
+	}
+	if v := os.Getenv("SEI_RESOURCE_MEM_DEFAULT"); v != "" {
+		platform.ResourceMemDefault = v
+	}
 
 	if err := (&nodecontroller.SeiNodeReconciler{
 		Client:   mgr.GetClient(),

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,8 +32,25 @@ spec:
           - --metrics-bind-address=:8443
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller@sha256:e0b1a7644dfa5284bf241dea117b2b1d44a26b735a034753049edb210a126210
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller@sha256:ee65334ea4523628a2ce49a6a9176aa91ed1a30828ea258cf86c86f6446fc11a
         name: manager
+        env:
+          - name: SEI_STORAGE_CLASS_PERF
+            value: gp3-10k-750
+          - name: SEI_STORAGE_CLASS_DEFAULT
+            value: gp3
+          - name: SEI_STORAGE_SIZE_DEFAULT
+            value: 1000Gi
+          - name: SEI_STORAGE_SIZE_ARCHIVE
+            value: 2000Gi
+          - name: SEI_RESOURCE_CPU_ARCHIVE
+            value: "8"
+          - name: SEI_RESOURCE_MEM_ARCHIVE
+            value: 48Gi
+          - name: SEI_RESOURCE_CPU_DEFAULT
+            value: "4"
+          - name: SEI_RESOURCE_MEM_DEFAULT
+            value: 32Gi
         ports: []
         securityContext:
           readOnlyRootFilesystem: true

--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -28,19 +28,35 @@ const (
 // environment. Values are read from environment variables in main.go with
 // sensible defaults.
 type PlatformConfig struct {
-	NodepoolName   string
-	TolerationKey  string
-	TolerationVal  string
-	ServiceAccount string
+	NodepoolName        string
+	TolerationKey       string
+	TolerationVal       string
+	ServiceAccount      string
+	StorageClassPerf    string
+	StorageClassDefault string
+	StorageSizeDefault  string
+	StorageSizeArchive  string
+	ResourceCPUArchive  string
+	ResourceMemArchive  string
+	ResourceCPUDefault  string
+	ResourceMemDefault  string
 }
 
 // DefaultPlatformConfig returns PlatformConfig with production defaults.
 func DefaultPlatformConfig() PlatformConfig {
 	return PlatformConfig{
-		NodepoolName:   "sei-node",
-		TolerationKey:  "sei.io/workload",
-		TolerationVal:  "sei-node",
-		ServiceAccount: "seid-node",
+		NodepoolName:        "sei-node",
+		TolerationKey:       "sei.io/workload",
+		TolerationVal:       "sei-node",
+		ServiceAccount:      "seid-node",
+		StorageClassPerf:    "gp3-10k-750",
+		StorageClassDefault: "gp3",
+		StorageSizeDefault:  "1000Gi",
+		StorageSizeArchive:  "2000Gi",
+		ResourceCPUArchive:  "8",
+		ResourceMemArchive:  "48Gi",
+		ResourceCPUDefault:  "4",
+		ResourceMemDefault:  "32Gi",
 	}
 }
 
@@ -154,7 +170,7 @@ func (r *SeiNodeReconciler) deleteNodeDataPVC(ctx context.Context, node *seiv1al
 }
 
 func (r *SeiNodeReconciler) ensureNodeDataPVC(ctx context.Context, node *seiv1alpha1.SeiNode) error {
-	desired := generateNodeDataPVC(node)
+	desired := generateNodeDataPVC(node, r.Platform)
 	if err := ctrl.SetControllerReference(node, desired, r.Scheme); err != nil {
 		return fmt.Errorf("setting owner reference: %w", err)
 	}

--- a/internal/controller/node/plan_execution_test.go
+++ b/internal/controller/node/plan_execution_test.go
@@ -94,8 +94,9 @@ func newProgressionReconciler(t *testing.T, mock *mockSidecarClient, objs ...cli
 		WithStatusSubresource(&seiv1alpha1.SeiNode{}).
 		Build()
 	r := &SeiNodeReconciler{
-		Client: c,
-		Scheme: s,
+		Client:   c,
+		Scheme:   s,
+		Platform: DefaultPlatformConfig(),
 		BuildSidecarClientFn: func(_ *seiv1alpha1.SeiNode) SidecarStatusClient {
 			return mock
 		},

--- a/internal/controller/node/reconciler_test.go
+++ b/internal/controller/node/reconciler_test.go
@@ -39,8 +39,9 @@ func newNodeReconciler(t *testing.T, objs ...client.Object) (*SeiNodeReconciler,
 		WithStatusSubresource(&seiv1alpha1.SeiNode{}).
 		Build()
 	r := &SeiNodeReconciler{
-		Client: c,
-		Scheme: s,
+		Client:   c,
+		Scheme:   s,
+		Platform: DefaultPlatformConfig(),
 		BuildSidecarClientFn: func(_ *seiv1alpha1.SeiNode) SidecarStatusClient {
 			return &mockSidecarClient{}
 		},

--- a/internal/controller/node/resources.go
+++ b/internal/controller/node/resources.go
@@ -76,7 +76,7 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, platform PlatformConfig) corev1
 		buildSeidInitContainer(node),
 		buildSidecarContainer(node),
 	}
-	spec.Containers = []corev1.Container{buildSidecarMainContainer(node)}
+	spec.Containers = []corev1.Container{buildSidecarMainContainer(node, platform)}
 
 	return spec
 }
@@ -125,10 +125,10 @@ func buildSidecarContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 // sidecar to become healthy before exec'ing seid. Kubernetes starts main
 // containers as soon as restartable init containers are running, so we
 // wrap the entrypoint in a shell loop that polls /healthz until 200.
-func buildSidecarMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
+func buildSidecarMainContainer(node *seiv1alpha1.SeiNode, platform PlatformConfig) corev1.Container {
 	container := buildNodeMainContainer(node)
 	container.Command, container.Args = sidecarWaitCommand(node)
-	container.Resources = defaultResourcesForMode(nodeMode(node))
+	container.Resources = defaultResourcesForMode(nodeMode(node), platform)
 	container.StartupProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -261,8 +261,8 @@ func generateNodeHeadlessService(node *seiv1alpha1.SeiNode) *corev1.Service {
 	}
 }
 
-func generateNodeDataPVC(node *seiv1alpha1.SeiNode) *corev1.PersistentVolumeClaim {
-	sc, size := defaultStorageForMode(nodeMode(node))
+func generateNodeDataPVC(node *seiv1alpha1.SeiNode, platform PlatformConfig) *corev1.PersistentVolumeClaim {
+	sc, size := defaultStorageForMode(nodeMode(node), platform)
 
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/node/resources_test.go
+++ b/internal/controller/node/resources_test.go
@@ -543,7 +543,7 @@ func TestGenerateNodeDataPVC(t *testing.T) {
 	g := NewWithT(t)
 	node := newSnapshotNode("snap-0", "ns1")
 
-	pvc := generateNodeDataPVC(node)
+	pvc := generateNodeDataPVC(node, DefaultPlatformConfig())
 
 	g.Expect(pvc.Name).To(Equal("data-snap-0"))
 	g.Expect(pvc.Namespace).To(Equal("ns1"))

--- a/internal/controller/node/sizing.go
+++ b/internal/controller/node/sizing.go
@@ -8,13 +8,6 @@ import (
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
 
-const (
-	storageClassPerf    = "gp3-10k-750"
-	storageClassDefault = "gp3"
-
-	defaultStorageSize = "1000Gi"
-)
-
 // nodeMode returns the sei-config mode string for the node based on which
 // sub-spec is populated. Falls back to "full" if none is set.
 func nodeMode(node *seiv1alpha1.SeiNode) string {
@@ -27,27 +20,25 @@ func nodeMode(node *seiv1alpha1.SeiNode) string {
 
 // defaultResourcesForMode returns CPU and memory requests for the seid
 // container based on the node's operating mode.
-func defaultResourcesForMode(mode string) corev1.ResourceRequirements {
+func defaultResourcesForMode(mode string, platform PlatformConfig) corev1.ResourceRequirements {
 	switch mode {
 	case string(seiconfig.ModeArchive):
-		return makeResources("8", "48Gi")
-	case string(seiconfig.ModeFull), string(seiconfig.ModeValidator):
-		return makeResources("4", "32Gi")
+		return makeResources(platform.ResourceCPUArchive, platform.ResourceMemArchive)
 	default:
-		return makeResources("4", "32Gi")
+		return makeResources(platform.ResourceCPUDefault, platform.ResourceMemDefault)
 	}
 }
 
 // defaultStorageForMode returns the StorageClass name and PVC size for a
 // node based on its operating mode.
-func defaultStorageForMode(mode string) (storageClass string, size string) {
+func defaultStorageForMode(mode string, platform PlatformConfig) (storageClass string, size string) {
 	switch mode {
 	case string(seiconfig.ModeArchive):
-		return storageClassPerf, "2000Gi"
+		return platform.StorageClassPerf, platform.StorageSizeArchive
 	case string(seiconfig.ModeFull), string(seiconfig.ModeValidator):
-		return storageClassPerf, defaultStorageSize
+		return platform.StorageClassPerf, platform.StorageSizeDefault
 	default:
-		return storageClassDefault, defaultStorageSize
+		return platform.StorageClassDefault, platform.StorageSizeDefault
 	}
 }
 


### PR DESCRIPTION
## Summary

- Move all hardcoded sizing values (storage class names, PVC sizes, CPU/memory requests) out of Go constants in `sizing.go` into `PlatformConfig` fields with sensible defaults
- Wire up 8 new environment variables (`SEI_STORAGE_CLASS_PERF`, `SEI_STORAGE_CLASS_DEFAULT`, `SEI_STORAGE_SIZE_DEFAULT`, `SEI_STORAGE_SIZE_ARCHIVE`, `SEI_RESOURCE_CPU_ARCHIVE`, `SEI_RESOURCE_MEM_ARCHIVE`, `SEI_RESOURCE_CPU_DEFAULT`, `SEI_RESOURCE_MEM_DEFAULT`) in `main.go`
- Set default values in `config/manager/manager.yaml` so they are visible and overridable per environment via kustomize patches

## Test plan

- [x] All 97 existing unit tests pass
- [x] Verify CI passes
- [x] Deploy to dev and confirm PVC uses correct StorageClass from env var