### PR TITLE
refactor: absorb genesis ceremony logic into planner interfaces

### DIFF
--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -115,15 +115,9 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *SeiNodeReconciler) reconcilePending(ctx context.Context, node *seiv1alpha1.SeiNode, p planner.NodePlanner) (ctrl.Result, error) {
 	patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 
-	var initPlan *seiv1alpha1.TaskPlan
-	var buildErr error
-	if planner.IsGenesisCeremonyNode(node) {
-		initPlan, buildErr = planner.BuildGenesisInitPlan(node)
-	} else {
-		initPlan, buildErr = p.BuildPlan(node)
-	}
-	if buildErr != nil {
-		return ctrl.Result{}, fmt.Errorf("building init plan: %w", buildErr)
+	initPlan, err := p.BuildPlan(node)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("building init plan: %w", err)
 	}
 	node.Status.InitPlan = initPlan
 	node.Status.Phase = seiv1alpha1.PhaseInitializing

--- a/internal/controller/nodegroup/genesis.go
+++ b/internal/controller/nodegroup/genesis.go
@@ -91,7 +91,11 @@ func (r *SeiNodeGroupReconciler) reconcileGenesisAssembly(ctx context.Context, g
 }
 
 func (r *SeiNodeGroupReconciler) startAssembly(ctx context.Context, group *seiv1alpha1.SeiNodeGroup, nodes []seiv1alpha1.SeiNode) (ctrl.Result, error) {
-	plan, err := planner.BuildGroupAssemblyPlan(group, nodes)
+	p, err := planner.ForGroup(group)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	plan, err := p.BuildPlan(group, nodes)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("building assembly plan: %w", err)
 	}

--- a/internal/planner/bootstrap.go
+++ b/internal/planner/bootstrap.go
@@ -138,11 +138,11 @@ func IsBootstrapComplete(plan *seiv1alpha1.TaskPlan) bool {
 // genesis.json.
 const genesisConfigureMaxRetries = 180
 
-// BuildGenesisInitPlan constructs the full Init plan for genesis ceremony
+// buildGenesisInitPlan constructs the full Init plan for genesis ceremony
 // nodes. Per-node artifact generation and upload runs first, then
 // configure-genesis retries until the group controller has assembled and
 // uploaded genesis.json to S3.
-func BuildGenesisInitPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
+func buildGenesisInitPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	gc := node.Spec.Validator.GenesisCeremony
 	attempt := 0
 

--- a/internal/planner/group.go
+++ b/internal/planner/group.go
@@ -9,12 +9,14 @@ import (
 
 const groupAssemblyMaxRetries = 60
 
-// BuildGroupAssemblyPlan constructs a TaskPlan for the SeiNodeGroup that:
+type genesisGroupPlanner struct{}
+
+// BuildPlan constructs a TaskPlan for the SeiNodeGroup that:
 //  1. Assembles all per-node genesis artifacts into a final genesis.json
 //     (retried until the sidecar succeeds).
 //  2. Waits for all child SeiNodes to reach PhaseRunning, confirming
 //     they picked up the genesis.
-func BuildGroupAssemblyPlan(
+func (p *genesisGroupPlanner) BuildPlan(
 	group *seiv1alpha1.SeiNodeGroup,
 	nodes []seiv1alpha1.SeiNode,
 ) (*seiv1alpha1.TaskPlan, error) {

--- a/internal/planner/group_test.go
+++ b/internal/planner/group_test.go
@@ -32,9 +32,13 @@ func TestBuildGroupAssemblyPlan(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}},
 	}
 
-	plan, err := BuildGroupAssemblyPlan(group, nodes)
+	p, err := ForGroup(group)
 	if err != nil {
-		t.Fatalf("BuildGroupAssemblyPlan: %v", err)
+		t.Fatalf("ForGroup: %v", err)
+	}
+	plan, err := p.BuildPlan(group, nodes)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
 	}
 
 	if plan.Phase != seiv1alpha1.TaskPlanActive {
@@ -116,9 +120,13 @@ func TestBuildGroupAssemblyPlan_DefaultS3(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node-0"}},
 	}
 
-	plan, err := BuildGroupAssemblyPlan(group, nodes)
+	p, err := ForGroup(group)
 	if err != nil {
-		t.Fatalf("BuildGroupAssemblyPlan: %v", err)
+		t.Fatalf("ForGroup: %v", err)
+	}
+	plan, err := p.BuildPlan(group, nodes)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
 	}
 
 	var params task.AssembleAndUploadGenesisParams
@@ -148,11 +156,15 @@ func TestBuildGroupAssemblyPlan_DeterministicIDs(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
 	}
 
-	plan1, err := BuildGroupAssemblyPlan(group, nodes)
+	p, err := ForGroup(group)
 	if err != nil {
 		t.Fatal(err)
 	}
-	plan2, err := BuildGroupAssemblyPlan(group, nodes)
+	plan1, err := p.BuildPlan(group, nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan2, err := p.BuildPlan(group, nodes)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -47,6 +47,20 @@ type NodePlanner interface {
 	Mode() string
 }
 
+// GroupPlanner encapsulates logic for building a group-level task plan.
+type GroupPlanner interface {
+	BuildPlan(group *seiv1alpha1.SeiNodeGroup, nodes []seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error)
+}
+
+// ForGroup returns the appropriate GroupPlanner based on which group-level
+// feature is configured.
+func ForGroup(group *seiv1alpha1.SeiNodeGroup) (GroupPlanner, error) {
+	if group.Spec.Genesis != nil {
+		return &genesisGroupPlanner{}, nil
+	}
+	return nil, fmt.Errorf("no group planner for %s/%s: no genesis spec", group.Namespace, group.Name)
+}
+
 // ForNode returns the appropriate NodePlanner based on which mode sub-spec
 // is populated on the SeiNode.
 func ForNode(node *seiv1alpha1.SeiNode, snapshotRegion string) (NodePlanner, error) {
@@ -102,8 +116,8 @@ func NeedsBootstrap(node *seiv1alpha1.SeiNode) bool {
 		snap.S3 != nil && snap.S3.TargetHeight > 0
 }
 
-// IsGenesisCeremonyNode returns true when the node participates in a group genesis ceremony.
-func IsGenesisCeremonyNode(node *seiv1alpha1.SeiNode) bool {
+// isGenesisCeremonyNode returns true when the node participates in a group genesis ceremony.
+func isGenesisCeremonyNode(node *seiv1alpha1.SeiNode) bool {
 	return node.Spec.Validator != nil && node.Spec.Validator.GenesisCeremony != nil
 }
 

--- a/internal/planner/validator.go
+++ b/internal/planner/validator.go
@@ -40,6 +40,9 @@ func (p *validatorPlanner) Validate(node *seiv1alpha1.SeiNode) error {
 }
 
 func (p *validatorPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
+	if isGenesisCeremonyNode(node) {
+		return buildGenesisInitPlan(node)
+	}
 	v := node.Spec.Validator
 	params := &task.ConfigApplyParams{
 		Mode:      string(seiconfig.ModeValidator),


### PR DESCRIPTION
## Summary

- **Absorb genesis ceremony into `validatorPlanner.BuildPlan`**: The node controller no longer branches on `IsGenesisCeremonyNode` — the validator planner internally delegates to `buildGenesisInitPlan` when `GenesisCeremony` is configured. Both `IsGenesisCeremonyNode` and `BuildGenesisInitPlan` are now unexported.
- **Introduce `GroupPlanner` interface**: Mirrors the existing `NodePlanner`/`ForNode` pattern. `BuildGroupAssemblyPlan` becomes `BuildPlan` on a `genesisGroupPlanner` struct, selected via `ForGroup(group)`. The nodegroup controller calls the interface rather than a standalone function.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests updated)
- [x] `make lint` passes with 0 issues