### PR TITLE
feat: P2P external address propagation from LoadBalancer

### DIFF
--- a/api/v1alpha1/seinode_types.go
+++ b/api/v1alpha1/seinode_types.go
@@ -242,6 +242,13 @@ type SeiNodeStatus struct {
 	// +optional
 	ResolvedPeers []string `json:"resolvedPeers,omitempty"`
 
+	// ExternalAddress is the routable P2P address (host:port) for this node,
+	// populated by the SeiNodeDeployment controller from the LoadBalancer
+	// ingress. Used by the planner to set p2p.external_address in CometBFT
+	// config so the node advertises a reachable address for gossip discovery.
+	// +optional
+	ExternalAddress string `json:"externalAddress,omitempty"`
+
 	// ConfigStatus reports the observed configuration state from the sidecar.
 	// +optional
 	ConfigStatus *ConfigStatus `json:"configStatus,omitempty"`

--- a/config/crd/sei.io_seinodes.yaml
+++ b/config/crd/sei.io_seinodes.yaml
@@ -607,6 +607,13 @@ spec:
                     description: Version is the on-disk config schema version.
                     type: integer
                 type: object
+              externalAddress:
+                description: |-
+                  ExternalAddress is the routable P2P address (host:port) for this node,
+                  populated by the SeiNodeDeployment controller from the LoadBalancer
+                  ingress. Used by the planner to set p2p.external_address in CometBFT
+                  config so the node advertises a reachable address for gossip discovery.
+                type: string
               monitorTasks:
                 additionalProperties:
                   description: |-

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -95,10 +95,9 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("reconciling networking: %w", err)
 	}
 
-	// Gate: if a LoadBalancer Service is configured, wait for the external
-	// address before creating nodes. This ensures the P2P address is baked
-	// into the SeiNode's overrides at plan build time (plans are immutable).
-	if r.needsExternalAddress(group) && r.resolveExternalP2PAddress(ctx, group) == "" {
+	// Gate: wait for the LoadBalancer to provision an external address
+	// before creating nodes so the P2P address is baked into the plan.
+	if r.hasExternalService(group) && r.resolveExternalP2PAddress(ctx, group) == "" {
 		logger.Info("waiting for LoadBalancer to provision external address")
 		setCondition(group, seiv1alpha1.ConditionExternalServiceReady, metav1.ConditionFalse,
 			"LoadBalancerPending", "Waiting for LoadBalancer to provision external P2P address")

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,6 +85,29 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	statusBase := client.MergeFromWithOptions(group.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	ns, name := group.Namespace, group.Name
 
+	// Networking runs before node creation so that the external P2P
+	// address (from the LoadBalancer ingress) is known at plan build time.
+	if err := timeSubstep("reconcileNetworking", func() error {
+		return r.reconcileNetworking(ctx, group)
+	}); err != nil {
+		logger.Error(err, "reconciling networking")
+		observability.ReconcileErrorsTotal.WithLabelValues(controllerName, ns, name).Inc()
+		return ctrl.Result{}, fmt.Errorf("reconciling networking: %w", err)
+	}
+
+	// Gate: if a LoadBalancer Service is configured, wait for the external
+	// address before creating nodes. This ensures the P2P address is baked
+	// into the SeiNode's overrides at plan build time (plans are immutable).
+	if r.needsExternalAddress(group) && r.resolveExternalP2PAddress(ctx, group) == "" {
+		logger.Info("waiting for LoadBalancer to provision external address")
+		setCondition(group, seiv1alpha1.ConditionExternalServiceReady, metav1.ConditionFalse,
+			"LoadBalancerPending", "Waiting for LoadBalancer to provision external P2P address")
+		if err := r.updateStatus(ctx, group, statusBase); err != nil {
+			return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
+		}
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
 	if err := timeSubstep("reconcileSeiNodes", func() error {
 		return r.reconcileSeiNodes(ctx, group)
 	}); err != nil {
@@ -103,14 +127,6 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
 		}
 		return planResult, nil
-	}
-
-	if err := timeSubstep("reconcileNetworking", func() error {
-		return r.reconcileNetworking(ctx, group)
-	}); err != nil {
-		logger.Error(err, "reconciling networking")
-		observability.ReconcileErrorsTotal.WithLabelValues(controllerName, ns, name).Inc()
-		return ctrl.Result{}, fmt.Errorf("reconciling networking: %w", err)
 	}
 
 	if err := timeSubstep("reconcileMonitoring", func() error {

--- a/internal/controller/nodedeployment/external_address_test.go
+++ b/internal/controller/nodedeployment/external_address_test.go
@@ -1,0 +1,81 @@
+package nodedeployment
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+)
+
+func TestHasExternalService(t *testing.T) {
+	r := &SeiNodeDeploymentReconciler{}
+
+	t.Run("nil networking", func(t *testing.T) {
+		g := NewWithT(t)
+		group := newTestGroup("test", "ns")
+		g.Expect(r.hasExternalService(group)).To(BeFalse())
+	})
+
+	t.Run("nil service", func(t *testing.T) {
+		g := NewWithT(t)
+		group := newTestGroup("test", "ns")
+		group.Spec.Networking = &seiv1alpha1.NetworkingConfig{}
+		g.Expect(r.hasExternalService(group)).To(BeFalse())
+	})
+
+	t.Run("service configured", func(t *testing.T) {
+		g := NewWithT(t)
+		group := newTestGroup("test", "ns")
+		group.Spec.Networking = &seiv1alpha1.NetworkingConfig{
+			Service: &seiv1alpha1.ExternalServiceConfig{Type: corev1.ServiceTypeLoadBalancer},
+		}
+		g.Expect(r.hasExternalService(group)).To(BeTrue())
+	})
+}
+
+func TestResolveExternalP2PAddress_FromService(t *testing.T) {
+	t.Run("prefers hostname over IP", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &corev1.Service{
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{Hostname: "p2p.atlantic-2.seinetwork.io", IP: "1.2.3.4"},
+					},
+				},
+			},
+		}
+		addr := externalAddressFromService(svc)
+		g.Expect(addr).To(Equal("p2p.atlantic-2.seinetwork.io:26656"))
+	})
+
+	t.Run("falls back to IP", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &corev1.Service{
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "10.0.0.1"},
+					},
+				},
+			},
+		}
+		addr := externalAddressFromService(svc)
+		g.Expect(addr).To(Equal("10.0.0.1:26656"))
+	})
+
+	t.Run("empty when no ingress", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &corev1.Service{}
+		addr := externalAddressFromService(svc)
+		g.Expect(addr).To(BeEmpty())
+	})
+
+	t.Run("empty when nil", func(t *testing.T) {
+		g := NewWithT(t)
+		addr := externalAddressFromService(nil)
+		g.Expect(addr).To(BeEmpty())
+	})
+}

--- a/internal/controller/nodedeployment/networking.go
+++ b/internal/controller/nodedeployment/networking.go
@@ -43,6 +43,14 @@ const (
 	keyP2PExternalAddress  = "p2p.external_address"
 )
 
+// needsExternalAddress returns true when node creation should wait for
+// a LoadBalancer external address before proceeding.
+func (r *SeiNodeDeploymentReconciler) needsExternalAddress(group *seiv1alpha1.SeiNodeDeployment) bool {
+	return group.Spec.Networking != nil &&
+		group.Spec.Networking.Service != nil &&
+		group.Spec.Networking.Service.Type == corev1.ServiceTypeLoadBalancer
+}
+
 func (r *SeiNodeDeploymentReconciler) reconcileNetworking(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
 	if group.Spec.Networking == nil {
 		removeCondition(group, seiv1alpha1.ConditionExternalServiceReady)
@@ -67,8 +75,8 @@ func (r *SeiNodeDeploymentReconciler) reconcileNetworking(ctx context.Context, g
 }
 
 // reconcileExternalAddress propagates the external P2P address from the
-// LoadBalancer Service to child SeiNode overrides so that CometBFT
-// advertises a routable address for gossip-based peer discovery.
+// LoadBalancer Service to child SeiNode status so that the planner can
+// inject p2p.external_address into CometBFT config at plan build time.
 func (r *SeiNodeDeploymentReconciler) reconcileExternalAddress(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
 	addr := r.resolveExternalP2PAddress(ctx, group)
 	if addr == "" {
@@ -82,19 +90,15 @@ func (r *SeiNodeDeploymentReconciler) reconcileExternalAddress(ctx context.Conte
 
 	for i := range nodes {
 		node := &nodes[i]
-		current := node.Spec.Overrides[keyP2PExternalAddress]
-		if current == addr {
+		if node.Status.ExternalAddress == addr {
 			continue
 		}
 		patch := client.MergeFrom(node.DeepCopy())
-		if node.Spec.Overrides == nil {
-			node.Spec.Overrides = make(map[string]string)
+		node.Status.ExternalAddress = addr
+		if err := r.Status().Patch(ctx, node, patch); err != nil {
+			return fmt.Errorf("patching external address status on SeiNode %s: %w", node.Name, err)
 		}
-		node.Spec.Overrides[keyP2PExternalAddress] = addr
-		if err := r.Patch(ctx, node, patch); err != nil {
-			return fmt.Errorf("patching external address on SeiNode %s: %w", node.Name, err)
-		}
-		log.FromContext(ctx).Info("set P2P external address", "node", node.Name, "address", addr)
+		log.FromContext(ctx).Info("set P2P external address on status", "node", node.Name, "address", addr)
 	}
 	return nil
 }

--- a/internal/controller/nodedeployment/networking.go
+++ b/internal/controller/nodedeployment/networking.go
@@ -39,8 +39,8 @@ type effectiveRoute struct {
 }
 
 const (
-	p2pPort                = 26656
-	keyP2PExternalAddress  = "p2p.external_address"
+	p2pPort               = 26656
+	keyP2PExternalAddress = "p2p.external_address"
 )
 
 // needsExternalAddress returns true when node creation should wait for

--- a/internal/controller/nodedeployment/networking.go
+++ b/internal/controller/nodedeployment/networking.go
@@ -43,12 +43,9 @@ const (
 	keyP2PExternalAddress = "p2p.external_address"
 )
 
-// needsExternalAddress returns true when node creation should wait for
-// a LoadBalancer external address before proceeding.
-func (r *SeiNodeDeploymentReconciler) needsExternalAddress(group *seiv1alpha1.SeiNodeDeployment) bool {
-	return group.Spec.Networking != nil &&
-		group.Spec.Networking.Service != nil &&
-		group.Spec.Networking.Service.Type == corev1.ServiceTypeLoadBalancer
+// hasExternalService returns true when the deployment has an external Service configured.
+func (r *SeiNodeDeploymentReconciler) hasExternalService(group *seiv1alpha1.SeiNodeDeployment) bool {
+	return group.Spec.Networking != nil && group.Spec.Networking.Service != nil
 }
 
 func (r *SeiNodeDeploymentReconciler) reconcileNetworking(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {

--- a/internal/controller/nodedeployment/networking.go
+++ b/internal/controller/nodedeployment/networking.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
@@ -37,6 +38,11 @@ type effectiveRoute struct {
 	Port      int32
 }
 
+const (
+	p2pPort                = 26656
+	keyP2PExternalAddress  = "p2p.external_address"
+)
+
 func (r *SeiNodeDeploymentReconciler) reconcileNetworking(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
 	if group.Spec.Networking == nil {
 		removeCondition(group, seiv1alpha1.ConditionExternalServiceReady)
@@ -48,6 +54,9 @@ func (r *SeiNodeDeploymentReconciler) reconcileNetworking(ctx context.Context, g
 	if err := r.reconcileExternalService(ctx, group); err != nil {
 		return fmt.Errorf("reconciling external service: %w", err)
 	}
+	if err := r.reconcileExternalAddress(ctx, group); err != nil {
+		return fmt.Errorf("reconciling external P2P address: %w", err)
+	}
 	if err := r.reconcileRoute(ctx, group); err != nil {
 		return fmt.Errorf("reconciling route: %w", err)
 	}
@@ -55,6 +64,58 @@ func (r *SeiNodeDeploymentReconciler) reconcileNetworking(ctx context.Context, g
 		return fmt.Errorf("reconciling isolation: %w", err)
 	}
 	return nil
+}
+
+// reconcileExternalAddress propagates the external P2P address from the
+// LoadBalancer Service to child SeiNode overrides so that CometBFT
+// advertises a routable address for gossip-based peer discovery.
+func (r *SeiNodeDeploymentReconciler) reconcileExternalAddress(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
+	addr := r.resolveExternalP2PAddress(ctx, group)
+	if addr == "" {
+		return nil
+	}
+
+	nodes, err := r.listChildSeiNodes(ctx, group)
+	if err != nil {
+		return fmt.Errorf("listing child SeiNodes: %w", err)
+	}
+
+	for i := range nodes {
+		node := &nodes[i]
+		current := node.Spec.Overrides[keyP2PExternalAddress]
+		if current == addr {
+			continue
+		}
+		patch := client.MergeFrom(node.DeepCopy())
+		if node.Spec.Overrides == nil {
+			node.Spec.Overrides = make(map[string]string)
+		}
+		node.Spec.Overrides[keyP2PExternalAddress] = addr
+		if err := r.Patch(ctx, node, patch); err != nil {
+			return fmt.Errorf("patching external address on SeiNode %s: %w", node.Name, err)
+		}
+		log.FromContext(ctx).Info("set P2P external address", "node", node.Name, "address", addr)
+	}
+	return nil
+}
+
+// resolveExternalP2PAddress returns the routable P2P address for this
+// deployment's nodes, or "" if not yet available.
+func (r *SeiNodeDeploymentReconciler) resolveExternalP2PAddress(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) string {
+	svc, err := r.fetchExternalService(ctx, group)
+	if err != nil || svc == nil {
+		return ""
+	}
+	for _, ingress := range svc.Status.LoadBalancer.Ingress {
+		host := ingress.Hostname
+		if host == "" {
+			host = ingress.IP
+		}
+		if host != "" {
+			return fmt.Sprintf("%s:%d", host, p2pPort)
+		}
+	}
+	return ""
 }
 
 func (r *SeiNodeDeploymentReconciler) reconcileExternalService(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {

--- a/internal/controller/nodedeployment/networking.go
+++ b/internal/controller/nodedeployment/networking.go
@@ -104,7 +104,16 @@ func (r *SeiNodeDeploymentReconciler) reconcileExternalAddress(ctx context.Conte
 // deployment's nodes, or "" if not yet available.
 func (r *SeiNodeDeploymentReconciler) resolveExternalP2PAddress(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) string {
 	svc, err := r.fetchExternalService(ctx, group)
-	if err != nil || svc == nil {
+	if err != nil {
+		return ""
+	}
+	return externalAddressFromService(svc)
+}
+
+// externalAddressFromService extracts the P2P address from a Service's
+// LoadBalancer ingress. Prefers hostname (DNS) over IP.
+func externalAddressFromService(svc *corev1.Service) string {
+	if svc == nil {
 		return ""
 	}
 	for _, ingress := range svc.Status.LoadBalancer.Ingress {

--- a/internal/planner/archive.go
+++ b/internal/planner/archive.go
@@ -25,7 +25,7 @@ func (p *archiveNodePlanner) Validate(node *seiv1alpha1.SeiNode) error {
 func (p *archiveNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	return buildBasePlan(node, node.Spec.Peers, p.snapshotSource(), &task.ConfigApplyParams{
 		Mode:      string(seiconfig.ModeArchive),
-		Overrides: mergeOverrides(p.controllerOverrides(node), node.Spec.Overrides),
+		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
 	})
 }
 

--- a/internal/planner/bootstrap.go
+++ b/internal/planner/bootstrap.go
@@ -183,7 +183,7 @@ func genesisParamsForTaskType(node *seiv1alpha1.SeiNode, gc *seiv1alpha1.Genesis
 	case TaskConfigApply:
 		return &task.ConfigApplyParams{
 			Mode:      string(seiconfig.ModeValidator),
-			Overrides: mergeOverrides(nil, node.Spec.Overrides),
+			Overrides: mergeOverrides(commonOverrides(node), node.Spec.Overrides),
 		}
 	case TaskSetGenesisPeers:
 		return &task.SetGenesisPeersParams{}

--- a/internal/planner/common_overrides_test.go
+++ b/internal/planner/common_overrides_test.go
@@ -1,0 +1,59 @@
+package planner
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+)
+
+func TestCommonOverrides_WithExternalAddress(t *testing.T) {
+	node := &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Status: seiv1alpha1.SeiNodeStatus{
+			ExternalAddress: "p2p.atlantic-2.seinetwork.io:26656",
+		},
+	}
+	overrides := commonOverrides(node)
+	if overrides == nil {
+		t.Fatal("expected overrides, got nil")
+	}
+	if got := overrides[keyP2PExternalAddress]; got != "p2p.atlantic-2.seinetwork.io:26656" {
+		t.Errorf("p2p.external_address = %q, want %q", got, "p2p.atlantic-2.seinetwork.io:26656")
+	}
+}
+
+func TestCommonOverrides_EmptyExternalAddress(t *testing.T) {
+	node := &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+	}
+	overrides := commonOverrides(node)
+	if overrides != nil {
+		t.Errorf("expected nil overrides, got %v", overrides)
+	}
+}
+
+func TestCommonOverrides_UserOverrideTakesPrecedence(t *testing.T) {
+	node := &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Spec: seiv1alpha1.SeiNodeSpec{
+			ChainID:  "test-1",
+			Image:    "seid:v1",
+			FullNode: &seiv1alpha1.FullNodeSpec{},
+			Overrides: map[string]string{
+				keyP2PExternalAddress: "custom.address:26656",
+			},
+		},
+		Status: seiv1alpha1.SeiNodeStatus{
+			ExternalAddress: "lb.address:26656",
+		},
+	}
+
+	common := commonOverrides(node)
+	merged := mergeOverrides(common, node.Spec.Overrides)
+
+	if got := merged[keyP2PExternalAddress]; got != "custom.address:26656" {
+		t.Errorf("user override should win: got %q, want %q", got, "custom.address:26656")
+	}
+}

--- a/internal/planner/constants.go
+++ b/internal/planner/constants.go
@@ -17,7 +17,7 @@ const (
 
 	keyP2PExternalAddress = "p2p.external_address"
 
-	valCustom = "custom"
+	valCustom  = "custom"
 	valNothing = "nothing"
 
 	defaultConcurrencyWorkers = "500"

--- a/internal/planner/constants.go
+++ b/internal/planner/constants.go
@@ -15,7 +15,9 @@ const (
 	keySCSnapshotKeepRecent      = "storage.state_commit.memiavl.snapshot_keep_recent"
 	keySCSnapshotMinTimeInterval = "storage.state_commit.memiavl.snapshot_min_time_interval"
 
-	valCustom  = "custom"
+	keyP2PExternalAddress = "p2p.external_address"
+
+	valCustom = "custom"
 	valNothing = "nothing"
 
 	defaultConcurrencyWorkers = "500"

--- a/internal/planner/full.go
+++ b/internal/planner/full.go
@@ -31,7 +31,7 @@ func (p *fullNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 	fn := node.Spec.FullNode
 	params := &task.ConfigApplyParams{
 		Mode:      string(seiconfig.ModeFull),
-		Overrides: mergeOverrides(p.controllerOverrides(node), node.Spec.Overrides),
+		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
 	}
 	if NeedsBootstrap(node) {
 		return buildBootstrapPlan(node, node.Spec.Peers, fn.Snapshot, params)

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -351,6 +351,17 @@ func configureStateSyncParams(snap *seiv1alpha1.SnapshotSource) *task.ConfigureS
 	return p
 }
 
+// commonOverrides returns controller overrides derived from node status
+// that apply to all node modes (e.g., external P2P address from the LB).
+func commonOverrides(node *seiv1alpha1.SeiNode) map[string]string {
+	if node.Status.ExternalAddress == "" {
+		return nil
+	}
+	return map[string]string{
+		keyP2PExternalAddress: node.Status.ExternalAddress,
+	}
+}
+
 // mergeOverrides combines controller-generated overrides with user-specified
 // overrides. User overrides take precedence.
 func mergeOverrides(controllerOverrides, userOverrides map[string]string) map[string]string {

--- a/internal/planner/replay.go
+++ b/internal/planner/replay.go
@@ -34,7 +34,7 @@ func (p *replayerPlanner) Validate(node *seiv1alpha1.SeiNode) error {
 func (p *replayerPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	params := &task.ConfigApplyParams{
 		Mode:      string(seiconfig.ModeFull),
-		Overrides: mergeOverrides(p.controllerOverrides(), node.Spec.Overrides),
+		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides()), node.Spec.Overrides),
 	}
 	if NeedsBootstrap(node) {
 		return buildBootstrapPlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, params)

--- a/internal/planner/validator.go
+++ b/internal/planner/validator.go
@@ -42,7 +42,7 @@ func (p *validatorPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Ta
 	v := node.Spec.Validator
 	params := &task.ConfigApplyParams{
 		Mode:      string(seiconfig.ModeValidator),
-		Overrides: mergeOverrides(nil, node.Spec.Overrides),
+		Overrides: mergeOverrides(commonOverrides(node), node.Spec.Overrides),
 	}
 	if NeedsBootstrap(node) {
 		return buildBootstrapPlan(node, node.Spec.Peers, v.Snapshot, params)

--- a/manifests/sei.io_seinodes.yaml
+++ b/manifests/sei.io_seinodes.yaml
@@ -607,6 +607,13 @@ spec:
                     description: Version is the on-disk config schema version.
                     type: integer
                 type: object
+              externalAddress:
+                description: |-
+                  ExternalAddress is the routable P2P address (host:port) for this node,
+                  populated by the SeiNodeDeployment controller from the LoadBalancer
+                  ingress. Used by the planner to set p2p.external_address in CometBFT
+                  config so the node advertises a reachable address for gossip discovery.
+                type: string
               monitorTasks:
                 additionalProperties:
                   description: |-


### PR DESCRIPTION
## Summary
- Gates SeiNode creation on LoadBalancer readiness so the external P2P address is known at plan build time
- Adds `SeiNodeStatus.ExternalAddress` field populated by the SeiNodeDeployment controller from LB ingress
- Planner injects `p2p.external_address` as a controller override via `commonOverrides()`

## Problem
Nodes in K8s advertise their pod's `svc.cluster.local` DNS name for CometBFT P2P gossip, which is unreachable outside the cluster. This was observed on atlantic-2 state-syncer advertising `atlantic-2-state-syncer-0-0.atlantic-2-state-syncer-0.atlantic-2.svc.cluster.local:26656`.

## Design
- Reconcile loop reordered: networking runs before node creation
- When a LoadBalancer Service is configured, controller waits for ingress before creating SeiNodes (requeues every 10s)
- Deployment controller populates `SeiNode.Status.ExternalAddress` from LB hostname (preferred) or IP
- Planner reads status field and injects `p2p.external_address` as lowest-priority override (below mode-specific and user overrides)
- `reconcileExternalAddress` patches status on existing nodes — kept for future config mutability support

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — all tests pass
- [x] `make manifests` — CRDs regenerate cleanly with new `externalAddress` status field
- [x] Deploy to dev cluster and verify P2P address in `net_info`

🤖 Generated with [Claude Code](https://claude.com/claude-code)