### PR TITLE
fix: use sei-shadow image for fork exporter sourceImage

### DIFF
--- a/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
+++ b/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
@@ -22,7 +22,7 @@ spec:
 
     fork:
       sourceChainId: pacific-1
-      sourceImage: "ghcr.io/sei-protocol/sei:v5.9.0"
+      sourceImage: "ghcr.io/bdchatham/sei-shadow@sha256:5dee59eaf2d0841a6e6c0f155bbafa5519a283295dd36e4271c6012f751afcd6"
       exportHeight: 200450000
 
   template:


### PR DESCRIPTION
The fork exporter's `sourceImage` was still set to `sei:v5.9.0`. Updated to the sei-shadow image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)