### PR TITLE
fix: add GenerationChangedPredicate to prevent retry backoff bypass

### DIFF
--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -13,9 +13,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/planner"
@@ -208,7 +210,7 @@ func (r *SeiNodeReconciler) transitionPhase(ctx context.Context, node *seiv1alph
 // SetupWithManager sets up the controller with the Manager.
 func (r *SeiNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&seiv1alpha1.SeiNode{}).
+		For(&seiv1alpha1.SeiNode{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Service{}).

--- a/internal/controller/nodegroup/controller.go
+++ b/internal/controller/nodegroup/controller.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/controller/observability"
@@ -180,7 +181,7 @@ func shouldRequeue(result ctrl.Result) bool {
 // SetupWithManager sets up the controller with the Manager.
 func (r *SeiNodeGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&seiv1alpha1.SeiNodeGroup{}).
+		For(&seiv1alpha1.SeiNodeGroup{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&seiv1alpha1.SeiNode{}, builder.WithPredicates(childPhaseChangedPredicate())).
 		Owns(&corev1.Service{}).
 		Named(controllerName).


### PR DESCRIPTION
## Summary

Status patches from the executor's retry logic triggered watch events that immediately requeued reconciles, bypassing `RequeueAfter` backoff. 180 retries of `configure-genesis` completed in ~6 minutes instead of the intended ~90 minutes.

### Root cause

When the executor resets a failed task to Pending and patches status, the patch mutates the watched resource. Controller-runtime processes watch-triggered reconciles immediately, overriding the `RequeueAfter` delay.

### Fix

Add `GenerationChangedPredicate` to both SeiNode and SeiNodeGroup `For()` watches. Status-only updates don't increment `.metadata.generation`, so they're filtered out. The executor's `RequeueAfter` backoff now works as designed. Spec changes (which DO increment generation) still trigger immediate reconciles.

**2 files, +5 lines, -2 lines.**

## Test plan

- [x] `make test` — all tests pass
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)