### PR TITLE
fix: pass accountBalance to genesis assembler task

### DIFF
--- a/internal/planner/group.go
+++ b/internal/planner/group.go
@@ -28,11 +28,12 @@ func (p *genesisGroupPlanner) BuildPlan(
 	}
 
 	assembleParams := &task.AssembleAndUploadGenesisParams{
-		S3Bucket: s3.Bucket,
-		S3Prefix: s3.Prefix,
-		S3Region: s3.Region,
-		ChainID:  group.Spec.Genesis.ChainID,
-		Nodes:    nodeParams,
+		S3Bucket:       s3.Bucket,
+		S3Prefix:       s3.Prefix,
+		S3Region:       s3.Region,
+		ChainID:        group.Spec.Genesis.ChainID,
+		AccountBalance: group.Spec.Genesis.AccountBalance,
+		Nodes:          nodeParams,
 	}
 
 	assembleTask, err := buildGroupPlannedTask(group.Name, TaskAssembleGenesis, 0, assembleParams)

--- a/internal/task/genesis.go
+++ b/internal/task/genesis.go
@@ -67,11 +67,12 @@ func (p *UploadGenesisArtifactsParams) toRequestParams() *map[string]any {
 // AssembleAndUploadGenesisParams are the serialized fields for the
 // group-level assemble-and-upload-genesis sidecar task.
 type AssembleAndUploadGenesisParams struct {
-	S3Bucket string             `json:"s3Bucket"`
-	S3Prefix string             `json:"s3Prefix"`
-	S3Region string             `json:"s3Region"`
-	ChainID  string             `json:"chainId"`
-	Nodes    []GenesisNodeParam `json:"nodes"`
+	S3Bucket       string             `json:"s3Bucket"`
+	S3Prefix       string             `json:"s3Prefix"`
+	S3Region       string             `json:"s3Region"`
+	ChainID        string             `json:"chainId"`
+	AccountBalance string             `json:"accountBalance"`
+	Nodes          []GenesisNodeParam `json:"nodes"`
 }
 
 // GenesisNodeParam identifies a node participating in the genesis ceremony.


### PR DESCRIPTION
## Summary

- Adds `accountBalance` field to `AssembleAndUploadGenesisParams` so the seictl assembler can add missing validator accounts to genesis before running `collect-gentxs`
- Populates it from `group.Spec.Genesis.AccountBalance` in the group planner

## Context

During genesis assembly, `collect-gentxs` validates that every gentx delegator address exists in the genesis state. Each node only adds its own account during `generate-gentx`, so the assembler node is missing the other validators accounts. The seictl-side fix (separate PR) parses downloaded gentx files, extracts delegator addresses, and adds them with this balance before calling `collect-gentxs`.

## Test plan

- [x] `go test ./internal/planner/... ./internal/task/...` passes
- [ ] E2E: deploy with updated seictl image and verify genesis ceremony completes