### PR TITLE
fix: add peers to fork genesis ceremony template

### DIFF
--- a/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
+++ b/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
@@ -40,4 +40,11 @@ spec:
       sidecar:
         image: "ghcr.io/bdchatham/seictl@sha256:4882fe7aba24c902e6cb8ed47ae41b5c7ff4273514dd005fa5aee6160b0672f7"
 
+      peers:
+        - ec2Tags:
+            region: eu-central-1
+            tags:
+              ChainIdentifier: pacific-1
+              Component: state-syncer
+
       validator: {}


### PR DESCRIPTION
The fork exporter needs peers for state sync after snapshot restore. This commit was supposed to land in PR #53 but was lost during squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)