### PR TITLE
fix: skip configure-state-sync for S3 snapshot restores

### DIFF
--- a/internal/controller/node/plan_execution_integration_test.go
+++ b/internal/controller/node/plan_execution_integration_test.go
@@ -95,7 +95,6 @@ func TestIntegrationFullProgressionSnapshotMode(t *testing.T) {
 
 	driveTask(t, g, r, mock, fetch, planner.TaskConfigureGenesis)
 	driveTask(t, g, r, mock, fetch, planner.TaskConfigApply)
-	driveTask(t, g, r, mock, fetch, planner.TaskConfigureStateSync)
 	driveTask(t, g, r, mock, fetch, planner.TaskConfigValidate)
 	driveTask(t, g, r, mock, fetch, planner.TaskMarkReady)
 

--- a/internal/controller/node/plan_execution_test.go
+++ b/internal/controller/node/plan_execution_test.go
@@ -262,7 +262,7 @@ func TestBuildPlan_Snapshot(t *testing.T) {
 	p, _ := planner.ForNode(snapshotNode())
 	plan := mustBuildPlan(t, p, snapshotNode())
 	got := taskTypes(plan)
-	want := []string{planner.TaskSnapshotRestore, planner.TaskConfigureGenesis, planner.TaskConfigApply, planner.TaskConfigureStateSync, planner.TaskConfigValidate, planner.TaskMarkReady}
+	want := []string{planner.TaskSnapshotRestore, planner.TaskConfigureGenesis, planner.TaskConfigApply, planner.TaskConfigValidate, planner.TaskMarkReady}
 	assertProgression(t, got, want)
 }
 
@@ -274,7 +274,7 @@ func TestBuildPlan_SnapshotWithPeers(t *testing.T) {
 	p, _ := planner.ForNode(node)
 	plan := mustBuildPlan(t, p, node)
 	got := taskTypes(plan)
-	want := []string{planner.TaskSnapshotRestore, planner.TaskConfigureGenesis, planner.TaskConfigApply, planner.TaskDiscoverPeers, planner.TaskConfigureStateSync, planner.TaskConfigValidate, planner.TaskMarkReady}
+	want := []string{planner.TaskSnapshotRestore, planner.TaskConfigureGenesis, planner.TaskConfigApply, planner.TaskDiscoverPeers, planner.TaskConfigValidate, planner.TaskMarkReady}
 	assertProgression(t, got, want)
 }
 
@@ -311,7 +311,7 @@ func TestBuildPlan_Replayer(t *testing.T) {
 	p, _ := planner.ForNode(node)
 	plan := mustBuildPlan(t, p, node)
 	got := taskTypes(plan)
-	want := []string{planner.TaskSnapshotRestore, planner.TaskConfigureGenesis, planner.TaskConfigApply, planner.TaskDiscoverPeers, planner.TaskConfigureStateSync, planner.TaskConfigValidate, planner.TaskMarkReady}
+	want := []string{planner.TaskSnapshotRestore, planner.TaskConfigureGenesis, planner.TaskConfigApply, planner.TaskDiscoverPeers, planner.TaskConfigValidate, planner.TaskMarkReady}
 	assertProgression(t, got, want)
 }
 
@@ -330,8 +330,8 @@ func TestBuildPlanPhaseAndTasks(t *testing.T) {
 	if plan.Phase != seiv1alpha1.TaskPlanActive {
 		t.Errorf("phase = %q, want Active", plan.Phase)
 	}
-	if len(plan.Tasks) != 6 {
-		t.Fatalf("expected 6 tasks, got %d: %v", len(plan.Tasks), taskTypes(plan))
+	if len(plan.Tasks) != 5 {
+		t.Fatalf("expected 5 tasks, got %d: %v", len(plan.Tasks), taskTypes(plan))
 	}
 	for _, pt := range plan.Tasks {
 		if pt.Status != seiv1alpha1.TaskPending {

--- a/internal/planner/bootstrap.go
+++ b/internal/planner/bootstrap.go
@@ -89,7 +89,7 @@ func buildBootstrapProgression(peers []seiv1alpha1.PeerSource, snap *seiv1alpha1
 	if len(peers) > 0 {
 		prog = insertBefore(prog, TaskConfigValidate, TaskDiscoverPeers)
 	}
-	if snap != nil {
+	if hasStateSync(snap) {
 		prog = insertBefore(prog, TaskConfigValidate, TaskConfigureStateSync)
 	}
 

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -247,7 +247,7 @@ func buildBasePlan(
 	if len(peers) > 0 {
 		prog = insertBefore(prog, TaskConfigValidate, TaskDiscoverPeers)
 	}
-	if snap != nil {
+	if hasStateSync(snap) {
 		prog = insertBefore(prog, TaskConfigValidate, TaskConfigureStateSync)
 	}
 


### PR DESCRIPTION
## Summary

`configure-state-sync` was incorrectly inserted into init plans for S3 snapshot restores, causing nodes to ignore restored data and loop forever: "no snapshots discovered, sleeping."

### Root Cause

S3 `snapshot-restore` writes a complete data directory (app.db, blockstore, state). CometBFT should start with `statesync.enable=false` and block-sync forward. But `configure-state-sync` runs after `config-apply` and overwrites with `enable=true`, causing seid to enter its state sync reactor and try to discover snapshot chunks from peers — which have already rotated.

### Fix

Change both `buildBasePlan` and `buildBootstrapProgression` to only insert `configure-state-sync` when `hasStateSync(snap)` is true (StateSync source), not when any snapshot source exists.

### Tests

- Removed `TaskConfigureStateSync` from S3 snapshot plan progression assertions
- Updated expected task count (6 → 5) for snapshot mode
- Removed state-sync step from snapshot integration test
- StateSync and Archive tests unchanged (they correctly use StateSync source)

## Test plan

- [x] `make test` — all tests pass
- [x] StateSync plans still include `configure-state-sync`
- [x] S3 snapshot plans no longer include `configure-state-sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)