### PR TITLE
feat: add HTTPS support via Gateway sectionName

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -134,6 +134,7 @@ func main() {
 		GenesisRegion:       os.Getenv("SEI_GENESIS_REGION"),
 		GatewayName:         os.Getenv("SEI_GATEWAY_NAME"),
 		GatewayNamespace:    os.Getenv("SEI_GATEWAY_NAMESPACE"),
+		GatewaySectionName:  os.Getenv("SEI_GATEWAY_SECTION_NAME"),
 	}
 
 	if err := platformCfg.Validate(); err != nil {
@@ -179,12 +180,13 @@ func main() {
 	//nolint:staticcheck // migrating to events.EventRecorder API is a separate effort
 	recorder := mgr.GetEventRecorderFor("seinodedeployment-controller")
 	if err := (&nodedeploymentcontroller.SeiNodeDeploymentReconciler{
-		Client:           kc,
-		Scheme:           mgr.GetScheme(),
-		Recorder:         recorder,
-		ControllerSA:     controllerSA,
-		GatewayName:      platformCfg.GatewayName,
-		GatewayNamespace: platformCfg.GatewayNamespace,
+		Client:             kc,
+		Scheme:             mgr.GetScheme(),
+		Recorder:           recorder,
+		ControllerSA:       controllerSA,
+		GatewayName:        platformCfg.GatewayName,
+		GatewayNamespace:   platformCfg.GatewayNamespace,
+		GatewaySectionName: platformCfg.GatewaySectionName,
 		PlanExecutor: &planner.Executor[*seiv1alpha1.SeiNodeDeployment]{
 			Client: kc,
 			ConfigFor: func(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) task.ExecutionConfig {

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -45,6 +45,11 @@ type SeiNodeDeploymentReconciler struct {
 	GatewayName      string
 	GatewayNamespace string
 
+	// GatewaySectionName optionally targets a specific Gateway listener
+	// (e.g. "https"). When non-empty, HTTPRoute parentRefs include a
+	// sectionName field. Read from SEI_GATEWAY_SECTION_NAME.
+	GatewaySectionName string
+
 	// PlanExecutor drives group-level task plans (e.g. genesis assembly).
 	PlanExecutor planner.PlanExecutor[*seiv1alpha1.SeiNodeDeployment]
 }

--- a/internal/controller/nodedeployment/networking.go
+++ b/internal/controller/nodedeployment/networking.go
@@ -258,7 +258,7 @@ func (r *SeiNodeDeploymentReconciler) reconcileHTTPRoute(ctx context.Context, gr
 	}
 
 	for _, er := range routes {
-		desired := generateHTTPRoute(group, er, r.GatewayName, r.GatewayNamespace)
+		desired := generateHTTPRoute(group, er, r.GatewayName, r.GatewayNamespace, r.GatewaySectionName)
 		if err := ctrl.SetControllerReference(group, desired, r.Scheme); err != nil {
 			return fmt.Errorf("setting owner reference on HTTPRoute %s: %w", er.Name, err)
 		}
@@ -311,7 +311,7 @@ func (r *SeiNodeDeploymentReconciler) deleteOrphanedHTTPRoutes(ctx context.Conte
 	return nil
 }
 
-func generateHTTPRoute(group *seiv1alpha1.SeiNodeDeployment, er effectiveRoute, gatewayName, gatewayNamespace string) *unstructured.Unstructured {
+func generateHTTPRoute(group *seiv1alpha1.SeiNodeDeployment, er effectiveRoute, gatewayName, gatewayNamespace, gatewaySectionName string) *unstructured.Unstructured {
 	svcName := externalServiceName(group)
 
 	hostnames := make([]any, len(er.Hostnames))
@@ -322,6 +322,9 @@ func generateHTTPRoute(group *seiv1alpha1.SeiNodeDeployment, er effectiveRoute, 
 	parentRef := map[string]any{
 		"name":      gatewayName,
 		"namespace": gatewayNamespace,
+	}
+	if gatewaySectionName != "" {
+		parentRef["sectionName"] = gatewaySectionName
 	}
 
 	route := &unstructured.Unstructured{

--- a/internal/controller/nodedeployment/networking_test.go
+++ b/internal/controller/nodedeployment/networking_test.go
@@ -112,7 +112,7 @@ func TestGenerateHTTPRoute_BasicFields(t *testing.T) {
 
 	routes := resolveEffectiveRoutes(group)
 	g.Expect(routes).To(HaveLen(1))
-	route := generateHTTPRoute(group, routes[0], "sei-gateway", "istio-system")
+	route := generateHTTPRoute(group, routes[0], "sei-gateway", "istio-system", "")
 
 	g.Expect(route.GetName()).To(Equal("archive-rpc"))
 	g.Expect(route.GetNamespace()).To(Equal("sei"))
@@ -140,7 +140,7 @@ func TestGenerateHTTPRoute_ManagedByAnnotation(t *testing.T) {
 	}
 
 	routes := resolveEffectiveRoutes(group)
-	route := generateHTTPRoute(group, routes[0], "sei-gateway", "istio-system")
+	route := generateHTTPRoute(group, routes[0], "sei-gateway", "istio-system", "")
 	g.Expect(route.GetAnnotations()).To(HaveKeyWithValue("sei.io/managed-by", "seinodedeployment"))
 }
 
@@ -155,7 +155,7 @@ func TestGenerateHTTPRoute_BackendRef(t *testing.T) {
 	}
 
 	routes := resolveEffectiveRoutes(group)
-	route := generateHTTPRoute(group, routes[0], "sei-gateway", "istio-system")
+	route := generateHTTPRoute(group, routes[0], "sei-gateway", "istio-system", "")
 
 	spec := route.Object["spec"].(map[string]any)
 	rules := spec["rules"].([]any)
@@ -216,7 +216,7 @@ func TestGenerateHTTPRoute_BaseDomain_CorrectHostnamesAndPorts(t *testing.T) {
 	routes := resolveEffectiveRoutes(group)
 	g.Expect(routes).To(HaveLen(5))
 
-	grpcRoute := generateHTTPRoute(group, routes[2], "sei-gateway", "istio-system")
+	grpcRoute := generateHTTPRoute(group, routes[2], "sei-gateway", "istio-system", "")
 	g.Expect(grpcRoute.GetName()).To(Equal("pacific-1-rpc-grpc"))
 
 	spec := grpcRoute.Object["spec"].(map[string]any)
@@ -244,6 +244,45 @@ func TestResolveEffectiveRoutes_LegacyHostnames_SingleRoute(t *testing.T) {
 	g.Expect(routes[0].Name).To(Equal("archive-rpc"))
 	g.Expect(routes[0].Hostnames).To(Equal([]string{"rpc.sei.io"}))
 	g.Expect(routes[0].Port).To(Equal(int32(26657)))
+}
+
+func TestGenerateHTTPRoute_SectionName_IncludedWhenSet(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("archive-rpc", "sei")
+	group.Spec.Networking = &seiv1alpha1.NetworkingConfig{
+		Service: &seiv1alpha1.ExternalServiceConfig{},
+		Gateway: &seiv1alpha1.GatewayRouteConfig{
+			Hostnames: []string{"rpc.pacific-1.sei.io"},
+		},
+	}
+
+	routes := resolveEffectiveRoutes(group)
+	route := generateHTTPRoute(group, routes[0], "sei-gateway", "istio-system", "https")
+
+	spec := route.Object["spec"].(map[string]any)
+	parentRefs := spec["parentRefs"].([]any)
+	ref := parentRefs[0].(map[string]any)
+	g.Expect(ref["sectionName"]).To(Equal("https"))
+}
+
+func TestGenerateHTTPRoute_SectionName_OmittedWhenEmpty(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("archive-rpc", "sei")
+	group.Spec.Networking = &seiv1alpha1.NetworkingConfig{
+		Service: &seiv1alpha1.ExternalServiceConfig{},
+		Gateway: &seiv1alpha1.GatewayRouteConfig{
+			Hostnames: []string{"rpc.pacific-1.sei.io"},
+		},
+	}
+
+	routes := resolveEffectiveRoutes(group)
+	route := generateHTTPRoute(group, routes[0], "sei-gateway", "istio-system", "")
+
+	spec := route.Object["spec"].(map[string]any)
+	parentRefs := spec["parentRefs"].([]any)
+	ref := parentRefs[0].(map[string]any)
+	_, hasSectionName := ref["sectionName"]
+	g.Expect(hasSectionName).To(BeFalse(), "sectionName should not be present when GatewaySectionName is empty")
 }
 
 func TestResolveEffectiveRoutes_BaseDomainTakesPrecedence(t *testing.T) {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -37,8 +37,9 @@ type Config struct {
 	GenesisBucket string
 	GenesisRegion string
 
-	GatewayName      string
-	GatewayNamespace string
+	GatewayName        string
+	GatewayNamespace   string
+	GatewaySectionName string
 }
 
 // Validate returns an error if required fields are missing.

--- a/internal/platform/platformtest/config.go
+++ b/internal/platform/platformtest/config.go
@@ -28,5 +28,6 @@ func Config() platform.Config {
 		GenesisRegion:       "us-east-2",
 		GatewayName:         "sei-gateway",
 		GatewayNamespace:    "istio-system",
+		GatewaySectionName:  "",
 	}
 }


### PR DESCRIPTION
## Summary

Add `SEI_GATEWAY_SECTION_NAME` platform env var so HTTPRoute parentRefs can target a specific Gateway listener (e.g., the HTTPS listener).

## How It Works

In the Gateway API model, TLS termination is configured on the **Gateway** resource's listeners, not on HTTPRoutes. An HTTPRoute attaches to a listener via `parentRef.sectionName`. When `SEI_GATEWAY_SECTION_NAME` is set (e.g., `"https"`), all generated HTTPRoutes include this in their parentRef, directing traffic through the HTTPS listener.

```
Gateway (platform-managed)
  listener "http"  → port 80
  listener "https" → port 443, TLS cert

HTTPRoute (controller-managed)
  parentRef: {name: sei-gateway, namespace: istio-system, sectionName: "https"}
  → attaches only to the HTTPS listener
```

## Changes

- `internal/platform/platform.go` — add `GatewaySectionName` field (optional, not in `Validate()`)
- `cmd/main.go` — read `SEI_GATEWAY_SECTION_NAME` env var
- `internal/controller/nodedeployment/controller.go` — add field to reconciler struct
- `internal/controller/nodedeployment/networking.go` — pass sectionName through to `generateHTTPRoute`, conditionally include in parentRef
- Tests: sectionName included when set, omitted when empty

No CRD changes. TLS is the Gateway's responsibility.

## Test plan
- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [ ] Verify HTTPRoute includes sectionName when `SEI_GATEWAY_SECTION_NAME=https`
- [ ] Verify HTTPRoute omits sectionName when env var is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)