### PR TITLE
fix: enable state sync configuration for replayer nodes

### DIFF
--- a/internal/controller/node/plan_execution_test.go
+++ b/internal/controller/node/plan_execution_test.go
@@ -300,7 +300,7 @@ func TestBuildPlan_Replayer(t *testing.T) {
 	planner, _ := PlannerForNode(node)
 	plan := planner.BuildPlan(node)
 	got := taskTypes(plan)
-	want := []string{taskSnapshotRestore, taskConfigureGenesis, taskConfigApply, taskDiscoverPeers, taskConfigValidate, taskMarkReady}
+	want := []string{taskSnapshotRestore, taskConfigureGenesis, taskConfigApply, taskDiscoverPeers, taskConfigureStateSync, taskConfigValidate, taskMarkReady}
 	assertProgression(t, got, want)
 }
 
@@ -317,6 +317,19 @@ func TestBuildTask_Replayer_DiscoverPeers(t *testing.T) {
 	}
 	if task.Sources[0].Type != sidecar.PeerSourceEC2Tags {
 		t.Errorf("type = %v, want ec2Tags", task.Sources[0].Type)
+	}
+}
+
+func TestBuildTask_Replayer_ConfigureStateSync(t *testing.T) {
+	node := replayerNode()
+	planner, _ := PlannerForNode(node)
+	b := planner.BuildTask(node, taskConfigureStateSync)
+	task, ok := b.(sidecar.ConfigureStateSyncTask)
+	if !ok {
+		t.Fatalf("expected ConfigureStateSyncTask, got %T", b)
+	}
+	if !task.UseLocalSnapshot {
+		t.Error("UseLocalSnapshot should be true for S3 snapshot source")
 	}
 }
 

--- a/internal/controller/node/planner_replay.go
+++ b/internal/controller/node/planner_replay.go
@@ -31,45 +31,16 @@ func (p *replayerPlanner) Validate(node *seiv1alpha1.SeiNode) error {
 }
 
 func (p *replayerPlanner) BuildPlan(node *seiv1alpha1.SeiNode) *seiv1alpha1.TaskPlan {
-	prog := []string{taskSnapshotRestore, taskConfigApply, taskDiscoverPeers, taskConfigValidate, taskMarkReady}
-
-	if node.Spec.Genesis.S3 != nil {
-		prog = insertBefore(prog, taskConfigApply, taskConfigureGenesis)
-	}
-
-	tasks := make([]seiv1alpha1.PlannedTask, len(prog))
-	for i, taskType := range prog {
-		tasks[i] = seiv1alpha1.PlannedTask{
-			Type:   taskType,
-			Status: seiv1alpha1.PlannedTaskPending,
-		}
-	}
-	return &seiv1alpha1.TaskPlan{
-		Phase: seiv1alpha1.TaskPlanActive,
-		Tasks: tasks,
-	}
+	return buildPlan(node, node.Spec.Replayer.Peers, &node.Spec.Replayer.Snapshot)
 }
 
 func (p *replayerPlanner) BuildTask(node *seiv1alpha1.SeiNode, taskType string) sidecar.TaskBuilder {
-	snap := &node.Spec.Replayer.Snapshot
-	switch taskType {
-	case taskSnapshotRestore:
-		return snapshotRestoreTask(snap, node.Spec.ChainID)
-	case taskDiscoverPeers:
-		return discoverPeersTask(node.Spec.Replayer.Peers)
-	case taskConfigApply:
+	if taskType == taskConfigApply {
 		return sidecar.ConfigApplyTask{
 			Intent: seiconfig.ConfigIntent{
 				Mode: seiconfig.ModeArchive,
 			},
 		}
-	case taskConfigureGenesis:
-		return configureGenesisBuilder(node)
-	case taskConfigValidate:
-		return sidecar.ConfigValidateTask{}
-	case taskMarkReady:
-		return sidecar.MarkReadyTask{}
-	default:
-		return sidecar.MarkReadyTask{}
 	}
+	return buildSharedTask(node, node.Spec.Replayer.Peers, &node.Spec.Replayer.Snapshot, taskType)
 }


### PR DESCRIPTION
## Summary

- Refactors `replayerPlanner` to use the shared `buildPlan()` / `buildSharedTask()` helpers instead of manually constructing its task plan and dispatch
- This adds the missing `configure-state-sync` step to the replayer's init progression, which sets `use-local-snapshot = true`, discovers the trust point from peers, and writes state sync settings to `config.toml`
- Without this, seid starts with state sync disabled, ignores the snapshot chunks in `/sei/data/snapshots/`, sees `appHeight=0`, and falls into `InitGenesis` — panicking on incomplete embedded genesis params

## Root cause

The replayer planner was the only planner that bypassed the shared plan infrastructure. The full node and archive planners already use `buildPlan()` which automatically inserts `taskConfigureStateSync` when a snapshot source is present. The replayer's bespoke plan missed this step entirely.

## Test plan

- [x] Updated `TestBuildPlan_Replayer` to expect `taskConfigureStateSync` in the progression
- [x] Added `TestBuildTask_Replayer_ConfigureStateSync` to verify the task builder sets `UseLocalSnapshot: true` for S3 sources
- [x] Full test suite passes (`go test ./...`)
- [x] Deploy to dev cluster and verify shadow replayer initializes correctly with state sync