### PR TITLE
chore: bump sidecar image to 32c1c1a (dual-format RPC fix)

### DIFF
--- a/manifests/samples/seinode/pacific-1-shadow-replayer.yaml
+++ b/manifests/samples/seinode/pacific-1-shadow-replayer.yaml
@@ -14,7 +14,7 @@ spec:
   image: ghcr.io/bdchatham/sei-shadow@sha256:5dee59eaf2d0841a6e6c0f155bbafa5519a283295dd36e4271c6012f751afcd6
 
   sidecar:
-    image: ghcr.io/bdchatham/seictl@sha256:f20bc2a2d37d8a780653da50fec2b920ece594fc83ffc0ff3bd43aa60035c6dd
+    image: ghcr.io/bdchatham/seictl@sha256:4882fe7aba24c902e6cb8ed47ae41b5c7ff4273514dd005fa5aee6160b0672f7
 
   entrypoint:
     command: ["seid"]

--- a/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
+++ b/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
@@ -38,6 +38,6 @@ spec:
         args: ["start", "--home", "/sei"]
 
       sidecar:
-        image: "ghcr.io/bdchatham/seictl@sha256:f20bc2a2d37d8a780653da50fec2b920ece594fc83ffc0ff3bd43aa60035c6dd"
+        image: "ghcr.io/bdchatham/seictl@sha256:4882fe7aba24c902e6cb8ed47ae41b5c7ff4273514dd005fa5aee6160b0672f7"
 
       validator: {}


### PR DESCRIPTION
Bumps sidecar image in both shadow replayer and fork genesis manifests to `32c1c1a` which includes the dual-format RPC fix (seictl#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)