### PR TITLE
refactor: standardize task implementations with taskBase and sentinel errors

### DIFF
--- a/internal/planner/executor.go
+++ b/internal/planner/executor.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -106,7 +107,11 @@ func executePlan(
 
 	if status == task.ExecutionRunning && t.Status == seiv1alpha1.TaskPending {
 		if err := exec.Execute(ctx); err != nil {
-			log.FromContext(ctx).Info("task submission failed, will retry",
+			var termErr *task.TerminalError
+			if errors.As(err, &termErr) {
+				return failTask(ctx, kc, obj, plan, t, err.Error())
+			}
+			log.FromContext(ctx).Info("task execution failed, will retry",
 				"task", t.Type, "error", err)
 			return ctrl.Result{RequeueAfter: TaskPollInterval}, nil
 		}

--- a/internal/task/await_nodes_running.go
+++ b/internal/task/await_nodes_running.go
@@ -25,11 +25,9 @@ type AwaitNodesRunningParams struct {
 }
 
 type awaitNodesRunningExecution struct {
-	id     string
+	taskBase
 	params AwaitNodesRunningParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeAwaitNodesRunning(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -40,18 +38,17 @@ func deserializeAwaitNodesRunning(id string, params json.RawMessage, cfg Executi
 		}
 	}
 	return &awaitNodesRunningExecution{
-		id:     id,
-		params: p,
-		cfg:    cfg,
-		status: ExecutionRunning,
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
 	}, nil
 }
 
 func (e *awaitNodesRunningExecution) Execute(_ context.Context) error { return nil }
 
 func (e *awaitNodesRunningExecution) Status(ctx context.Context) ExecutionStatus {
-	if e.status == ExecutionComplete || e.status == ExecutionFailed {
-		return e.status
+	if s, done := e.isTerminal(); done {
+		return s
 	}
 
 	nodes, err := e.listTargetNodes(ctx)
@@ -65,14 +62,13 @@ func (e *awaitNodesRunningExecution) Status(ctx context.Context) ExecutionStatus
 		case seiv1alpha1.PhaseRunning:
 			running++
 		case seiv1alpha1.PhaseFailed:
-			e.err = fmt.Errorf("node %s is in Failed phase", nodes[i].Name)
-			e.status = ExecutionFailed
+			e.setFailed(fmt.Errorf("node %s is in Failed phase", nodes[i].Name))
 			return ExecutionFailed
 		}
 	}
 
 	if running >= e.params.Expected {
-		e.status = ExecutionComplete
+		e.complete()
 		return ExecutionComplete
 	}
 	return ExecutionRunning
@@ -99,5 +95,3 @@ func (e *awaitNodesRunningExecution) listTargetNodes(ctx context.Context) ([]sei
 	}
 	return nodeList.Items, nil
 }
-
-func (e *awaitNodesRunningExecution) Err() error { return e.err }

--- a/internal/task/bootstrap_await.go
+++ b/internal/task/bootstrap_await.go
@@ -10,19 +10,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// AwaitBootstrapCompleteParams holds the serialized parameters for the
-// await-bootstrap-complete task.
 type AwaitBootstrapCompleteParams struct {
 	JobName   string `json:"jobName"`
 	Namespace string `json:"namespace"`
 }
 
 type awaitBootstrapCompleteExecution struct {
-	id     string
+	taskBase
 	params AwaitBootstrapCompleteParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeBootstrapAwait(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -33,43 +29,37 @@ func deserializeBootstrapAwait(id string, params json.RawMessage, cfg ExecutionC
 		}
 	}
 	return &awaitBootstrapCompleteExecution{
-		id:     id,
-		params: p,
-		cfg:    cfg,
-		status: ExecutionRunning,
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
 	}, nil
 }
 
-// Execute is a no-op — the Job is already running from a previous task.
 func (e *awaitBootstrapCompleteExecution) Execute(_ context.Context) error { return nil }
 
 func (e *awaitBootstrapCompleteExecution) Status(ctx context.Context) ExecutionStatus {
-	if e.status == ExecutionComplete || e.status == ExecutionFailed {
-		return e.status
+	if s, done := e.isTerminal(); done {
+		return s
 	}
 
 	job := &batchv1.Job{}
 	key := types.NamespacedName{Name: e.params.JobName, Namespace: e.params.Namespace}
 	if err := e.cfg.KubeClient.Get(ctx, key, job); err != nil {
 		if apierrors.IsNotFound(err) {
-			e.err = fmt.Errorf("bootstrap job %s not found", e.params.JobName)
-			e.status = ExecutionFailed
+			e.setFailed(fmt.Errorf("bootstrap job %s not found", e.params.JobName))
 			return ExecutionFailed
 		}
 		return ExecutionRunning
 	}
 
 	if IsJobComplete(job) {
-		e.status = ExecutionComplete
+		e.complete()
 		return ExecutionComplete
 	}
 	if IsJobFailed(job) {
-		e.err = fmt.Errorf("bootstrap job failed: %s", JobFailureReason(job))
-		e.status = ExecutionFailed
+		e.setFailed(fmt.Errorf("bootstrap job failed: %s", JobFailureReason(job)))
 		return ExecutionFailed
 	}
 
 	return ExecutionRunning
 }
-
-func (e *awaitBootstrapCompleteExecution) Err() error { return e.err }

--- a/internal/task/bootstrap_job.go
+++ b/internal/task/bootstrap_job.go
@@ -13,19 +13,15 @@ import (
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
 
-// DeployBootstrapJobParams holds the serialized parameters for the
-// deploy-bootstrap-job task.
 type DeployBootstrapJobParams struct {
 	JobName   string `json:"jobName"`
 	Namespace string `json:"namespace"`
 }
 
 type deployBootstrapJobExecution struct {
-	id     string
+	taskBase
 	params DeployBootstrapJobParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeBootstrapJob(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -36,10 +32,9 @@ func deserializeBootstrapJob(id string, params json.RawMessage, cfg ExecutionCon
 		}
 	}
 	return &deployBootstrapJobExecution{
-		id:     id,
-		params: p,
-		cfg:    cfg,
-		status: ExecutionRunning,
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
 	}, nil
 }
 
@@ -58,25 +53,23 @@ func (e *deployBootstrapJobExecution) Execute(ctx context.Context) error {
 	}
 	if err := e.cfg.KubeClient.Create(ctx, job); err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			e.status = ExecutionComplete
+			e.complete()
 			return nil
 		}
 		return fmt.Errorf("creating bootstrap job: %w", err)
 	}
-	e.status = ExecutionComplete
+	e.complete()
 	return nil
 }
 
 func (e *deployBootstrapJobExecution) Status(ctx context.Context) ExecutionStatus {
-	if e.status == ExecutionComplete {
-		return ExecutionComplete
+	if s, done := e.isTerminal(); done {
+		return s
 	}
 	existing := &batchv1.Job{}
 	key := types.NamespacedName{Name: e.params.JobName, Namespace: e.params.Namespace}
 	if err := e.cfg.KubeClient.Get(ctx, key, existing); err == nil {
-		e.status = ExecutionComplete
+		e.complete()
 	}
 	return e.status
 }
-
-func (e *deployBootstrapJobExecution) Err() error { return e.err }

--- a/internal/task/bootstrap_resources.go
+++ b/internal/task/bootstrap_resources.go
@@ -187,7 +187,7 @@ func bootstrapWaitCommand(port int32, haltHeight int64) (command []string, args 
 		`echo "waiting for sidecar to become ready..."; `+
 			`while true; do `+
 			`{ exec 3<>/dev/tcp/localhost/%d; } 2>/dev/null && `+
-			`printf "GET /v0/healthz HTTP/1.0\r\nHost: localhost\r\n\r\n" >&3 && `+
+			`printf "GET /v0/status HTTP/1.0\r\nHost: localhost\r\n\r\n" >&3 && `+
 			`head -1 <&3 | grep -q "200" && break; `+
 			`exec 3>&-; sleep 5; done; `+
 			`exec 3>&-; `+

--- a/internal/task/bootstrap_service.go
+++ b/internal/task/bootstrap_service.go
@@ -13,19 +13,15 @@ import (
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
 
-// DeployBootstrapServiceParams holds the serialized parameters for the
-// deploy-bootstrap-service task.
 type DeployBootstrapServiceParams struct {
 	ServiceName string `json:"serviceName"`
 	Namespace   string `json:"namespace"`
 }
 
 type deployBootstrapServiceExecution struct {
-	id     string
+	taskBase
 	params DeployBootstrapServiceParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeBootstrapService(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -36,10 +32,9 @@ func deserializeBootstrapService(id string, params json.RawMessage, cfg Executio
 		}
 	}
 	return &deployBootstrapServiceExecution{
-		id:     id,
-		params: p,
-		cfg:    cfg,
-		status: ExecutionRunning,
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
 	}, nil
 }
 
@@ -54,25 +49,23 @@ func (e *deployBootstrapServiceExecution) Execute(ctx context.Context) error {
 	}
 	if err := e.cfg.KubeClient.Create(ctx, svc); err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			e.status = ExecutionComplete
+			e.complete()
 			return nil
 		}
 		return fmt.Errorf("creating bootstrap service: %w", err)
 	}
-	e.status = ExecutionComplete
+	e.complete()
 	return nil
 }
 
 func (e *deployBootstrapServiceExecution) Status(ctx context.Context) ExecutionStatus {
-	if e.status == ExecutionComplete {
-		return ExecutionComplete
+	if s, done := e.isTerminal(); done {
+		return s
 	}
 	existing := &corev1.Service{}
 	key := types.NamespacedName{Name: e.params.ServiceName, Namespace: e.params.Namespace}
 	if err := e.cfg.KubeClient.Get(ctx, key, existing); err == nil {
-		e.status = ExecutionComplete
+		e.complete()
 	}
 	return e.status
 }
-
-func (e *deployBootstrapServiceExecution) Err() error { return e.err }

--- a/internal/task/bootstrap_teardown.go
+++ b/internal/task/bootstrap_teardown.go
@@ -13,8 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// TeardownBootstrapParams holds the serialized parameters for the
-// teardown-bootstrap task.
 type TeardownBootstrapParams struct {
 	JobName     string `json:"jobName"`
 	ServiceName string `json:"serviceName"`
@@ -22,11 +20,9 @@ type TeardownBootstrapParams struct {
 }
 
 type teardownBootstrapExecution struct {
-	id     string
+	taskBase
 	params TeardownBootstrapParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeBootstrapTeardown(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -37,10 +33,9 @@ func deserializeBootstrapTeardown(id string, params json.RawMessage, cfg Executi
 		}
 	}
 	return &teardownBootstrapExecution{
-		id:     id,
-		params: p,
-		cfg:    cfg,
-		status: ExecutionRunning,
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
 	}, nil
 }
 
@@ -73,32 +68,19 @@ func (e *teardownBootstrapExecution) Execute(ctx context.Context) error {
 }
 
 func (e *teardownBootstrapExecution) Status(ctx context.Context) ExecutionStatus {
-	if e.status == ExecutionComplete {
-		return ExecutionComplete
+	if s, done := e.isTerminal(); done {
+		return s
 	}
 
 	kc := e.cfg.KubeClient
 	ns := e.params.Namespace
 
-	job := &batchv1.Job{}
-	jobKey := types.NamespacedName{Name: e.params.JobName, Namespace: ns}
-	jobGone := false
-	if err := kc.Get(ctx, jobKey, job); apierrors.IsNotFound(err) {
-		jobGone = true
-	}
-
-	svc := &corev1.Service{}
-	svcKey := types.NamespacedName{Name: e.params.ServiceName, Namespace: ns}
-	svcGone := false
-	if err := kc.Get(ctx, svcKey, svc); apierrors.IsNotFound(err) {
-		svcGone = true
-	}
+	jobGone := apierrors.IsNotFound(kc.Get(ctx, types.NamespacedName{Name: e.params.JobName, Namespace: ns}, &batchv1.Job{}))
+	svcGone := apierrors.IsNotFound(kc.Get(ctx, types.NamespacedName{Name: e.params.ServiceName, Namespace: ns}, &corev1.Service{}))
 
 	if jobGone && svcGone {
-		e.status = ExecutionComplete
+		e.complete()
 		return ExecutionComplete
 	}
 	return ExecutionRunning
 }
-
-func (e *teardownBootstrapExecution) Err() error { return e.err }

--- a/internal/task/deployment.go
+++ b/internal/task/deployment.go
@@ -13,8 +13,9 @@ const (
 )
 
 // deploymentTaskNamespace is a fixed UUID v5 namespace for generating
-// deterministic task IDs scoped to deployment operations.
-var deploymentTaskNamespace = uuid.MustParse("b7e89c3a-4f12-4d8b-9a6e-1c2d3e4f5a6b")
+// deterministic task IDs scoped to deployment operations. Distinct from
+// taskIDNamespace to prevent cross-domain collisions.
+var deploymentTaskNamespace = uuid.MustParse("d4a7e1f3-8b29-4c6d-a5e0-2f1d3c4b5a6e")
 
 // CreateEntrantNodesParams holds parameters for creating entrant SeiNode resources.
 type CreateEntrantNodesParams struct {

--- a/internal/task/deployment_await.go
+++ b/internal/task/deployment_await.go
@@ -14,14 +14,11 @@ import (
 )
 
 // awaitNodesAtHeightExecution submits await-condition(height=H) to each
-// node's sidecar and polls until all complete. Used by HardFork strategy.
+// node's sidecar and polls until all complete.
 type awaitNodesAtHeightExecution struct {
-	id        string
-	params    AwaitNodesAtHeightParams
-	cfg       ExecutionConfig
-	status    ExecutionStatus
-	err       error
-	submitted map[string]uuid.UUID
+	taskBase
+	params AwaitNodesAtHeightParams
+	cfg    ExecutionConfig
 }
 
 func deserializeAwaitNodesAtHeight(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -32,8 +29,9 @@ func deserializeAwaitNodesAtHeight(id string, params json.RawMessage, cfg Execut
 		}
 	}
 	return &awaitNodesAtHeightExecution{
-		id: id, params: p, cfg: cfg,
-		status: ExecutionRunning, submitted: make(map[string]uuid.UUID),
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
 	}, nil
 }
 
@@ -57,34 +55,29 @@ func (e *awaitNodesAtHeightExecution) Execute(ctx context.Context) error {
 			logger.Info("failed to submit await-height, will retry", "node", name, "error", err)
 			return err
 		}
-		e.submitted[name] = taskID
 	}
 	return nil
 }
 
+// Status polls each node's sidecar for the await-condition task using
+// deterministic IDs. No in-memory state is needed — task IDs are
+// recomputed on every call, making this restart-safe.
 func (e *awaitNodesAtHeightExecution) Status(ctx context.Context) ExecutionStatus {
-	if e.status == ExecutionComplete || e.status == ExecutionFailed {
-		return e.status
-	}
-	if len(e.submitted) == 0 {
-		return ExecutionRunning
+	if s, done := e.isTerminal(); done {
+		return s
 	}
 	for _, name := range e.params.NodeNames {
-		taskID, ok := e.submitted[name]
-		if !ok {
-			return ExecutionRunning
-		}
+		taskID := deterministicDeploymentTaskID(name, "await-height", e.id)
 		status, err := e.pollSidecarTask(ctx, name, taskID)
 		if err != nil {
-			e.err = err
-			e.status = ExecutionFailed
+			e.setFailed(err)
 			return ExecutionFailed
 		}
 		if status != ExecutionComplete {
 			return status
 		}
 	}
-	e.status = ExecutionComplete
+	e.complete()
 	return ExecutionComplete
 }
 
@@ -119,17 +112,11 @@ func (e *awaitNodesAtHeightExecution) sidecarForNode(ctx context.Context, name s
 	return sidecarClientForNode(node)
 }
 
-func (e *awaitNodesAtHeightExecution) Err() error { return e.err }
-
-// awaitNodesCaughtUpExecution polls node sidecars until all report
-// Ready status (sidecar transitions to Ready after mark-ready succeeds,
-// which requires seid to be synced and serving).
+// awaitNodesCaughtUpExecution polls node sidecars until all report Ready.
 type awaitNodesCaughtUpExecution struct {
-	id     string
+	taskBase
 	params AwaitNodesCaughtUpParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeAwaitNodesCaughtUp(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -139,21 +126,25 @@ func deserializeAwaitNodesCaughtUp(id string, params json.RawMessage, cfg Execut
 			return nil, fmt.Errorf("deserializing await-nodes-caught-up params: %w", err)
 		}
 	}
-	return &awaitNodesCaughtUpExecution{id: id, params: p, cfg: cfg, status: ExecutionRunning}, nil
+	return &awaitNodesCaughtUpExecution{
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
+	}, nil
 }
 
 func (e *awaitNodesCaughtUpExecution) Execute(_ context.Context) error { return nil }
 
 func (e *awaitNodesCaughtUpExecution) Status(ctx context.Context) ExecutionStatus {
-	if e.status == ExecutionComplete || e.status == ExecutionFailed {
-		return e.status
+	if s, done := e.isTerminal(); done {
+		return s
 	}
 	for _, name := range e.params.NodeNames {
 		if !e.isNodeReady(ctx, name) {
 			return ExecutionRunning
 		}
 	}
-	e.status = ExecutionComplete
+	e.complete()
 	return ExecutionComplete
 }
 
@@ -172,8 +163,6 @@ func (e *awaitNodesCaughtUpExecution) isNodeReady(ctx context.Context, name stri
 	}
 	return resp.Status == sidecar.Ready
 }
-
-func (e *awaitNodesCaughtUpExecution) Err() error { return e.err }
 
 // sidecarClientForNode constructs a SidecarClient from a SeiNode's
 // pod DNS name and sidecar port.

--- a/internal/task/deployment_create.go
+++ b/internal/task/deployment_create.go
@@ -14,11 +14,9 @@ import (
 )
 
 type createEntrantNodesExecution struct {
-	id     string
+	taskBase
 	params CreateEntrantNodesParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeCreateEntrantNodes(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -28,22 +26,26 @@ func deserializeCreateEntrantNodes(id string, params json.RawMessage, cfg Execut
 			return nil, fmt.Errorf("deserializing create-entrant-nodes params: %w", err)
 		}
 	}
-	return &createEntrantNodesExecution{id: id, params: p, cfg: cfg, status: ExecutionRunning}, nil
+	return &createEntrantNodesExecution{
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
+	}, nil
 }
 
 func (e *createEntrantNodesExecution) Execute(ctx context.Context) error {
 	group, err := ResourceAs[*seiv1alpha1.SeiNodeGroup](e.cfg)
 	if err != nil {
-		return e.fail(err)
+		return Terminal(err)
 	}
 
 	for i, name := range e.params.NodeNames {
 		if err := e.ensureEntrantNode(ctx, group, name, i); err != nil {
-			return e.fail(err)
+			return err // transient — kube API errors are retryable
 		}
 	}
 
-	e.status = ExecutionComplete
+	e.complete()
 	return nil
 }
 
@@ -92,14 +94,6 @@ func (e *createEntrantNodesExecution) ensureEntrantNode(
 	return nil
 }
 
-func (e *createEntrantNodesExecution) fail(err error) error {
-	e.status = ExecutionFailed
-	e.err = err
-	return err
-}
-
 func (e *createEntrantNodesExecution) Status(_ context.Context) ExecutionStatus {
 	return e.status
 }
-
-func (e *createEntrantNodesExecution) Err() error { return e.err }

--- a/internal/task/deployment_signal.go
+++ b/internal/task/deployment_signal.go
@@ -16,11 +16,9 @@ import (
 // await-condition(height=H, action=SIGTERM) to each incumbent node's
 // sidecar. Completes immediately after submission (best-effort).
 type submitHaltSignalExecution struct {
-	id     string
+	taskBase
 	params SubmitHaltSignalParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeSubmitHaltSignal(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -30,7 +28,11 @@ func deserializeSubmitHaltSignal(id string, params json.RawMessage, cfg Executio
 			return nil, fmt.Errorf("deserializing submit-halt-signal params: %w", err)
 		}
 	}
-	return &submitHaltSignalExecution{id: id, params: p, cfg: cfg, status: ExecutionRunning}, nil
+	return &submitHaltSignalExecution{
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
+	}, nil
 }
 
 func (e *submitHaltSignalExecution) Execute(ctx context.Context) error {
@@ -40,9 +42,7 @@ func (e *submitHaltSignalExecution) Execute(ctx context.Context) error {
 		e.submitToNode(ctx, logger, name)
 	}
 
-	// Best-effort: always complete. For a real hard fork, consensus
-	// halts at the height regardless of whether SIGTERM was delivered.
-	e.status = ExecutionComplete
+	e.complete()
 	return nil
 }
 
@@ -82,5 +82,3 @@ func (e *submitHaltSignalExecution) submitToNode(ctx context.Context, logger int
 func (e *submitHaltSignalExecution) Status(_ context.Context) ExecutionStatus {
 	return e.status
 }
-
-func (e *submitHaltSignalExecution) Err() error { return e.err }

--- a/internal/task/deployment_switch.go
+++ b/internal/task/deployment_switch.go
@@ -14,15 +14,11 @@ import (
 )
 
 // switchTrafficExecution updates the group's deployment status to reflect
-// the entrant revision as active. The group controller's networking
-// reconciliation uses the active revision in the Service selector, so
-// updating the status is sufficient to switch traffic.
+// the entrant revision as active.
 type switchTrafficExecution struct {
-	id     string
+	taskBase
 	params SwitchTrafficParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeSwitchTraffic(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -32,49 +28,45 @@ func deserializeSwitchTraffic(id string, params json.RawMessage, cfg ExecutionCo
 			return nil, fmt.Errorf("deserializing switch-traffic params: %w", err)
 		}
 	}
-	return &switchTrafficExecution{id: id, params: p, cfg: cfg, status: ExecutionRunning}, nil
+	return &switchTrafficExecution{
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
+	}, nil
 }
 
 func (e *switchTrafficExecution) Execute(ctx context.Context) error {
 	group, err := ResourceAs[*seiv1alpha1.SeiNodeGroup](e.cfg)
 	if err != nil {
-		return e.fail(err)
+		return Terminal(err)
 	}
 
 	if group.Status.Deployment == nil {
-		return e.fail(fmt.Errorf("no deployment status on group %s", e.params.GroupName))
+		return Terminal(fmt.Errorf("no deployment status on group %s", e.params.GroupName))
 	}
 
 	patch := client.MergeFrom(group.DeepCopy())
 	group.Status.Deployment.IncumbentRevision = e.params.EntrantRevision
 	if err := e.cfg.KubeClient.Status().Patch(ctx, group, patch); err != nil {
-		return e.fail(fmt.Errorf("patching deployment revision: %w", err))
+		return fmt.Errorf("patching deployment revision: %w", err) // transient
 	}
 
 	log.FromContext(ctx).Info("traffic switched to entrant revision",
 		"group", e.params.GroupName, "revision", e.params.EntrantRevision)
 
-	e.status = ExecutionComplete
+	e.complete()
 	return nil
 }
 
-func (e *switchTrafficExecution) fail(err error) error {
-	e.status = ExecutionFailed
-	e.err = err
-	return err
+func (e *switchTrafficExecution) Status(_ context.Context) ExecutionStatus {
+	return e.status
 }
 
-func (e *switchTrafficExecution) Status(_ context.Context) ExecutionStatus { return e.status }
-func (e *switchTrafficExecution) Err() error                               { return e.err }
-
-// teardownNodesExecution deletes incumbent SeiNode resources after
-// traffic has been switched to the entrant set.
+// teardownNodesExecution deletes incumbent SeiNode resources.
 type teardownNodesExecution struct {
-	id     string
+	taskBase
 	params TeardownNodesParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeTeardownNodes(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -84,7 +76,11 @@ func deserializeTeardownNodes(id string, params json.RawMessage, cfg ExecutionCo
 			return nil, fmt.Errorf("deserializing teardown-nodes params: %w", err)
 		}
 	}
-	return &teardownNodesExecution{id: id, params: p, cfg: cfg, status: ExecutionRunning}, nil
+	return &teardownNodesExecution{
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
+	}, nil
 }
 
 func (e *teardownNodesExecution) Execute(ctx context.Context) error {
@@ -92,12 +88,12 @@ func (e *teardownNodesExecution) Execute(ctx context.Context) error {
 
 	for _, name := range e.params.NodeNames {
 		if err := e.deleteNode(ctx, name); err != nil {
-			return e.fail(err)
+			return err // transient — kube API errors are retryable
 		}
 		logger.Info("deleted incumbent node", "node", name)
 	}
 
-	e.status = ExecutionComplete
+	e.complete()
 	return nil
 }
 
@@ -116,11 +112,6 @@ func (e *teardownNodesExecution) deleteNode(ctx context.Context, name string) er
 	return nil
 }
 
-func (e *teardownNodesExecution) fail(err error) error {
-	e.status = ExecutionFailed
-	e.err = err
-	return err
+func (e *teardownNodesExecution) Status(_ context.Context) ExecutionStatus {
+	return e.status
 }
-
-func (e *teardownNodesExecution) Status(_ context.Context) ExecutionStatus { return e.status }
-func (e *teardownNodesExecution) Err() error                               { return e.err }

--- a/internal/task/genesis_peers.go
+++ b/internal/task/genesis_peers.go
@@ -16,8 +16,6 @@ const (
 	defaultP2PPort             = int32(26656)
 )
 
-// CollectAndSetPeersParams holds parameters for collecting node IDs from
-// each node's sidecar and setting static peers on all validator nodes.
 type CollectAndSetPeersParams struct {
 	GroupName string   `json:"groupName"`
 	Namespace string   `json:"namespace"`
@@ -28,11 +26,9 @@ type CollectAndSetPeersParams struct {
 }
 
 type collectAndSetPeersExecution struct {
-	id     string
+	taskBase
 	params CollectAndSetPeersParams
 	cfg    ExecutionConfig
-	status ExecutionStatus
-	err    error
 }
 
 func deserializeCollectAndSetPeers(id string, params json.RawMessage, cfg ExecutionConfig) (TaskExecution, error) {
@@ -42,32 +38,36 @@ func deserializeCollectAndSetPeers(id string, params json.RawMessage, cfg Execut
 			return nil, fmt.Errorf("deserializing collect-and-set-peers params: %w", err)
 		}
 	}
-	return &collectAndSetPeersExecution{id: id, params: p, cfg: cfg, status: ExecutionRunning}, nil
+	return &collectAndSetPeersExecution{
+		taskBase: taskBase{id: id, status: ExecutionRunning},
+		params:   p,
+		cfg:      cfg,
+	}, nil
 }
 
 func (e *collectAndSetPeersExecution) Execute(ctx context.Context) error {
 	peers, err := e.collectPeers(ctx)
 	if err != nil {
-		return e.fail(fmt.Errorf("collecting peers: %w", err))
+		return fmt.Errorf("collecting peers: %w", err) // transient — sidecar may not be ready
 	}
 
 	if err := e.setPeersOnNodes(ctx, peers); err != nil {
-		return e.fail(fmt.Errorf("setting peers: %w", err))
+		return fmt.Errorf("setting peers: %w", err) // transient
 	}
 
 	group, err := ResourceAs[*seiv1alpha1.SeiNodeGroup](e.cfg)
 	if err != nil {
-		return e.fail(err)
+		return Terminal(err)
 	}
 
 	genesisURI := fmt.Sprintf("s3://%s/%sgenesis.json", e.params.S3Bucket, e.params.S3Prefix)
 	patch := client.MergeFrom(group.DeepCopy())
 	group.Status.GenesisS3URI = genesisURI
 	if err := e.cfg.KubeClient.Status().Patch(ctx, group, patch); err != nil {
-		return e.fail(fmt.Errorf("recording genesis S3 URI: %w", err))
+		return fmt.Errorf("recording genesis S3 URI: %w", err) // transient
 	}
 
-	e.status = ExecutionComplete
+	e.complete()
 	return nil
 }
 
@@ -115,13 +115,6 @@ func (e *collectAndSetPeersExecution) setPeersOnNodes(ctx context.Context, peers
 	return nil
 }
 
-func (e *collectAndSetPeersExecution) fail(err error) error {
-	e.status = ExecutionFailed
-	e.err = err
-	return err
-}
-
 func (e *collectAndSetPeersExecution) Status(_ context.Context) ExecutionStatus {
 	return e.status
 }
-func (e *collectAndSetPeersExecution) Err() error { return e.err }

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -42,14 +42,68 @@ const (
 var ErrTaskNotFound = errors.New("task not found on sidecar")
 
 // TaskExecution defines how the plan executor drives a single task.
-// Execute is a command (called once to submit). Status is a query
-// (called on every reconcile to poll progress). Err returns details
-// when Status reports ExecutionFailed.
+// Execute is a command (called once to submit — must be idempotent).
+// Status is a query (called on every reconcile to poll progress).
+// Err returns details when Status reports ExecutionFailed.
+//
+// Execute error semantics:
+//   - Return a plain error for transient failures — the executor retries.
+//   - Return Terminal(err) for permanent failures — the executor fails the plan.
+//
+// Implementations should embed taskBase for terminal-state caching and Err().
 type TaskExecution interface {
 	Execute(ctx context.Context) error
 	Status(ctx context.Context) ExecutionStatus
 	Err() error
 }
+
+// TerminalError wraps an error to signal that the failure is permanent
+// and the task should not be retried. The executor checks for this via
+// errors.As to decide whether to retry or fail the plan.
+type TerminalError struct {
+	Err error
+}
+
+func (e *TerminalError) Error() string { return e.Err.Error() }
+func (e *TerminalError) Unwrap() error { return e.Err }
+
+// Terminal wraps an error to mark it as non-retryable.
+func Terminal(err error) error {
+	return &TerminalError{Err: err}
+}
+
+// taskBase provides standard lifecycle helpers for TaskExecution
+// implementations. Embed it to get terminal-state caching, error
+// tracking, and the Err() method.
+type taskBase struct {
+	id     string
+	status ExecutionStatus
+	err    error
+}
+
+// isTerminal returns the cached status and true if the task has reached
+// a terminal state. Call at the top of Status() to short-circuit polling.
+func (b *taskBase) isTerminal() (ExecutionStatus, bool) {
+	if b.status == ExecutionComplete || b.status == ExecutionFailed {
+		return b.status, true
+	}
+	return "", false
+}
+
+// complete marks the task as successfully completed.
+func (b *taskBase) complete() {
+	b.status = ExecutionComplete
+}
+
+// setFailed marks the task as failed with the given error.
+// Used by Status() methods to record failures detected during polling.
+func (b *taskBase) setFailed(err error) {
+	b.status = ExecutionFailed
+	b.err = err
+}
+
+// Err returns the error that caused failure, or nil.
+func (b *taskBase) Err() error { return b.err }
 
 // UnknownTaskTypeError is returned by Deserialize for unrecognized task types.
 // The executor should treat this as a permanent failure.


### PR DESCRIPTION
## Summary

Two key patterns for uniform, idempotent task execution:

### 1. `taskBase` embedded struct
All controller-side tasks embed `taskBase` for consistent lifecycle:
- `isTerminal()` — short-circuit guard for Status() polling
- `complete()` — mark success
- `setFailed(err)` — record failure during Status() polling
- `Err()` — standard error accessor

### 2. `TerminalError` sentinel type
Execute() error semantics are now explicit and idiomatic Go:
```go
return err              // transient — executor retries
return Terminal(err)    // permanent — executor fails the plan
```
The executor checks `errors.As(*TerminalError)` to decide. Eliminates the ambiguous `fail()` method that served dual purpose in Execute and Status contexts.

### Additional fixes
- Eliminate `submitted` map from `awaitNodesAtHeightExecution` — deterministic task IDs computed inline in Status() for restart safety
- Fix `/v0/healthz` → `/v0/status` in bootstrap wait command
- Distinct UUID namespace for deployment task IDs

## Test plan
- [x] All existing tests pass
- [x] Zero lint issues