### PR TITLE
fix: use snapshotter peers for shadow replayer and fork genesis

### DIFF
--- a/manifests/samples/seinode/pacific-1-shadow-replayer.yaml
+++ b/manifests/samples/seinode/pacific-1-shadow-replayer.yaml
@@ -29,7 +29,7 @@ spec:
         region: eu-central-1
         tags:
           ChainIdentifier: pacific-1
-          Component: state-syncer
+          Component: snapshotter
 
   replayer:
     snapshot:

--- a/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
+++ b/manifests/samples/seinodegroup/fork-genesis-ceremony.yaml
@@ -45,6 +45,6 @@ spec:
             region: eu-central-1
             tags:
               ChainIdentifier: pacific-1
-              Component: state-syncer
+              Component: snapshotter
 
       validator: {}


### PR DESCRIPTION
State-syncer nodes have pruned blocks below the snapshot height, causing `configure-state-sync` to fail with "empty block hash". Snapshotter nodes retain the full block history needed for trust hash resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)