### PR TITLE
chore: bump seictl sidecar image to sha-e9353d9

### DIFF
--- a/internal/controller/node/labels.go
+++ b/internal/controller/node/labels.go
@@ -10,7 +10,7 @@ const (
 	nodeLabel           = "sei.io/node"
 	componentLabel      = "sei.io/component"
 	dataDir             = "/sei"
-	defaultSidecarImage = "ghcr.io/sei-protocol/seictl@sha256:64f92fb5bc3f451b3cd23d95275685b7fed28ab4dff36a0182267dc77e266c49"
+	defaultSidecarImage = "ghcr.io/sei-protocol/seictl@sha256:8834d1f312b3427ffc39ecba705114299a7a3964672f60001ad76b0bc708b155"
 )
 
 func resourceLabelsForNode(node *seiv1alpha1.SeiNode) map[string]string {

--- a/manifests/samples/pacific-1-full-node.yaml
+++ b/manifests/samples/pacific-1-full-node.yaml
@@ -12,7 +12,7 @@ spec:
   image: "ghcr.io/sei-protocol/sei:v6.3.0"
 
   sidecar:
-    image: ghcr.io/sei-protocol/seictl@sha256:64f92fb5bc3f451b3cd23d95275685b7fed28ab4dff36a0182267dc77e266c49
+    image: ghcr.io/sei-protocol/seictl@sha256:8834d1f312b3427ffc39ecba705114299a7a3964672f60001ad76b0bc708b155
 
   storage:
     retainOnDelete: true

--- a/manifests/samples/pacific-1-shadow-replayer.yaml
+++ b/manifests/samples/pacific-1-shadow-replayer.yaml
@@ -14,11 +14,16 @@ spec:
   image: ghcr.io/bdchatham/sei-shadow:skip-apphash
 
   sidecar:
-    image: ghcr.io/sei-protocol/seictl@sha256:64f92fb5bc3f451b3cd23d95275685b7fed28ab4dff36a0182267dc77e266c49
+    image: ghcr.io/sei-protocol/seictl@sha256:8834d1f312b3427ffc39ecba705114299a7a3964672f60001ad76b0bc708b155
 
   entrypoint:
     command: ["seid"]
     args: ["start", "--home", "/sei", "--skip-app-hash-validation"]
+
+  genesis:
+    s3:
+      uri: s3://sei-testnet-genesis-config/pacific-1/genesis.json
+      region: us-east-2
 
   storage:
     retainOnDelete: true

--- a/manifests/samples/pacific-1-snapshotter.yaml
+++ b/manifests/samples/pacific-1-snapshotter.yaml
@@ -12,7 +12,7 @@ spec:
   image: "ghcr.io/sei-protocol/sei:v6.3.0"
 
   sidecar:
-    image: ghcr.io/sei-protocol/seictl@sha256:64f92fb5bc3f451b3cd23d95275685b7fed28ab4dff36a0182267dc77e266c49
+    image: ghcr.io/sei-protocol/seictl@sha256:8834d1f312b3427ffc39ecba705114299a7a3964672f60001ad76b0bc708b155
 
   entrypoint:
     command: ["seid"]

--- a/manifests/samples/pacific-1-state-syncer.yaml
+++ b/manifests/samples/pacific-1-state-syncer.yaml
@@ -12,7 +12,7 @@ spec:
   image: "ghcr.io/sei-protocol/sei:v6.3.0"
 
   sidecar:
-    image: ghcr.io/sei-protocol/seictl@sha256:64f92fb5bc3f451b3cd23d95275685b7fed28ab4dff36a0182267dc77e266c49
+    image: ghcr.io/sei-protocol/seictl@sha256:8834d1f312b3427ffc39ecba705114299a7a3964672f60001ad76b0bc708b155
 
   entrypoint:
     command: ["seid"]


### PR DESCRIPTION
## Summary

- Bumps the default seictl sidecar image to pick up the fix from [seictl#39](https://github.com/sei-protocol/seictl/pull/39) -- the /status response parsing was expecting a JSONRPC result wrapper that seid does not return, causing await-condition to silently fail on every poll.
- Updates all sample manifests to the new digest.
- Adds genesis.s3 config to the shadow replayer manifest.

## Test plan

- [x] seictl tests pass with the new response format
- [x] Deploy updated controller and verify shadow replayer pre-init completes