### PR TITLE
refactor: align with seictl v0.0.18 — simplified task model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.38.2
 	github.com/sei-protocol/sei-config v0.0.8
-	github.com/sei-protocol/seictl v0.0.16
+	github.com/sei-protocol/seictl v0.0.18
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sei-protocol/sei-config v0.0.8 h1:8HPxXvcJ4eBmHXLxUlpTe2/KZtBvsM+GeENnl65ldCQ=
 github.com/sei-protocol/sei-config v0.0.8/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
-github.com/sei-protocol/seictl v0.0.16 h1:fUEhonburQEWb2EBYiYZO4YhjtjG2XPydcVxB2KCIOU=
-github.com/sei-protocol/seictl v0.0.16/go.mod h1:CHKMT7b7n6wUaPnWajOgqs8mEZA8NchLa7ct+KgQPcw=
+github.com/sei-protocol/seictl v0.0.18 h1:aicDJws1JMSvI86Rt3YhS/iNQDkqOdQjdhIdG93o11k=
+github.com/sei-protocol/seictl v0.0.18/go.mod h1:yStmlDoRN35chV8sQXf3pt6sYYwPjfDDsrxBXkNc50g=
 github.com/sei-protocol/seilog v0.0.2 h1:xDWNr1LUHLnOER1o/5f3rq2TQZFCv/mG1ANBaQcw24s=
 github.com/sei-protocol/seilog v0.0.2/go.mod h1:CKg58wraWnB3gRxWQ0v1rIVr0gmDHjkfP1bM2giKFFU=
 github.com/spf13/cobra v1.10.0 h1:a5/WeUlSDCvV5a45ljW2ZFtV0bTDpkfSAj3uqB6Sc+0=

--- a/internal/controller/node/plan_execution.go
+++ b/internal/controller/node/plan_execution.go
@@ -31,7 +31,7 @@ const (
 
 // SidecarStatusClient abstracts the sidecar HTTP API for testability.
 type SidecarStatusClient interface {
-	SubmitTask(ctx context.Context, task sidecar.TaskBuilder) (uuid.UUID, error)
+	SubmitTask(ctx context.Context, task sidecar.TaskRequest) (uuid.UUID, error)
 	GetTask(ctx context.Context, id uuid.UUID) (*sidecar.TaskResult, error)
 }
 
@@ -122,7 +122,8 @@ func (r *SeiNodeReconciler) submitTask(
 	task *seiv1alpha1.PlannedTask,
 ) (ctrl.Result, error) {
 	builder := planner.BuildTask(node, task.Type)
-	id, err := sc.SubmitTask(ctx, builder)
+	req := builder.ToTaskRequest()
+	id, err := sc.SubmitTask(ctx, req)
 	if err != nil {
 		log.FromContext(ctx).Info("task submission failed, will retry", "task", task.Type, "error", err)
 		return ctrl.Result{RequeueAfter: bootstrapPollInterval}, nil
@@ -156,18 +157,18 @@ func (r *SeiNodeReconciler) pollTask(
 	}
 
 	switch result.Status {
-	case sidecar.TaskResultStatusRunning:
+	case sidecar.Running:
 		log.FromContext(ctx).V(1).Info("task still running", "task", task.Type)
 		return ctrl.Result{RequeueAfter: bootstrapPollInterval}, nil
 
-	case sidecar.TaskResultStatusFailed:
+	case sidecar.Failed:
 		errMsg := "unknown error"
 		if result.Error != nil && *result.Error != "" {
 			errMsg = *result.Error
 		}
 		return r.failTask(ctx, node, task, errMsg)
 
-	case sidecar.TaskResultStatusCompleted:
+	case sidecar.Completed:
 		patch := client.MergeFrom(node.DeepCopy())
 		task.Status = seiv1alpha1.PlannedTaskComplete
 		if err := r.Status().Patch(ctx, node, patch); err != nil {
@@ -210,31 +211,32 @@ func (r *SeiNodeReconciler) markPlanComplete(ctx context.Context, node *seiv1alp
 	return ctrl.Result{RequeueAfter: statusPollInterval}, nil
 }
 
-// reconcileRuntimeTasks ensures all scheduled tasks are submitted exactly once.
-// The sidecar owns execution cadence after that.
+// reconcileRuntimeTasks ensures all scheduled tasks are submitted exactly
+// once. The sidecar owns execution cadence after that.
 func (r *SeiNodeReconciler) reconcileRuntimeTasks(ctx context.Context, node *seiv1alpha1.SeiNode, sc SidecarStatusClient) (ctrl.Result, error) {
-	if task := snapshotUploadTaskFromSpec(node); task != nil {
-		if err := r.ensureScheduledTask(ctx, node, sc, task); err != nil {
-			log.FromContext(ctx).Info("scheduled task submission failed, will retry", "task", task.TaskType(), "error", err)
+	if builder := snapshotUploadScheduledTask(node); builder != nil {
+		req := builder.ToTaskRequest()
+		if err := r.ensureScheduledTask(ctx, node, sc, req); err != nil {
+			log.FromContext(ctx).Info("scheduled task submission failed, will retry", "task", req.Type, "error", err)
 		}
 	}
-	if task := resultExportTaskFromSpec(node); task != nil {
-		if err := r.ensureScheduledTask(ctx, node, sc, task); err != nil {
-			log.FromContext(ctx).Info("scheduled task submission failed, will retry", "task", task.TaskType(), "error", err)
+	if builder := resultExportScheduledTask(node); builder != nil {
+		req := builder.ToTaskRequest()
+		if err := r.ensureScheduledTask(ctx, node, sc, req); err != nil {
+			log.FromContext(ctx).Info("scheduled task submission failed, will retry", "task", req.Type, "error", err)
 		}
 	}
 	return ctrl.Result{RequeueAfter: statusPollInterval}, nil
 }
 
-func (r *SeiNodeReconciler) ensureScheduledTask(ctx context.Context, node *seiv1alpha1.SeiNode, sc SidecarStatusClient, task sidecar.TaskBuilder) error {
-	taskType := task.TaskType()
+func (r *SeiNodeReconciler) ensureScheduledTask(ctx context.Context, node *seiv1alpha1.SeiNode, sc SidecarStatusClient, req sidecar.TaskRequest) error {
 	if node.Status.ScheduledTasks != nil {
-		if _, ok := node.Status.ScheduledTasks[taskType]; ok {
+		if _, ok := node.Status.ScheduledTasks[req.Type]; ok {
 			return nil
 		}
 	}
 
-	id, err := sc.SubmitTask(ctx, task)
+	id, err := sc.SubmitTask(ctx, req)
 	if err != nil {
 		return err
 	}
@@ -243,6 +245,6 @@ func (r *SeiNodeReconciler) ensureScheduledTask(ctx context.Context, node *seiv1
 	if node.Status.ScheduledTasks == nil {
 		node.Status.ScheduledTasks = make(map[string]string)
 	}
-	node.Status.ScheduledTasks[taskType] = id.String()
+	node.Status.ScheduledTasks[req.Type] = id.String()
 	return r.Status().Patch(ctx, node, patch)
 }

--- a/internal/controller/node/plan_execution_integration_test.go
+++ b/internal/controller/node/plan_execution_integration_test.go
@@ -33,7 +33,7 @@ func driveTask(
 	_, err = r.reconcileSidecarProgression(context.Background(), node, planner)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(mock.submitted).To(HaveLen(1))
-	g.Expect(mock.submitted[0].TaskType()).To(Equal(taskType))
+	g.Expect(mock.submitted[0].Type).To(Equal(taskType))
 
 	mock.taskResults = map[uuid.UUID]*sidecar.TaskResult{
 		taskID: completedResult(taskID, taskType, nil),
@@ -65,7 +65,7 @@ func TestIntegrationFullProgressionSnapshotMode(t *testing.T) {
 	_, err := r.reconcileSidecarProgression(ctx, node, planner)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(fetch().Status.InitPlan).NotTo(BeNil())
-	g.Expect(mock.submitted[0].TaskType()).To(Equal(taskSnapshotRestore))
+	g.Expect(mock.submitted[0].Type).To(Equal(taskSnapshotRestore))
 
 	// Complete snapshot-restore.
 	mock.taskResults = map[uuid.UUID]*sidecar.TaskResult{
@@ -110,7 +110,7 @@ func TestIntegrationFullProgressionGenesisMode(t *testing.T) {
 	mock.submitID = taskID
 	_, err := r.reconcileSidecarProgression(ctx, node, planner)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(mock.submitted[0].TaskType()).To(Equal(taskConfigApply))
+	g.Expect(mock.submitted[0].Type).To(Equal(taskConfigApply))
 
 	// Complete config-apply.
 	mock.taskResults = map[uuid.UUID]*sidecar.TaskResult{

--- a/internal/controller/node/plan_execution_test.go
+++ b/internal/controller/node/plan_execution_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 type mockSidecarClient struct {
-	submitted []sidecar.TaskBuilder
+	submitted []sidecar.TaskRequest
 	submitErr error
 	submitID  uuid.UUID
 
@@ -28,7 +28,7 @@ type mockSidecarClient struct {
 	getTaskErr  error
 }
 
-func (m *mockSidecarClient) SubmitTask(_ context.Context, task sidecar.TaskBuilder) (uuid.UUID, error) {
+func (m *mockSidecarClient) SubmitTask(_ context.Context, task sidecar.TaskRequest) (uuid.UUID, error) {
 	m.submitted = append(m.submitted, task)
 	if m.submitErr != nil {
 		return uuid.Nil, m.submitErr
@@ -56,9 +56,9 @@ func strPtr(s string) *string { return &s }
 
 func completedResult(id uuid.UUID, taskType string, taskErr *string) *sidecar.TaskResult {
 	now := time.Now()
-	status := sidecar.TaskResultStatusCompleted
+	status := sidecar.Completed
 	if taskErr != nil && *taskErr != "" {
-		status = sidecar.TaskResultStatusFailed
+		status = sidecar.Failed
 	}
 	return &sidecar.TaskResult{
 		Id:          id,
@@ -74,7 +74,7 @@ func runningResult(id uuid.UUID, taskType string) *sidecar.TaskResult {
 	return &sidecar.TaskResult{
 		Id:          id,
 		Type:        taskType,
-		Status:      sidecar.TaskResultStatusRunning,
+		Status:      sidecar.Running,
 		SubmittedAt: time.Now(),
 	}
 }
@@ -473,8 +473,8 @@ func TestReconcile_CreatesPlanOnFirstRun(t *testing.T) {
 	if len(mock.submitted) != 1 {
 		t.Fatalf("expected 1 submitted task, got %d", len(mock.submitted))
 	}
-	if mock.submitted[0].TaskType() != taskSnapshotRestore {
-		t.Errorf("submitted task = %q, want %q", mock.submitted[0].TaskType(), taskSnapshotRestore)
+	if mock.submitted[0].Type != taskSnapshotRestore {
+		t.Errorf("submitted task = %q, want %q", mock.submitted[0].Type, taskSnapshotRestore)
 	}
 }
 
@@ -661,8 +661,8 @@ func TestReconcile_CompletePlan_SubmitsScheduledTask(t *testing.T) {
 	if len(mock.submitted) != 1 {
 		t.Fatalf("expected 1 scheduled task submitted, got %d", len(mock.submitted))
 	}
-	if mock.submitted[0].TaskType() != taskSnapshotUpload {
-		t.Errorf("task type = %q, want %q", mock.submitted[0].TaskType(), taskSnapshotUpload)
+	if mock.submitted[0].Type != taskSnapshotUpload {
+		t.Errorf("task type = %q, want %q", mock.submitted[0].Type, taskSnapshotUpload)
 	}
 
 	updated := fetchNode(t, c, node.Name, node.Namespace)
@@ -870,23 +870,27 @@ func TestConfigApply_GenesisNodeNoOverrides(t *testing.T) {
 
 // --- Snapshot upload tests ---
 
-func TestSnapshotUploadTask_WithDestination(t *testing.T) {
-	b := snapshotUploadTaskFromSpec(snapshotterNode())
-	if b == nil {
-		t.Fatal("expected non-nil task")
+func TestSnapshotUploadScheduledTask_WithDestination(t *testing.T) {
+	builder := snapshotUploadScheduledTask(snapshotterNode())
+	if builder == nil {
+		t.Fatal("expected non-nil builder")
 	}
-	task := b.(sidecar.SnapshotUploadTask)
+	task := builder.(sidecar.SnapshotUploadTask)
 	if task.Bucket != "atlantic-2-snapshots" {
 		t.Errorf("Bucket = %q, want %q", task.Bucket, "atlantic-2-snapshots")
 	}
-	if task.Cron != defaultSnapshotUploadCron {
-		t.Errorf("Cron = %q, want %q", task.Cron, defaultSnapshotUploadCron)
+	if task.Schedule == nil || task.Schedule.Cron == nil {
+		t.Fatal("expected schedule config on task")
+	}
+	if *task.Schedule.Cron != defaultSnapshotUploadCron {
+		t.Errorf("Cron = %q, want %q", *task.Schedule.Cron, defaultSnapshotUploadCron)
 	}
 }
 
-func TestSnapshotUploadTask_NoDestination(t *testing.T) {
-	if task := snapshotUploadTaskFromSpec(snapshotNode()); task != nil {
-		t.Errorf("expected nil, got %v", task)
+func TestSnapshotUploadScheduledTask_NoDestination(t *testing.T) {
+	builder := snapshotUploadScheduledTask(snapshotNode())
+	if builder != nil {
+		t.Errorf("expected nil builder, got %v", builder)
 	}
 }
 
@@ -941,16 +945,16 @@ func TestPlannerForNode_NoSubSpec(t *testing.T) {
 
 // --- Result export tests ---
 
-func TestResultExportTaskFromSpec_ReplayerWithExport(t *testing.T) {
+func TestResultExportScheduledTask_ReplayerWithExport(t *testing.T) {
 	node := replayerNode()
 	node.Spec.Replayer.ResultExport = &seiv1alpha1.ResultExportConfig{}
-	b := resultExportTaskFromSpec(node)
-	if b == nil {
-		t.Fatal("expected non-nil task")
+	builder := resultExportScheduledTask(node)
+	if builder == nil {
+		t.Fatal("expected non-nil builder")
 	}
-	task, ok := b.(sidecar.ResultExportTask)
+	task, ok := builder.(sidecar.ResultExportTask)
 	if !ok {
-		t.Fatalf("expected ResultExportTask, got %T", b)
+		t.Fatalf("expected ResultExportTask, got %T", builder)
 	}
 	if task.Bucket != "sei-node-mvp" {
 		t.Errorf("Bucket = %q, want %q", task.Bucket, "sei-node-mvp")
@@ -961,19 +965,27 @@ func TestResultExportTaskFromSpec_ReplayerWithExport(t *testing.T) {
 	if task.Region != "us-east-2" {
 		t.Errorf("Region = %q, want %q", task.Region, "us-east-2")
 	}
-}
-
-func TestResultExportTaskFromSpec_ReplayerWithoutExport(t *testing.T) {
-	node := replayerNode()
-	if b := resultExportTaskFromSpec(node); b != nil {
-		t.Errorf("expected nil, got %v", b)
+	if task.Schedule == nil || task.Schedule.Cron == nil {
+		t.Fatal("expected schedule config on task")
+	}
+	if *task.Schedule.Cron != defaultResultExportCron {
+		t.Errorf("Cron = %q, want %q", *task.Schedule.Cron, defaultResultExportCron)
 	}
 }
 
-func TestResultExportTaskFromSpec_FullNode(t *testing.T) {
+func TestResultExportScheduledTask_ReplayerWithoutExport(t *testing.T) {
+	node := replayerNode()
+	builder := resultExportScheduledTask(node)
+	if builder != nil {
+		t.Errorf("expected nil builder, got %v", builder)
+	}
+}
+
+func TestResultExportScheduledTask_FullNode(t *testing.T) {
 	node := snapshotNode()
-	if b := resultExportTaskFromSpec(node); b != nil {
-		t.Errorf("expected nil for full node, got %v", b)
+	builder := resultExportScheduledTask(node)
+	if builder != nil {
+		t.Errorf("expected nil builder for full node, got %v", builder)
 	}
 }
 
@@ -1042,8 +1054,8 @@ func TestReconcile_CompletePlan_SubmitsResultExportForReplayer(t *testing.T) {
 	if len(mock.submitted) != 1 {
 		t.Fatalf("expected 1 scheduled task submitted, got %d", len(mock.submitted))
 	}
-	if mock.submitted[0].TaskType() != taskResultExport {
-		t.Errorf("task type = %q, want %q", mock.submitted[0].TaskType(), taskResultExport)
+	if mock.submitted[0].Type != taskResultExport {
+		t.Errorf("task type = %q, want %q", mock.submitted[0].Type, taskResultExport)
 	}
 
 	updated := fetchNode(t, c, node.Name, node.Namespace)

--- a/internal/controller/node/task_builders.go
+++ b/internal/controller/node/task_builders.go
@@ -11,6 +11,7 @@ import (
 const (
 	defaultSnapshotUploadCron = "0 0 * * *"
 	defaultSnapshotInterval   = int64(2000)
+	defaultResultExportCron   = "*/10 * * * *"
 
 	resultExportBucket = "sei-node-mvp"
 	resultExportRegion = "us-east-2"
@@ -41,32 +42,36 @@ func configureGenesisBuilder(node *seiv1alpha1.SeiNode) sidecar.TaskBuilder {
 	}
 }
 
-// resultExportTaskFromSpec returns a scheduled result-export task if the
-// node is a replayer with result export enabled. Bucket, region, and prefix
-// are platform defaults — the prefix is derived from the node's chain ID.
-func resultExportTaskFromSpec(node *seiv1alpha1.SeiNode) sidecar.TaskBuilder {
+// resultExportScheduledTask returns a result-export task builder with a
+// cron schedule if the node is a replayer with result export enabled.
+// Returns nil when not applicable.
+func resultExportScheduledTask(node *seiv1alpha1.SeiNode) sidecar.TaskBuilder {
 	if node.Spec.Replayer == nil || node.Spec.Replayer.ResultExport == nil {
 		return nil
 	}
+	cron := defaultResultExportCron
 	return sidecar.ResultExportTask{
-		Bucket: resultExportBucket,
-		Prefix: resultExportPrefix + node.Spec.ChainID + "/",
-		Region: resultExportRegion,
+		Bucket:   resultExportBucket,
+		Prefix:   resultExportPrefix + node.Spec.ChainID + "/",
+		Region:   resultExportRegion,
+		Schedule: &sidecar.ScheduleConfig{Cron: &cron},
 	}
 }
 
-// snapshotUploadTaskFromSpec returns a scheduled snapshot-upload task if the
-// node's mode sub-spec configures snapshot generation with an S3 destination.
-func snapshotUploadTaskFromSpec(node *seiv1alpha1.SeiNode) sidecar.TaskBuilder {
+// snapshotUploadScheduledTask returns a snapshot-upload task builder with a
+// cron schedule if the node's mode sub-spec configures snapshot generation
+// with an S3 destination. Returns nil when not applicable.
+func snapshotUploadScheduledTask(node *seiv1alpha1.SeiNode) sidecar.TaskBuilder {
 	sg := snapshotGeneration(node)
 	if sg == nil || sg.Destination == nil || sg.Destination.S3 == nil {
 		return nil
 	}
 	dest := sg.Destination.S3
+	cron := defaultSnapshotUploadCron
 	return sidecar.SnapshotUploadTask{
-		Bucket: dest.Bucket,
-		Prefix: dest.Prefix,
-		Region: dest.Region,
-		Cron:   defaultSnapshotUploadCron,
+		Bucket:   dest.Bucket,
+		Prefix:   dest.Prefix,
+		Region:   dest.Region,
+		Schedule: &sidecar.ScheduleConfig{Cron: &cron},
 	}
 }


### PR DESCRIPTION
## Summary

- **Bump seictl to v0.0.18** which removes the serial execution pipeline and DaemonConfig, making all tasks run concurrently with ScheduleConfig as the only modifier.
- **SidecarStatusClient interface** now accepts `sidecar.TaskRequest` (wire format) instead of `sidecar.TaskBuilder`, aligning the controller with how the sidecar API actually works.
- **Task builders** updated: `Async: &sidecar.AsyncConfig{Schedule: &sidecar.ScheduleConfig{...}}` simplified to `Schedule: &sidecar.ScheduleConfig{...}` on `SnapshotUploadTask` and `ResultExportTask`.
- **Plan execution** renamed `ensureAsyncTask` → `ensureScheduledTask` and updated log messages.
- **Generated constant names** updated (`TaskResultStatusRunning` → `Running`, etc.) to match the regenerated seictl client.

Companion to sei-protocol/seictl#35.

## Test plan

- [x] All controller unit tests pass
- [x] All controller integration tests pass
- [x] `go build ./...` clean
- [x] Verified against released seictl v0.0.18