### PR TITLE
chore: bump controller image to d8d337b

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:a19bedab9bad19cbb7195b3226d24457f275c8b3
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:d8d337b16198c442d2d2201bf567cd80cc062fea
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Includes /bin/sh fix for bootstrap Jobs, GenerationChangedPredicate for retry backoff, and snapshotter peer updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)