### PR TITLE
chore: bump controller image to a19beda (bin/sh fix)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:e32ee6039b465bfc568ace98cf4cb33ff8ee299f
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:a19bedab9bad19cbb7195b3226d24457f275c8b3
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME

--- a/manifests/samples/seinode/pacific-1-shadow-replayer.yaml
+++ b/manifests/samples/seinode/pacific-1-shadow-replayer.yaml
@@ -14,7 +14,7 @@ spec:
   image: ghcr.io/bdchatham/sei-shadow@sha256:5dee59eaf2d0841a6e6c0f155bbafa5519a283295dd36e4271c6012f751afcd6
 
   sidecar:
-    image: ghcr.io/bdchatham/seictl@sha256:f20bc2a2d37d8a780653da50fec2b920ece594fc83ffc0ff3bd43aa60035c6dd
+    image: ghcr.io/bdchatham/seictl@sha256:4882fe7aba24c902e6cb8ed47ae41b5c7ff4273514dd005fa5aee6160b0672f7
 
   entrypoint:
     command: ["seid"]

--- a/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
+++ b/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
@@ -38,6 +38,6 @@ spec:
         args: ["start", "--home", "/sei"]
 
       sidecar:
-        image: "ghcr.io/bdchatham/seictl@sha256:f20bc2a2d37d8a780653da50fec2b920ece594fc83ffc0ff3bd43aa60035c6dd"
+        image: "ghcr.io/bdchatham/seictl@sha256:4882fe7aba24c902e6cb8ed47ae41b5c7ff4273514dd005fa5aee6160b0672f7"
 
       validator: {}


### PR DESCRIPTION
Bumps controller image to `a19beda` which includes the `/bin/bash` → `/bin/sh` fix for bootstrap Jobs. Without this, the fork exporter fails with `stat /bin/bash: no such file or directory` on minimal seid images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)