### PR TITLE
fix: converge StatefulSet and Service in Running phase

### DIFF
--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -166,8 +166,15 @@ func (r *SeiNodeReconciler) reconcileInitializing(ctx context.Context, node *sei
 	return result, nil
 }
 
-// reconcileRunning handles runtime tasks (scheduled uploads, exports).
+// reconcileRunning converges owned resources and handles runtime tasks.
 func (r *SeiNodeReconciler) reconcileRunning(ctx context.Context, node *seiv1alpha1.SeiNode) (ctrl.Result, error) {
+	if err := r.reconcileNodeStatefulSet(ctx, node); err != nil {
+		return ctrl.Result{}, fmt.Errorf("reconciling statefulset: %w", err)
+	}
+	if err := r.reconcileNodeService(ctx, node); err != nil {
+		return ctrl.Result{}, fmt.Errorf("reconciling service: %w", err)
+	}
+
 	sc := r.buildSidecarClient(node)
 	if sc == nil {
 		sidecarUnreachableTotal.WithLabelValues(node.Namespace, node.Name).Inc()

--- a/internal/controller/node/reconciler_test.go
+++ b/internal/controller/node/reconciler_test.go
@@ -180,6 +180,41 @@ func TestNodeReconcile_SnapshotNode_StatefulSetHasInitContainers(t *testing.T) {
 	g.Expect(sts.Spec.Template.Spec.InitContainers[1].Name).To(Equal("sei-sidecar"))
 }
 
+func TestNodeReconcile_RunningPhase_UpdatesStatefulSetImage(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	node := newGenesisNode("mynet-0", "default")
+	node.Finalizers = []string{nodeFinalizerName}
+	node.Status.Phase = seiv1alpha1.PhaseRunning
+
+	// Pre-create a StatefulSet with the old image.
+	oldSts := generateNodeStatefulSet(node, platformtest.Config())
+	oldSts.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("StatefulSet"))
+
+	r, c := newNodeReconciler(t, node, oldSts)
+
+	// Verify old image on the StatefulSet.
+	sts := &appsv1.StatefulSet{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: "mynet-0", Namespace: "default"}, sts)).To(Succeed())
+	seid := findContainer(sts.Spec.Template.Spec.Containers, "seid")
+	g.Expect(seid.Image).To(Equal("ghcr.io/sei-protocol/seid:latest"))
+
+	// Update the image on the SeiNode spec.
+	node = getSeiNode(t, ctx, c, "mynet-0", "default")
+	node.Spec.Image = "ghcr.io/sei-protocol/seid:v2.0.0"
+	g.Expect(c.Update(ctx, node)).To(Succeed())
+
+	// Reconcile — this enters reconcileRunning which should update the StatefulSet.
+	_, err := r.Reconcile(ctx, nodeReqFor("mynet-0", "default"))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// StatefulSet should now reflect the new image.
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: "mynet-0", Namespace: "default"}, sts)).To(Succeed())
+	seid = findContainer(sts.Spec.Template.Spec.Containers, "seid")
+	g.Expect(seid.Image).To(Equal("ghcr.io/sei-protocol/seid:v2.0.0"))
+}
+
 func TestNodeDeletion_SnapshotNode_WithoutRetain_DeletesPVC(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- `reconcileRunning` only handled sidecar runtime tasks, so spec changes (e.g. image updates) to a SeiNode already in Running phase never propagated to its owned StatefulSet or Service
- This caused pacific-1 nodes to remain on `v6.3.0` despite the SeiNode spec reading `v6.4.1` — the image flowed from SeiNodeDeployment → SeiNode but stopped there
- Added `reconcileNodeStatefulSet` and `reconcileNodeService` calls at the top of `reconcileRunning` so owned resources converge on every reconcile regardless of phase

## Test plan
- [x] New unit test `TestNodeReconcile_RunningPhase_UpdatesStatefulSetImage` — creates a Running node with a stale StatefulSet, updates the image, reconciles, and verifies the StatefulSet picks up the new image
- [x] Full test suite passes (`make test`)
- [x] Lint clean (`make lint`)
- [ ] After deploy, verify pacific-1 StatefulSets converge to `v6.4.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)