### PR TITLE
chore: bump controller image to a03ac73, update sample manifests

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:83a0a7cb1adac5fa5b515af0b86b85d3e22008d6
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:a03ac737c2d039513efd3f755bc18f235d7688e7
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME

--- a/manifests/samples/seinode/pacific-1-shadow-replayer.yaml
+++ b/manifests/samples/seinode/pacific-1-shadow-replayer.yaml
@@ -14,7 +14,7 @@ spec:
   image: ghcr.io/bdchatham/sei-shadow@sha256:5dee59eaf2d0841a6e6c0f155bbafa5519a283295dd36e4271c6012f751afcd6
 
   sidecar:
-    image: ghcr.io/sei-protocol/seictl@sha256:22639286ad0898fdeced42b850a8b07fa0f9267401c62b993df1cc0f1ddaca9a
+    image: ghcr.io/bdchatham/seictl@sha256:f20bc2a2d37d8a780653da50fec2b920ece594fc83ffc0ff3bd43aa60035c6dd
 
   entrypoint:
     command: ["seid"]
@@ -34,7 +34,7 @@ spec:
   replayer:
     snapshot:
       s3:
-        targetHeight: 200400000
+        targetHeight: 200440000
       bootstrapImage: "ghcr.io/sei-protocol/sei:v6.3.0"
       trustPeriod: "9999h0m0s"
     resultExport:

--- a/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
+++ b/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
@@ -23,7 +23,7 @@ spec:
     fork:
       sourceChainId: pacific-1
       sourceImage: "ghcr.io/sei-protocol/sei:v5.9.0"
-      exportHeight: 100000000
+      exportHeight: 200450000
 
   template:
     metadata:
@@ -38,6 +38,6 @@ spec:
         args: ["start", "--home", "/sei"]
 
       sidecar:
-        image: "ghcr.io/sei-protocol/seictl:v0.0.29"
+        image: "ghcr.io/bdchatham/seictl@sha256:f20bc2a2d37d8a780653da50fec2b920ece594fc83ffc0ff3bd43aa60035c6dd"
 
       validator: {}


### PR DESCRIPTION
## Summary

Bump controller and sidecar images to latest builds with all Alpha P3 changes. Updates sample manifests with correct snapshot heights.

- **Controller**: `a03ac73` (plan IDs, probes, SubmittedAt, failure diagnostics, simplified retry, buildPlannedTask consolidation)
- **Shadow replayer sidecar**: `bdchatham/seictl:26aaecb` (RPC consolidation, status-aware Submit, metrics)
- **Shadow replayer targetHeight**: `200440000` (matches available snapshot)
- **Fork genesis sidecar**: same image
- **Fork genesis exportHeight**: `200450000` (above available snapshot at 200440000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)