### PR TITLE
fix: default entrypoint to seid start --home /sei

### DIFF
--- a/internal/controller/node/resources.go
+++ b/internal/controller/node/resources.go
@@ -153,7 +153,7 @@ func buildSidecarMainContainer(node *seiv1alpha1.SeiNode, platform PlatformConfi
 // that blocks until the sidecar's /healthz returns 200, then exec's seid.
 func sidecarWaitCommand(node *seiv1alpha1.SeiNode) (command []string, args []string) {
 	cmd := "seid"
-	var cmdArgs []string
+	cmdArgs := []string{"start", "--home", dataDir}
 	if node.Spec.Entrypoint != nil && len(node.Spec.Entrypoint.Command) > 0 {
 		cmd = node.Spec.Entrypoint.Command[0]
 		cmdArgs = append(node.Spec.Entrypoint.Command[1:], node.Spec.Entrypoint.Args...)

--- a/internal/controller/node/resources_test.go
+++ b/internal/controller/node/resources_test.go
@@ -431,7 +431,7 @@ func TestSidecarMainContainer_WaitWrapper_IncludesEntrypointArgs(t *testing.T) {
 	g.Expect(seid.Args[0]).To(ContainSubstring(`exec seid "start" "--home" "/sei"`))
 }
 
-func TestSidecarMainContainer_WaitWrapper_NoEntrypoint_DefaultsSeid(t *testing.T) {
+func TestSidecarMainContainer_WaitWrapper_NoEntrypoint_DefaultsSeidStart(t *testing.T) {
 	g := NewWithT(t)
 	node := newSnapshotNode("sc-0", "default")
 
@@ -439,7 +439,7 @@ func TestSidecarMainContainer_WaitWrapper_NoEntrypoint_DefaultsSeid(t *testing.T
 	seid := findContainer(sts.Spec.Template.Spec.Containers, "seid")
 
 	g.Expect(seid.Command).To(Equal([]string{"/bin/bash", "-c"}))
-	g.Expect(seid.Args[0]).To(HaveSuffix("exec seid"))
+	g.Expect(seid.Args[0]).To(ContainSubstring(`exec seid "start" "--home" "/sei"`))
 }
 
 func TestSidecarMainContainer_NilSidecarConfig_UsesDefaults(t *testing.T) {

--- a/manifests/samples/pacific-1-full-node.yaml
+++ b/manifests/samples/pacific-1-full-node.yaml
@@ -11,6 +11,10 @@ spec:
   chainId: pacific-1
   image: "ghcr.io/sei-protocol/sei:v6.3.0"
 
+  entrypoint:
+    command: ["seid"]
+    args: ["start", "--home", "/sei"]
+
   sidecar:
     image: ghcr.io/sei-protocol/seictl@sha256:8bfef078409c160f03c62fcd969702b3edc9d957369fb56dca9e34e09ac6c99a
 


### PR DESCRIPTION
## Summary

- When no `spec.entrypoint` is configured, `sidecarWaitCommand` previously defaulted to bare `exec seid`, which prints help text and exits immediately — causing a CrashLoopBackOff.
- Defaults to `seid start --home /sei` to match the behavior every existing SeiNode already specifies explicitly.
- Updates the full-node sample manifest to include the explicit entrypoint for clarity.

## Test plan

- [x] Unit tests updated and passing (`TestSidecarMainContainer_WaitWrapper_NoEntrypoint_DefaultsSeidStart`)
- [x] Full test suite passes
- [x] Verified fix on dev cluster — recreated `pacific-1-full-node` without explicit entrypoint, confirmed pod starts correctly with 0 restarts