### PR TITLE
fix: add memiavl stability overrides for shadow replayer

### DIFF
--- a/internal/controller/node/plan_execution_test.go
+++ b/internal/controller/node/plan_execution_test.go
@@ -447,6 +447,10 @@ func TestConfigApply_ReplayerDefaultOverrides(t *testing.T) {
 		keyPruningKeepRecent:  "86400",
 		keyPruningKeepEvery:   "500",
 		keyPruningInterval:    "10",
+
+		keySCAsyncCommitBuffer:       "100",
+		keySCSnapshotKeepRecent:      "2",
+		keySCSnapshotMinTimeInterval: "3600",
 	}
 	for k, want := range checks {
 		if got := task.Intent.Overrides[k]; got != want {

--- a/internal/controller/node/planner_replay.go
+++ b/internal/controller/node/planner_replay.go
@@ -55,5 +55,9 @@ func (p *replayerPlanner) controllerOverrides() map[string]string {
 		keyPruningKeepRecent:  "86400",
 		keyPruningKeepEvery:   "500",
 		keyPruningInterval:    "10",
+
+		keySCAsyncCommitBuffer:       "100",
+		keySCSnapshotKeepRecent:      "2",
+		keySCSnapshotMinTimeInterval: "3600",
 	}
 }

--- a/internal/controller/node/task_builders.go
+++ b/internal/controller/node/task_builders.go
@@ -27,9 +27,9 @@ const (
 	keySnapshotInterval   = "storage.snapshot_interval"
 	keySnapshotKeepRecent = "storage.snapshot_keep_recent"
 
-	keySCAsyncCommitBuffer        = "storage.state_commit.async_commit_buffer"
-	keySCSnapshotKeepRecent       = "storage.state_commit.memiavl.snapshot_keep_recent"
-	keySCSnapshotMinTimeInterval  = "storage.state_commit.memiavl.snapshot_min_time_interval"
+	keySCAsyncCommitBuffer       = "storage.state_commit.async_commit_buffer"
+	keySCSnapshotKeepRecent      = "storage.state_commit.memiavl.snapshot_keep_recent"
+	keySCSnapshotMinTimeInterval = "storage.state_commit.memiavl.snapshot_min_time_interval"
 
 	valCustom  = "custom"
 	valNothing = "nothing"

--- a/internal/controller/node/task_builders.go
+++ b/internal/controller/node/task_builders.go
@@ -27,6 +27,10 @@ const (
 	keySnapshotInterval   = "storage.snapshot_interval"
 	keySnapshotKeepRecent = "storage.snapshot_keep_recent"
 
+	keySCAsyncCommitBuffer        = "storage.state_commit.async_commit_buffer"
+	keySCSnapshotKeepRecent       = "storage.state_commit.memiavl.snapshot_keep_recent"
+	keySCSnapshotMinTimeInterval  = "storage.state_commit.memiavl.snapshot_min_time_interval"
+
 	valCustom  = "custom"
 	valNothing = "nothing"
 


### PR DESCRIPTION
## Summary

- Adds three memiavl state-commit overrides to the replayer planner's controller defaults:
  - `sc-keep-recent = 2` — retains 2 old memiavl snapshots after a new one is created, preventing a SIGSEGV race where in-flight reads (served via hardcoded `ZeroCopy: true` in `sei-db`) reference mmap pages from a snapshot that has already been pruned/unmapped
  - `sc-async-commit-buffer = 100` — enables async commits (was 0/synchronous), significantly improving block catch-up performance for replayers
  - `sc-snapshot-min-time-interval = 3600` — prevents excessive snapshot creation during rapid catch-up (default 1 hour between snapshots)

### Context

The shadow replayer (`pacific-1-shadow-replayer`) crashed with a `SIGSEGV` at height 199407360. The fault occurred in `memeqbody` during an LRU cache string comparison inside `bank/keeper.SubUnlockedCoins`, immediately after a memiavl snapshot switch and async `pruneSnapshots()` call. The old snapshot's mmap pages were freed while a consensus goroutine still held references to them.

Root cause: `NewCommitStore` in `sei-db` hardcodes `ZeroCopy: true`, returning direct pointers into mmap'd memory. When `pruneSnapshots()` runs asynchronously after a snapshot switch (`db.go:509`), it can unmap pages that in-flight readers still reference. With `sc-keep-recent = 0` (the current default), old snapshots are pruned immediately, maximizing exposure to this race.

## Test plan

- [x] `TestConfigApply_ReplayerDefaultOverrides` updated to assert the 3 new keys
- [x] `TestConfigApply_ReplayerPassesSpecOverrides` still passes (user overrides take precedence)
- [x] Full `./internal/controller/node/` test suite passes (107 tests)
- [ ] Deploy to dev, verify replayer `app.toml` contains the new `[state-commit]` values
- [ ] Monitor shadow replayer for SIGSEGV recurrence over 48h