### PR TITLE
feat: restore spec.overrides for user-defined config overrides

### DIFF
--- a/api/v1alpha1/seinode_types.go
+++ b/api/v1alpha1/seinode_types.go
@@ -32,6 +32,12 @@ type SeiNodeSpec struct {
 	// +optional
 	Storage SeiNodeStorageConfig `json:"storage,omitempty"`
 
+	// Overrides is a flat map of dotted TOML key paths to string values.
+	// Keys use the sei-config unified schema (e.g. "evm.http_port", "storage.pruning").
+	// These are applied on top of mode defaults during config-apply.
+	// +optional
+	Overrides map[string]string `json:"overrides,omitempty"`
+
 	// Sidecar configures the sei-sidecar container.
 	// +optional
 	Sidecar *SidecarConfig `json:"sidecar,omitempty"`

--- a/config/crd/sei.io_seinodes.yaml
+++ b/config/crd/sei.io_seinodes.yaml
@@ -344,6 +344,14 @@ spec:
                 maxLength: 512
                 minLength: 1
                 type: string
+              overrides:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Overrides is a flat map of dotted TOML key paths to string values.
+                  Keys use the sei-config unified schema (e.g. "evm.http_port", "storage.pruning").
+                  These are applied on top of mode defaults during config-apply.
+                type: object
               replayer:
                 description: Replayer configures an ephemeral replay workload that
                   restores from a snapshot.

--- a/internal/controller/node/plan_execution_test.go
+++ b/internal/controller/node/plan_execution_test.go
@@ -344,6 +344,73 @@ func TestPlannerForNode_Replayer(t *testing.T) {
 	}
 }
 
+// --- Config overrides passthrough tests ---
+
+func TestConfigApply_ReplayerPassesSpecOverrides(t *testing.T) {
+	node := replayerNode()
+	node.Spec.Overrides = map[string]string{
+		"giga_executor.enabled": "true",
+		"evm.http_port":         "8545",
+	}
+	planner, _ := PlannerForNode(node)
+	b := planner.BuildTask(node, taskConfigApply)
+	task, ok := b.(sidecar.ConfigApplyTask)
+	if !ok {
+		t.Fatalf("expected ConfigApplyTask, got %T", b)
+	}
+	if task.Intent.Overrides["giga_executor.enabled"] != "true" {
+		t.Errorf("giga_executor.enabled = %q, want %q", task.Intent.Overrides["giga_executor.enabled"], "true")
+	}
+	if task.Intent.Overrides["evm.http_port"] != "8545" {
+		t.Errorf("evm.http_port = %q, want %q", task.Intent.Overrides["evm.http_port"], "8545")
+	}
+}
+
+func TestConfigApply_FullNodeMergesOverrides(t *testing.T) {
+	node := snapshotNode()
+	node.Spec.Overrides = map[string]string{
+		"giga_executor.enabled": "true",
+	}
+	planner, _ := PlannerForNode(node)
+	b := planner.BuildTask(node, taskConfigApply)
+	task, ok := b.(sidecar.ConfigApplyTask)
+	if !ok {
+		t.Fatalf("expected ConfigApplyTask, got %T", b)
+	}
+	if task.Intent.Overrides["giga_executor.enabled"] != "true" {
+		t.Errorf("giga_executor.enabled = %q, want %q", task.Intent.Overrides["giga_executor.enabled"], "true")
+	}
+	if task.Intent.Mode != seiconfig.ModeFull {
+		t.Errorf("Mode = %q, want %q", task.Intent.Mode, seiconfig.ModeFull)
+	}
+}
+
+func TestConfigApply_UserOverridesTakePrecedence(t *testing.T) {
+	node := snapshotterNode()
+	node.Spec.Overrides = map[string]string{
+		"storage.snapshot_keep_recent": "99",
+	}
+	planner, _ := PlannerForNode(node)
+	b := planner.BuildTask(node, taskConfigApply)
+	task, ok := b.(sidecar.ConfigApplyTask)
+	if !ok {
+		t.Fatalf("expected ConfigApplyTask, got %T", b)
+	}
+	if task.Intent.Overrides["storage.snapshot_keep_recent"] != "99" {
+		t.Errorf("user override should take precedence, got %q", task.Intent.Overrides["storage.snapshot_keep_recent"])
+	}
+}
+
+func TestConfigApply_NoOverridesYieldsNil(t *testing.T) {
+	node := replayerNode()
+	planner, _ := PlannerForNode(node)
+	b := planner.BuildTask(node, taskConfigApply)
+	task := b.(sidecar.ConfigApplyTask)
+	if task.Intent.Overrides != nil {
+		t.Errorf("expected nil overrides when none specified, got %v", task.Intent.Overrides)
+	}
+}
+
 func assertProgression(t *testing.T, got, want []string) {
 	t.Helper()
 	if len(got) != len(want) {

--- a/internal/controller/node/planner_archive.go
+++ b/internal/controller/node/planner_archive.go
@@ -31,7 +31,7 @@ func (p *archiveNodePlanner) BuildTask(node *seiv1alpha1.SeiNode, taskType strin
 func (p *archiveNodePlanner) buildConfigApply(node *seiv1alpha1.SeiNode) sidecar.TaskBuilder {
 	intent := seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeArchive,
-		Overrides: p.controllerOverrides(node),
+		Overrides: mergeOverrides(p.controllerOverrides(node), node.Spec.Overrides),
 	}
 	return sidecar.ConfigApplyTask{Intent: intent}
 }

--- a/internal/controller/node/planner_full.go
+++ b/internal/controller/node/planner_full.go
@@ -33,7 +33,7 @@ func (p *fullNodePlanner) BuildTask(node *seiv1alpha1.SeiNode, taskType string) 
 func (p *fullNodePlanner) buildConfigApply(node *seiv1alpha1.SeiNode) sidecar.TaskBuilder {
 	intent := seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeFull,
-		Overrides: p.controllerOverrides(node),
+		Overrides: mergeOverrides(p.controllerOverrides(node), node.Spec.Overrides),
 	}
 	return sidecar.ConfigApplyTask{Intent: intent}
 }

--- a/internal/controller/node/planner_replay.go
+++ b/internal/controller/node/planner_replay.go
@@ -38,7 +38,8 @@ func (p *replayerPlanner) BuildTask(node *seiv1alpha1.SeiNode, taskType string) 
 	if taskType == taskConfigApply {
 		return sidecar.ConfigApplyTask{
 			Intent: seiconfig.ConfigIntent{
-				Mode: seiconfig.ModeArchive,
+				Mode:      seiconfig.ModeArchive,
+				Overrides: mergeOverrides(nil, node.Spec.Overrides),
 			},
 		}
 	}

--- a/internal/controller/node/planner_validator.go
+++ b/internal/controller/node/planner_validator.go
@@ -24,7 +24,8 @@ func (p *validatorPlanner) BuildTask(node *seiv1alpha1.SeiNode, taskType string)
 	if taskType == taskConfigApply {
 		return sidecar.ConfigApplyTask{
 			Intent: seiconfig.ConfigIntent{
-				Mode: seiconfig.ModeValidator,
+				Mode:      seiconfig.ModeValidator,
+				Overrides: mergeOverrides(nil, node.Spec.Overrides),
 			},
 		}
 	}

--- a/internal/controller/node/task_builders.go
+++ b/internal/controller/node/task_builders.go
@@ -17,6 +17,22 @@ const (
 	valNothing = "nothing"
 )
 
+// mergeOverrides combines controller-generated overrides with user-specified
+// overrides from spec.overrides. User overrides take precedence.
+func mergeOverrides(controllerOverrides map[string]string, userOverrides map[string]string) map[string]string {
+	if len(controllerOverrides) == 0 && len(userOverrides) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(controllerOverrides)+len(userOverrides))
+	for k, v := range controllerOverrides {
+		merged[k] = v
+	}
+	for k, v := range userOverrides {
+		merged[k] = v
+	}
+	return merged
+}
+
 func configureGenesisBuilder(node *seiv1alpha1.SeiNode) sidecar.TaskBuilder {
 	if node.Spec.Genesis.S3 == nil {
 		return sidecar.ConfigureGenesisTask{}

--- a/internal/controller/node/task_builders.go
+++ b/internal/controller/node/task_builders.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"maps"
+
 	sidecar "github.com/sei-protocol/seictl/sidecar/client"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
@@ -24,12 +26,8 @@ func mergeOverrides(controllerOverrides map[string]string, userOverrides map[str
 		return nil
 	}
 	merged := make(map[string]string, len(controllerOverrides)+len(userOverrides))
-	for k, v := range controllerOverrides {
-		merged[k] = v
-	}
-	for k, v := range userOverrides {
-		merged[k] = v
-	}
+	maps.Copy(merged, controllerOverrides)
+	maps.Copy(merged, userOverrides)
 	return merged
 }
 

--- a/manifests/sei.io_seinodes.yaml
+++ b/manifests/sei.io_seinodes.yaml
@@ -344,6 +344,14 @@ spec:
                 maxLength: 512
                 minLength: 1
                 type: string
+              overrides:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Overrides is a flat map of dotted TOML key paths to string values.
+                  Keys use the sei-config unified schema (e.g. "evm.http_port", "storage.pruning").
+                  These are applied on top of mode defaults during config-apply.
+                type: object
               replayer:
                 description: Replayer configures an ephemeral replay workload that
                   restores from a snapshot.


### PR DESCRIPTION
## Summary

- Re-adds `spec.overrides` field to `SeiNodeSpec` — a flat `map[string]string` of dotted TOML key paths applied on top of mode defaults during `config-apply`
- Wired through all 4 planners (full, archive, replayer, validator) via a shared `mergeOverrides()` helper
- User overrides take precedence over controller-generated overrides (e.g. snapshot generation settings)

## Usage

```yaml
spec:
  chainId: pacific-1
  overrides:
    giga_executor.enabled: "true"
    evm.http_port: "8545"
  replayer:
    ...
```

## Test plan

- [x] `TestConfigApply_ReplayerPassesSpecOverrides` — replayer forwards user overrides
- [x] `TestConfigApply_FullNodeMergesOverrides` — full node merges controller + user overrides
- [x] `TestConfigApply_UserOverridesTakePrecedence` — user overrides win over controller overrides
- [x] `TestConfigApply_NoOverridesYieldsNil` — nil when no overrides specified
- [x] Full test suite passes