### PR TITLE
fix: decouple Service selector from revision, add template hash for change classification

### DIFF
--- a/api/v1alpha1/seinodegroup_types.go
+++ b/api/v1alpha1/seinodegroup_types.go
@@ -183,6 +183,13 @@ type SeiNodeGroupStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// TemplateHash is a hash of the spec fields that require deployment
+	// orchestration when changed (image, entrypoint, chainId). Updated
+	// during steady-state reconciliation. Compared against the current
+	// spec to detect deployment-worthy changes.
+	// +optional
+	TemplateHash string `json:"templateHash,omitempty"`
+
 	// Phase is the high-level lifecycle state.
 	Phase SeiNodeGroupPhase `json:"phase,omitempty"`
 

--- a/config/crd/sei.io_seinodegroups.yaml
+++ b/config/crd/sei.io_seinodegroups.yaml
@@ -1360,6 +1360,13 @@ spec:
                 description: Replicas is the desired number of SeiNodes.
                 format: int32
                 type: integer
+              templateHash:
+                description: |-
+                  TemplateHash is a hash of the spec fields that require deployment
+                  orchestration when changed (image, entrypoint, chainId). Updated
+                  during steady-state reconciliation. Compared against the current
+                  spec to detect deployment-worthy changes.
+                type: string
             type: object
         type: object
     served: true

--- a/internal/controller/nodegroup/labels.go
+++ b/internal/controller/nodegroup/labels.go
@@ -1,9 +1,12 @@
 package nodegroup
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"maps"
 	"strconv"
+	"strings"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
@@ -17,12 +20,12 @@ const (
 )
 
 func seiNodeName(group *seiv1alpha1.SeiNodeGroup, ordinal int) string {
-	return fmt.Sprintf("%s-g%s-%d", group.Name, activeRevision(group), ordinal)
+	return fmt.Sprintf("%s-%d", group.Name, ordinal)
 }
 
-// activeRevision returns the current active revision string for a group.
-// During a deployment, this comes from status; otherwise from the group's
-// generation.
+// activeRevision returns the revision string for the currently active
+// node set. Used for traffic routing during deployments and for
+// observability labels on pods.
 func activeRevision(group *seiv1alpha1.SeiNodeGroup) string {
 	if group.Status.Deployment != nil && group.Status.Deployment.IncumbentRevision != "" {
 		return group.Status.Deployment.IncumbentRevision
@@ -35,14 +38,24 @@ func externalServiceName(group *seiv1alpha1.SeiNodeGroup) string {
 }
 
 // groupSelector returns the label selector used by the shared external
-// Service, AuthorizationPolicy, and ServiceMonitor to target all pods
-// in the group. Includes the active revision label so that during a
-// blue-green deployment, only the active set receives traffic.
+// Service, AuthorizationPolicy, and ServiceMonitor. During an active
+// deployment, it includes the revision label to pin traffic to the
+// active set. At steady state, it selects by group membership only.
 func groupSelector(group *seiv1alpha1.SeiNodeGroup) map[string]string {
-	return map[string]string{
-		groupLabel:    group.Name,
-		revisionLabel: activeRevision(group),
+	if group.Status.Deployment != nil {
+		return map[string]string{
+			groupLabel:    group.Name,
+			revisionLabel: activeRevision(group),
+		}
 	}
+	return map[string]string{groupLabel: group.Name}
+}
+
+// groupOnlySelector returns a selector matching all nodes owned by the
+// group, regardless of revision. Used for listing and scale-down where
+// we need to see every child node.
+func groupOnlySelector(group *seiv1alpha1.SeiNodeGroup) map[string]string {
+	return map[string]string{groupLabel: group.Name}
 }
 
 // seiNodeLabels builds the metadata labels for a child SeiNode.
@@ -82,4 +95,18 @@ func resourceLabels(group *seiv1alpha1.SeiNodeGroup) map[string]string {
 // resources subject to periodic drift correction via polling reconciliation.
 func managedByAnnotations() map[string]string {
 	return map[string]string{managedByAnnotation: controllerName}
+}
+
+// templateHash computes a hash over spec fields that require new nodes
+// when changed. Fields that can be updated in-place on existing nodes
+// (sidecar, podLabels, overrides) are excluded.
+func templateHash(spec *seiv1alpha1.SeiNodeSpec) string {
+	h := sha256.New()
+	h.Write([]byte(spec.Image))
+	h.Write([]byte(spec.ChainID))
+	if spec.Entrypoint != nil {
+		h.Write([]byte(strings.Join(spec.Entrypoint.Command, "\x00")))
+		h.Write([]byte(strings.Join(spec.Entrypoint.Args, "\x00")))
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16]
 }

--- a/internal/controller/nodegroup/labels.go
+++ b/internal/controller/nodegroup/labels.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"maps"
 	"strconv"
-	"strings"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
@@ -103,10 +102,5 @@ func managedByAnnotations() map[string]string {
 func templateHash(spec *seiv1alpha1.SeiNodeSpec) string {
 	h := sha256.New()
 	h.Write([]byte(spec.Image))
-	h.Write([]byte(spec.ChainID))
-	if spec.Entrypoint != nil {
-		h.Write([]byte(strings.Join(spec.Entrypoint.Command, "\x00")))
-		h.Write([]byte(strings.Join(spec.Entrypoint.Args, "\x00")))
-	}
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }

--- a/internal/controller/nodegroup/nodes.go
+++ b/internal/controller/nodegroup/nodes.go
@@ -44,24 +44,27 @@ func (r *SeiNodeGroupReconciler) reconcileSeiNodes(ctx context.Context, group *s
 	return nil
 }
 
-// detectDeploymentNeeded checks if an update strategy is configured and
-// the generation has changed. If so, it prepares the Deployment metadata
-// on the group status so the planner can select the deployment strategy.
+// detectDeploymentNeeded checks if deployment-worthy fields have changed
+// by comparing the current template hash against the stored hash. Only
+// fields that require new nodes (image, entrypoint, chainId) are hashed;
+// sidecar, overrides, and replica changes propagate in-place.
 func (r *SeiNodeGroupReconciler) detectDeploymentNeeded(group *seiv1alpha1.SeiNodeGroup) {
 	if group.Spec.UpdateStrategy == nil {
 		return
 	}
-	if group.Generation == group.Status.ObservedGeneration {
-		return
-	}
-	if group.Status.ObservedGeneration == 0 {
-		return // new group, never reconciled yet
+	if group.Status.TemplateHash == "" {
+		return // first reconcile, no baseline to compare against
 	}
 	if group.Status.Deployment != nil {
 		return
 	}
 	if hasConditionTrue(group, seiv1alpha1.ConditionPlanInProgress) {
 		return
+	}
+
+	currentHash := templateHash(&group.Spec.Template.Spec)
+	if currentHash == group.Status.TemplateHash {
+		return // no deployment-worthy fields changed
 	}
 
 	group.Status.Deployment = &seiv1alpha1.DeploymentStatus{
@@ -203,7 +206,7 @@ func (r *SeiNodeGroupReconciler) scaleDown(ctx context.Context, group *seiv1alph
 	nodeList := &seiv1alpha1.SeiNodeList{}
 	if err := r.List(ctx, nodeList,
 		client.InNamespace(group.Namespace),
-		client.MatchingLabels(groupSelector(group)),
+		client.MatchingLabels(groupOnlySelector(group)),
 	); err != nil {
 		return fmt.Errorf("listing child SeiNodes: %w", err)
 	}

--- a/internal/controller/nodegroup/nodes_test.go
+++ b/internal/controller/nodegroup/nodes_test.go
@@ -37,11 +37,11 @@ func TestGenerateSeiNode_NameAndNamespace(t *testing.T) {
 	group := newTestGroup("archive-rpc", "sei")
 
 	node := generateSeiNode(group, 0)
-	g.Expect(node.Name).To(Equal("archive-rpc-g0-0"))
+	g.Expect(node.Name).To(Equal("archive-rpc-0"))
 	g.Expect(node.Namespace).To(Equal("sei"))
 
 	node2 := generateSeiNode(group, 2)
-	g.Expect(node2.Name).To(Equal("archive-rpc-g0-2"))
+	g.Expect(node2.Name).To(Equal("archive-rpc-2"))
 }
 
 func TestGenerateSeiNode_SystemLabels(t *testing.T) {
@@ -113,7 +113,7 @@ func TestGenerateSeiNode_CopiesSpec(t *testing.T) {
 
 	node := generateSeiNode(group, 0)
 
-	g.Expect(node.Name).To(Equal("full-node-g0-0"))
+	g.Expect(node.Name).To(Equal("full-node-0"))
 	g.Expect(node.Namespace).To(Equal("pacific-1"))
 	g.Expect(node.Spec.ChainID).To(Equal("pacific-1"))
 	g.Expect(node.Spec.Image).To(Equal("ghcr.io/sei-protocol/seid:v1.0.0"))

--- a/internal/controller/nodegroup/status.go
+++ b/internal/controller/nodegroup/status.go
@@ -34,10 +34,11 @@ func (r *SeiNodeGroupReconciler) updateStatus(ctx context.Context, group *seiv1a
 		})
 	}
 
-	// Update ObservedGeneration when no plan is active. During plan
-	// execution, ObservedGeneration is updated by completePlan.
+	// Update ObservedGeneration and TemplateHash when no plan is active.
+	// During plan execution, ObservedGeneration is updated by completePlan.
 	if !hasConditionTrue(group, seiv1alpha1.ConditionPlanInProgress) {
 		group.Status.ObservedGeneration = group.Generation
+		group.Status.TemplateHash = templateHash(&group.Spec.Template.Spec)
 	}
 	group.Status.Replicas = group.Spec.Replicas
 	group.Status.ReadyReplicas = readyReplicas

--- a/manifests/sei.io_seinodegroups.yaml
+++ b/manifests/sei.io_seinodegroups.yaml
@@ -1360,6 +1360,13 @@ spec:
                 description: Replicas is the desired number of SeiNodes.
                 format: int32
                 type: integer
+              templateHash:
+                description: |-
+                  TemplateHash is a hash of the spec fields that require deployment
+                  orchestration when changed (image, entrypoint, chainId). Updated
+                  during steady-state reconciliation. Compared against the current
+                  spec to detect deployment-worthy changes.
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
## Summary

Fixes two gaps in the deployment model identified by expert review:

### 1. Scaling no longer breaks traffic
- `groupSelector` excludes `sei.io/revision` during steady state — only includes it during active deployments for traffic pinning between incumbent/entrant sets
- `groupOnlySelector` used for `listChildSeiNodes`/`scaleDown` where all children must be visible
- A replicas change bumps generation but does NOT change the template hash, so no deployment triggers

### 2. Sidecar upgrades are in-place, not blue-green
- `TemplateHash` on status hashes only deployment-worthy fields: `image`, `entrypoint`, `chainId`
- `detectDeploymentNeeded` compares hash instead of generation
- Sidecar image, overrides, and podLabels changes propagate in-place via `ensureSeiNode` → SeiNode controller → StatefulSet SSA

### Change classification matrix

| Change | Hash changes? | Result |
|--------|:-:|--------|
| `spec.template.spec.image` | Yes | Blue-green deployment |
| `spec.template.spec.entrypoint` | Yes | Blue-green deployment |
| `spec.template.spec.chainId` | Yes | Blue-green deployment |
| `spec.template.spec.sidecar.image` | No | In-place rolling restart |
| `spec.template.spec.overrides` | No | In-place config update |
| `spec.replicas` | No | Scale operation |

### 3. Node naming reverted to `{group}-{ordinal}`
- Generation-qualified names only for deployment entrant nodes
- Matches Kubernetes StatefulSet naming convention

## Test plan
- [x] All existing tests pass
- [x] Zero lint issues