### PR TITLE
fix: include sidecar image in template hash

### DIFF
--- a/internal/controller/nodegroup/labels.go
+++ b/internal/controller/nodegroup/labels.go
@@ -97,10 +97,13 @@ func managedByAnnotations() map[string]string {
 }
 
 // templateHash computes a hash over spec fields that require new nodes
-// when changed. Fields that can be updated in-place on existing nodes
-// (sidecar, podLabels, overrides) are excluded.
+// when changed. Any container image change triggers a full pod restart,
+// so both the chain binary and sidecar images are included.
 func templateHash(spec *seiv1alpha1.SeiNodeSpec) string {
 	h := sha256.New()
 	h.Write([]byte(spec.Image))
+	if spec.Sidecar != nil {
+		h.Write([]byte(spec.Sidecar.Image))
+	}
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }


### PR DESCRIPTION
Any container image change causes a full pod restart via StatefulSet rolling update, so sidecar upgrades have the same operational impact as chain binary upgrades. Both should go through blue-green orchestration for zero-downtime deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)