### PR TITLE
feat: NodeUpdate plans for spec-change-driven sidecar re-initialization

### DIFF
--- a/api/v1alpha1/seinode_types.go
+++ b/api/v1alpha1/seinode_types.go
@@ -258,6 +258,12 @@ type SeiNodeStatus struct {
 	ExternalAddress string `json:"externalAddress,omitempty"`
 }
 
+// Status condition types for SeiNode.
+const (
+	ConditionSidecarReady        = "SidecarReady"
+	ConditionNodeUpdateInProgress = "NodeUpdateInProgress"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=snode

--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -37,7 +37,7 @@ const (
 	ReasonNodeUpdateComplete    = "NodeUpdateComplete"
 	ReasonSidecarNotReady       = "SidecarNotReady"
 	ReasonNodeUpdatePlanStarted = "NodeUpdatePlanStarted"
-	ReasonNodeUpdatePlanDone    = "NodeUpdatePlanDone"
+	ReasonNodeUpdatePlanComplete    = "NodeUpdatePlanDone"
 	ReasonNodeUpdatePlanFailed  = "NodeUpdatePlanFailed"
 )
 
@@ -230,7 +230,7 @@ func (r *SeiNodeReconciler) handlePlanComplete(ctx context.Context, node *seiv1a
 			ReasonNodeUpdateComplete,
 			fmt.Sprintf("NodeUpdate plan %s completed", planID))
 		setSeiNodeCondition(node, seiv1alpha1.ConditionNodeUpdateInProgress, metav1.ConditionFalse,
-			ReasonNodeUpdatePlanDone,
+			ReasonNodeUpdatePlanComplete,
 			fmt.Sprintf("NodeUpdate plan %s completed", planID))
 		if err := r.Status().Patch(ctx, node, patch); err != nil {
 			return ctrl.Result{}, fmt.Errorf("completing NodeUpdate plan: %w", err)

--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -9,6 +9,8 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -30,6 +32,13 @@ const (
 	seiNodeControllerName = "seinode"
 	statusPollInterval    = 30 * time.Second
 	fieldOwner            = client.FieldOwner("seinode-controller")
+
+	ReasonInitPlanComplete      = "InitPlanComplete"
+	ReasonNodeUpdateComplete    = "NodeUpdateComplete"
+	ReasonSidecarNotReady       = "SidecarNotReady"
+	ReasonNodeUpdatePlanStarted = "NodeUpdatePlanStarted"
+	ReasonNodeUpdatePlanDone    = "NodeUpdatePlanDone"
+	ReasonNodeUpdatePlanFailed  = "NodeUpdatePlanFailed"
 )
 
 // PlatformConfig is an alias for platform.Config, used throughout the node
@@ -99,7 +108,7 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	case seiv1alpha1.PhaseInitializing:
 		return r.reconcileInitializing(ctx, node)
 	case seiv1alpha1.PhaseRunning:
-		return r.reconcileRunning(ctx, node)
+		return r.reconcileRunning(ctx, node, p)
 	case seiv1alpha1.PhaseFailed:
 		r.Recorder.Eventf(node, corev1.EventTypeWarning, "NodeFailed",
 			"SeiNode is in Failed state. Delete and recreate the resource to retry.")
@@ -109,10 +118,10 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 }
 
-// reconcilePending builds the unified Plan and transitions to Initializing.
-// For genesis ceremony nodes the plan includes artifact generation and assembly
-// steps. For bootstrap nodes the plan includes controller-side Job lifecycle
-// tasks followed by production config. All orchestration lives in the plan.
+// ---------------------------------------------------------------------------
+// Phase-specific reconciliation
+// ---------------------------------------------------------------------------
+
 func (r *SeiNodeReconciler) reconcilePending(ctx context.Context, node *seiv1alpha1.SeiNode, p planner.NodePlanner) (ctrl.Result, error) {
 	patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 
@@ -136,14 +145,8 @@ func (r *SeiNodeReconciler) reconcilePending(ctx context.Context, node *seiv1alp
 	return planner.ResultRequeueImmediate, nil
 }
 
-// reconcileInitializing drives the unified Plan to completion. For
-// bootstrap nodes the StatefulSet and Service are created only after
-// bootstrap teardown is complete (to avoid RWO PVC conflicts). For
-// non-bootstrap nodes they are created immediately.
 func (r *SeiNodeReconciler) reconcileInitializing(ctx context.Context, node *seiv1alpha1.SeiNode) (ctrl.Result, error) {
-	plan := node.Status.Plan
-
-	if !planner.NeedsBootstrap(node) || planner.IsBootstrapComplete(plan) {
+	if !planner.NeedsBootstrap(node) || planner.IsBootstrapComplete(node.Status.Plan) {
 		if err := r.reconcileNodeStatefulSet(ctx, node); err != nil {
 			return ctrl.Result{}, fmt.Errorf("reconciling statefulset: %w", err)
 		}
@@ -152,22 +155,10 @@ func (r *SeiNodeReconciler) reconcileInitializing(ctx context.Context, node *sei
 		}
 	}
 
-	result, err := r.PlanExecutor.ExecutePlan(ctx, node, plan)
-	if err != nil {
-		return result, err
-	}
-
-	if plan.Phase == seiv1alpha1.TaskPlanComplete {
-		return r.transitionPhase(ctx, node, seiv1alpha1.PhaseRunning)
-	}
-	if plan.Phase == seiv1alpha1.TaskPlanFailed {
-		return r.transitionPhase(ctx, node, seiv1alpha1.PhaseFailed)
-	}
-	return result, nil
+	return r.drivePlan(ctx, node)
 }
 
-// reconcileRunning converges owned resources and handles runtime tasks.
-func (r *SeiNodeReconciler) reconcileRunning(ctx context.Context, node *seiv1alpha1.SeiNode) (ctrl.Result, error) {
+func (r *SeiNodeReconciler) reconcileRunning(ctx context.Context, node *seiv1alpha1.SeiNode, p planner.NodePlanner) (ctrl.Result, error) {
 	if err := r.reconcileNodeStatefulSet(ctx, node); err != nil {
 		return ctrl.Result{}, fmt.Errorf("reconciling statefulset: %w", err)
 	}
@@ -175,17 +166,165 @@ func (r *SeiNodeReconciler) reconcileRunning(ctx context.Context, node *seiv1alp
 		return ctrl.Result{}, fmt.Errorf("reconciling service: %w", err)
 	}
 
+	if err := r.observeStatefulSetState(ctx, node); err != nil {
+		return ctrl.Result{}, fmt.Errorf("observing statefulset state: %w", err)
+	}
 	if err := r.observeCurrentImage(ctx, node); err != nil {
 		return ctrl.Result{}, fmt.Errorf("observing current image: %w", err)
 	}
 
-	sc := r.buildSidecarClient(node)
-	if sc == nil {
-		sidecarUnreachableTotal.WithLabelValues(node.Namespace, node.Name).Inc()
-		log.FromContext(ctx).Info("sidecar not reachable, will retry")
-		return ctrl.Result{RequeueAfter: statusPollInterval}, nil
+	if node.Status.Plan != nil && node.Status.Plan.Phase == seiv1alpha1.TaskPlanActive {
+		return r.drivePlan(ctx, node)
 	}
-	return r.reconcileRuntimeTasks(ctx, node, sc)
+
+	plan, err := p.BuildPlan(node)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("building plan: %w", err)
+	}
+	if plan != nil {
+		return r.startNodeUpdatePlan(ctx, node, plan)
+	}
+
+	return r.steadyState(ctx, node)
+}
+
+// ---------------------------------------------------------------------------
+// Shared plan lifecycle
+// ---------------------------------------------------------------------------
+
+func (r *SeiNodeReconciler) drivePlan(ctx context.Context, node *seiv1alpha1.SeiNode) (ctrl.Result, error) {
+	plan := node.Status.Plan
+
+	switch plan.Phase {
+	case seiv1alpha1.TaskPlanComplete:
+		return r.handlePlanComplete(ctx, node)
+	case seiv1alpha1.TaskPlanFailed:
+		return r.handlePlanFailed(ctx, node)
+	}
+
+	result, err := r.PlanExecutor.ExecutePlan(ctx, node, plan)
+	if err != nil {
+		return result, err
+	}
+
+	switch plan.Phase {
+	case seiv1alpha1.TaskPlanComplete:
+		return r.handlePlanComplete(ctx, node)
+	case seiv1alpha1.TaskPlanFailed:
+		return r.handlePlanFailed(ctx, node)
+	}
+
+	return result, nil
+}
+
+func (r *SeiNodeReconciler) handlePlanComplete(ctx context.Context, node *seiv1alpha1.SeiNode) (ctrl.Result, error) {
+	switch node.Status.Phase {
+	case seiv1alpha1.PhaseInitializing:
+		return r.transitionPhase(ctx, node, seiv1alpha1.PhaseRunning)
+
+	case seiv1alpha1.PhaseRunning:
+		planID := node.Status.Plan.ID
+		patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		node.Status.Plan = nil
+		setSeiNodeCondition(node, seiv1alpha1.ConditionSidecarReady, metav1.ConditionTrue,
+			ReasonNodeUpdateComplete,
+			fmt.Sprintf("NodeUpdate plan %s completed", planID))
+		setSeiNodeCondition(node, seiv1alpha1.ConditionNodeUpdateInProgress, metav1.ConditionFalse,
+			ReasonNodeUpdatePlanDone,
+			fmt.Sprintf("NodeUpdate plan %s completed", planID))
+		if err := r.Status().Patch(ctx, node, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("completing NodeUpdate plan: %w", err)
+		}
+		r.Recorder.Eventf(node, corev1.EventTypeNormal, "NodeUpdateComplete",
+			"NodeUpdate plan %s completed, sidecar ready", planID)
+		return planner.ResultRequeueImmediate, nil
+
+	default:
+		return ctrl.Result{}, fmt.Errorf("unexpected plan completion in phase %s", node.Status.Phase)
+	}
+}
+
+func (r *SeiNodeReconciler) handlePlanFailed(ctx context.Context, node *seiv1alpha1.SeiNode) (ctrl.Result, error) {
+	plan := node.Status.Plan
+
+	switch node.Status.Phase {
+	case seiv1alpha1.PhaseInitializing:
+		return r.transitionPhase(ctx, node, seiv1alpha1.PhaseFailed)
+
+	case seiv1alpha1.PhaseRunning:
+		detail := "unknown"
+		if plan.FailedTaskDetail != nil {
+			detail = fmt.Sprintf("task %s failed: %s (retries: %d/%d)",
+				plan.FailedTaskDetail.Type,
+				plan.FailedTaskDetail.Error,
+				plan.FailedTaskDetail.RetryCount,
+				plan.FailedTaskDetail.MaxRetries)
+		}
+
+		r.Recorder.Eventf(node, corev1.EventTypeWarning, "NodeUpdatePlanFailed",
+			"NodeUpdate plan %s failed: %s. Will retry on next reconcile.", plan.ID, detail)
+		log.FromContext(ctx).Info("NodeUpdate plan failed, clearing for retry",
+			"planID", plan.ID, "detail", detail)
+		nodeUpdatePlanFailuresTotal.WithLabelValues(node.Namespace, node.Name).Inc()
+
+		patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		node.Status.Plan = nil
+		setSeiNodeCondition(node, seiv1alpha1.ConditionNodeUpdateInProgress, metav1.ConditionFalse,
+			ReasonNodeUpdatePlanFailed,
+			fmt.Sprintf("NodeUpdate plan %s failed: %s", plan.ID, detail))
+		if err := r.Status().Patch(ctx, node, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("clearing failed NodeUpdate plan: %w", err)
+		}
+		return ctrl.Result{RequeueAfter: statusPollInterval}, nil
+
+	default:
+		return ctrl.Result{}, fmt.Errorf("unexpected plan failure in phase %s", node.Status.Phase)
+	}
+}
+
+func (r *SeiNodeReconciler) startNodeUpdatePlan(ctx context.Context, node *seiv1alpha1.SeiNode, plan *seiv1alpha1.TaskPlan) (ctrl.Result, error) {
+	patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	node.Status.Plan = plan
+	setSeiNodeCondition(node, seiv1alpha1.ConditionNodeUpdateInProgress, metav1.ConditionTrue,
+		ReasonNodeUpdatePlanStarted,
+		fmt.Sprintf("NodeUpdate plan %s started with %d tasks", plan.ID, len(plan.Tasks)))
+	if err := r.Status().Patch(ctx, node, patch); err != nil {
+		return ctrl.Result{}, fmt.Errorf("setting NodeUpdate plan: %w", err)
+	}
+	r.Recorder.Eventf(node, corev1.EventTypeNormal, "NodeUpdatePlanStarted",
+		"NodeUpdate plan %s started with %d tasks", plan.ID, len(plan.Tasks))
+	return planner.ResultRequeueImmediate, nil
+}
+
+// ---------------------------------------------------------------------------
+// Observation
+// ---------------------------------------------------------------------------
+
+func (r *SeiNodeReconciler) observeStatefulSetState(ctx context.Context, node *seiv1alpha1.SeiNode) error {
+	sts := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, types.NamespacedName{Name: node.Name, Namespace: node.Namespace}, sts); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if !isStatefulSetRolledOut(sts) {
+		return nil
+	}
+
+	if !isSidecarReadyConditionCurrent(node) {
+		patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		setSeiNodeCondition(node, seiv1alpha1.ConditionSidecarReady, metav1.ConditionFalse,
+			ReasonSidecarNotReady, "StatefulSet rollout complete, sidecar needs re-initialization")
+		if err := r.Status().Patch(ctx, node, patch); err != nil {
+			return fmt.Errorf("setting SidecarReady=False: %w", err)
+		}
+		r.Recorder.Eventf(node, corev1.EventTypeWarning, "SidecarNotReady",
+			"StatefulSet rolled out new pod template, NodeUpdate plan will be built")
+	}
+
+	return nil
 }
 
 func (r *SeiNodeReconciler) observeCurrentImage(ctx context.Context, node *seiv1alpha1.SeiNode) error {
@@ -197,7 +336,6 @@ func (r *SeiNodeReconciler) observeCurrentImage(ctx context.Context, node *seiv1
 		return err
 	}
 
-	// Wait for the StatefulSet controller to process the latest spec change.
 	if sts.Status.ObservedGeneration < sts.Generation {
 		return nil
 	}
@@ -213,8 +351,18 @@ func (r *SeiNodeReconciler) observeCurrentImage(ctx context.Context, node *seiv1
 	return nil
 }
 
-// transitionPhase transitions the node to a new phase and emits the associated
-// metric counter, phase gauge, and Kubernetes event.
+// ---------------------------------------------------------------------------
+// Steady state
+// ---------------------------------------------------------------------------
+
+func (r *SeiNodeReconciler) steadyState(_ context.Context, _ *seiv1alpha1.SeiNode) (ctrl.Result, error) {
+	return ctrl.Result{RequeueAfter: statusPollInterval}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Phase transitions
+// ---------------------------------------------------------------------------
+
 func (r *SeiNodeReconciler) transitionPhase(ctx context.Context, node *seiv1alpha1.SeiNode, phase seiv1alpha1.SeiNodePhase) (ctrl.Result, error) {
 	prev := node.Status.Phase
 	if prev == "" {
@@ -223,6 +371,10 @@ func (r *SeiNodeReconciler) transitionPhase(ctx context.Context, node *seiv1alph
 
 	patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	node.Status.Phase = phase
+	if phase == seiv1alpha1.PhaseRunning {
+		setSeiNodeCondition(node, seiv1alpha1.ConditionSidecarReady, metav1.ConditionTrue,
+			ReasonInitPlanComplete, "Initial plan completed, sidecar ready")
+	}
 	if err := r.Status().Patch(ctx, node, patch); err != nil {
 		return ctrl.Result{}, fmt.Errorf("setting phase to %s: %w", phase, err)
 	}
@@ -242,6 +394,43 @@ func (r *SeiNodeReconciler) transitionPhase(ctx context.Context, node *seiv1alph
 
 	return planner.ResultRequeueImmediate, nil
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func setSeiNodeCondition(node *seiv1alpha1.SeiNode, condType string, status metav1.ConditionStatus, reason, message string) {
+	apimeta.SetStatusCondition(&node.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: node.Generation,
+	})
+}
+
+func isStatefulSetRolledOut(sts *appsv1.StatefulSet) bool {
+	if sts.Status.ObservedGeneration < sts.Generation {
+		return false
+	}
+	if sts.Spec.Replicas == nil {
+		return false
+	}
+	return sts.Status.UpdatedReplicas >= *sts.Spec.Replicas
+}
+
+func isSidecarReadyConditionCurrent(node *seiv1alpha1.SeiNode) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == seiv1alpha1.ConditionSidecarReady {
+			return c.Status == metav1.ConditionTrue && c.ObservedGeneration >= node.Generation
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Resource management
+// ---------------------------------------------------------------------------
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SeiNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/node/metrics.go
+++ b/internal/controller/node/metrics.go
@@ -65,6 +65,14 @@ var (
 		[]string{"namespace", "node"},
 	)
 
+	nodeUpdatePlanFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sei_controller_node_update_plan_failures_total",
+			Help: "Number of NodeUpdate plan failures in Running phase",
+		},
+		[]string{"namespace", "name"},
+	)
+
 	monitorTaskCompletedTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "sei_controller_monitor_task_completed_total",
@@ -89,6 +97,7 @@ func init() {
 		nodeInitDuration,
 		nodeLastInitDuration,
 		sidecarUnreachableTotal,
+		nodeUpdatePlanFailuresTotal,
 		monitorTaskCompletedTotal,
 		monitorTaskStatus,
 	)

--- a/internal/controller/node/monitor_test.go
+++ b/internal/controller/node/monitor_test.go
@@ -495,6 +495,7 @@ func TestPollMonitorTasks_FailedWithUnknownError(t *testing.T) {
 // --- Reconcile integration tests ---
 
 func TestReconcileRunning_MonitorMode_SubmitsMonitorTask(t *testing.T) {
+	t.Skip("MonitorTasks descoped from reconcileRunning in M1")
 	taskID := uuid.New()
 	mock := &mockSidecarClient{submitID: taskID}
 	node := monitorReplayerNode()
@@ -503,7 +504,7 @@ func TestReconcileRunning_MonitorMode_SubmitsMonitorTask(t *testing.T) {
 
 	r, c := newProgressionReconciler(t, mock, node)
 
-	_, err := r.reconcileRunning(context.Background(), node)
+	_, err := r.reconcileRunning(context.Background(), node, mustPlanner(t, node))
 	if err != nil {
 		t.Fatalf("reconcileRunning: %v", err)
 	}

--- a/internal/controller/node/plan_execution_test.go
+++ b/internal/controller/node/plan_execution_test.go
@@ -33,6 +33,15 @@ const (
 	testSnapshotRegion   = "eu-central-1"
 )
 
+func mustPlanner(t *testing.T, node *seiv1alpha1.SeiNode) planner.NodePlanner {
+	t.Helper()
+	p, err := planner.ForNode(node)
+	if err != nil {
+		t.Fatalf("ForNode: %v", err)
+	}
+	return p
+}
+
 func mustBuildPlan(t *testing.T, p planner.NodePlanner, node *seiv1alpha1.SeiNode) *seiv1alpha1.TaskPlan {
 	t.Helper()
 	plan, err := p.BuildPlan(node)
@@ -541,6 +550,7 @@ func TestReconcile_FailedPlan_NoOps(t *testing.T) {
 }
 
 func TestReconcile_CompletePlan_SubmitsSnapshotUploadMonitor(t *testing.T) {
+	t.Skip("MonitorTasks descoped from reconcileRunning in M1")
 	taskID := uuid.New()
 	mock := &mockSidecarClient{submitID: taskID}
 	node := snapshotterNode()
@@ -550,7 +560,7 @@ func TestReconcile_CompletePlan_SubmitsSnapshotUploadMonitor(t *testing.T) {
 	r, c := newProgressionReconciler(t, mock, node)
 	ctx := context.Background()
 
-	_, err := r.reconcileRunning(ctx, node)
+	_, err := r.reconcileRunning(ctx, node, mustPlanner(t, node))
 	if err != nil {
 		t.Fatalf("error = %v", err)
 	}
@@ -585,7 +595,7 @@ func TestReconcile_CompletePlan_SkipsAlreadySubmittedMonitor(t *testing.T) {
 	r, _ := newProgressionReconciler(t, mock, node)
 	ctx := context.Background()
 
-	_, err := r.reconcileRunning(ctx, node)
+	_, err := r.reconcileRunning(ctx, node, mustPlanner(t, node))
 	if err != nil {
 		t.Fatalf("error = %v", err)
 	}
@@ -980,7 +990,7 @@ func TestReconcile_ReplayerWithoutResultExport_NoMonitorTask(t *testing.T) {
 
 	r, c := newProgressionReconciler(t, mock, node)
 
-	_, err := r.reconcileRunning(context.Background(), node)
+	_, err := r.reconcileRunning(context.Background(), node, mustPlanner(t, node))
 	if err != nil {
 		t.Fatalf("error = %v", err)
 	}
@@ -995,6 +1005,7 @@ func TestReconcile_ReplayerWithoutResultExport_NoMonitorTask(t *testing.T) {
 }
 
 func TestReconcile_SnapshotterWithMonitorTask_BothSubmitted(t *testing.T) {
+	t.Skip("MonitorTasks descoped from reconcileRunning in M1")
 	taskID := uuid.New()
 	mock := &mockSidecarClient{submitID: taskID}
 
@@ -1007,7 +1018,7 @@ func TestReconcile_SnapshotterWithMonitorTask_BothSubmitted(t *testing.T) {
 
 	r, c := newProgressionReconciler(t, mock, node)
 
-	_, err := r.reconcileRunning(context.Background(), node)
+	_, err := r.reconcileRunning(context.Background(), node, mustPlanner(t, node))
 	if err != nil {
 		t.Fatalf("error = %v", err)
 	}
@@ -1028,6 +1039,7 @@ func TestReconcile_SnapshotterWithMonitorTask_BothSubmitted(t *testing.T) {
 }
 
 func TestReconcileRunning_PollRequeue_ImmediateRequeue(t *testing.T) {
+	t.Skip("MonitorTasks descoped from reconcileRunning in M1")
 	taskID := uuid.New()
 	mock := &mockSidecarClient{
 		submitID: taskID,
@@ -1048,7 +1060,7 @@ func TestReconcileRunning_PollRequeue_ImmediateRequeue(t *testing.T) {
 
 	r, _ := newProgressionReconciler(t, mock, node)
 
-	result, err := r.reconcileRunning(context.Background(), node)
+	result, err := r.reconcileRunning(context.Background(), node, mustPlanner(t, node))
 	if err != nil {
 		t.Fatalf("error = %v", err)
 	}
@@ -1058,6 +1070,7 @@ func TestReconcileRunning_PollRequeue_ImmediateRequeue(t *testing.T) {
 }
 
 func TestReconcile_CompletePlan_SubmitsResultExportMonitorForReplayer(t *testing.T) {
+	t.Skip("MonitorTasks descoped from reconcileRunning in M1")
 	taskID := uuid.New()
 	mock := &mockSidecarClient{submitID: taskID}
 	node := monitorReplayerNode()
@@ -1066,7 +1079,7 @@ func TestReconcile_CompletePlan_SubmitsResultExportMonitorForReplayer(t *testing
 
 	r, c := newProgressionReconciler(t, mock, node)
 
-	_, err := r.reconcileRunning(context.Background(), node)
+	_, err := r.reconcileRunning(context.Background(), node, mustPlanner(t, node))
 	if err != nil {
 		t.Fatalf("error = %v", err)
 	}

--- a/internal/planner/archive.go
+++ b/internal/planner/archive.go
@@ -23,10 +23,20 @@ func (p *archiveNodePlanner) Validate(node *seiv1alpha1.SeiNode) error {
 }
 
 func (p *archiveNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
-	return buildBasePlan(node, node.Spec.Peers, nil, &task.ConfigApplyParams{
+	if NeedsNodeUpdate(node) {
+		return buildNodeUpdatePlan(node, p.configApplyParams(node))
+	}
+	if node.Status.Phase != "" && node.Status.Phase != seiv1alpha1.PhasePending {
+		return nil, nil
+	}
+	return buildBasePlan(node, node.Spec.Peers, nil, p.configApplyParams(node))
+}
+
+func (p *archiveNodePlanner) configApplyParams(node *seiv1alpha1.SeiNode) *task.ConfigApplyParams {
+	return &task.ConfigApplyParams{
 		Mode:      string(seiconfig.ModeArchive),
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
-	})
+	}
 }
 
 func (p *archiveNodePlanner) controllerOverrides(node *seiv1alpha1.SeiNode) map[string]string {

--- a/internal/planner/full.go
+++ b/internal/planner/full.go
@@ -27,15 +27,25 @@ func (p *fullNodePlanner) Validate(node *seiv1alpha1.SeiNode) error {
 }
 
 func (p *fullNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
-	fn := node.Spec.FullNode
-	params := &task.ConfigApplyParams{
-		Mode:      string(seiconfig.ModeFull),
-		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
+	if NeedsNodeUpdate(node) {
+		return buildNodeUpdatePlan(node, p.configApplyParams(node))
 	}
+	if node.Status.Phase != "" && node.Status.Phase != seiv1alpha1.PhasePending {
+		return nil, nil
+	}
+	fn := node.Spec.FullNode
+	params := p.configApplyParams(node)
 	if NeedsBootstrap(node) {
 		return buildBootstrapPlan(node, node.Spec.Peers, fn.Snapshot, params)
 	}
 	return buildBasePlan(node, node.Spec.Peers, fn.Snapshot, params)
+}
+
+func (p *fullNodePlanner) configApplyParams(node *seiv1alpha1.SeiNode) *task.ConfigApplyParams {
+	return &task.ConfigApplyParams{
+		Mode:      string(seiconfig.ModeFull),
+		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
+	}
 }
 
 func (p *fullNodePlanner) controllerOverrides(node *seiv1alpha1.SeiNode) map[string]string {

--- a/internal/planner/node_update.go
+++ b/internal/planner/node_update.go
@@ -1,0 +1,42 @@
+package planner
+
+import (
+	"github.com/google/uuid"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/task"
+)
+
+// buildNodeUpdatePlan constructs a TaskPlan for re-initializing the sidecar
+// after a spec change in the Running phase. The task sequence mirrors
+// post-bootstrap initialization: configure genesis, apply config, discover
+// peers, validate config, and mark ready. All tasks are idempotent — if
+// the PVC state is already current, each task is a fast no-op on the sidecar.
+//
+// Callers provide the mode and configApplyParams so that mode-specific
+// controller overrides (e.g., snapshot generation settings) are included.
+func buildNodeUpdatePlan(
+	node *seiv1alpha1.SeiNode,
+	configApplyParams *task.ConfigApplyParams,
+) (*seiv1alpha1.TaskPlan, error) {
+	prog := []string{TaskConfigureGenesis, TaskConfigApply}
+	if len(node.Spec.Peers) > 0 {
+		prog = append(prog, TaskDiscoverPeers)
+	}
+	prog = append(prog, TaskConfigValidate, TaskMarkReady)
+
+	planID := uuid.New().String()
+	tasks := make([]seiv1alpha1.PlannedTask, len(prog))
+	for i, taskType := range prog {
+		t, err := buildPlannedTask(planID, taskType, i, paramsForTaskType(node, taskType, nil, configApplyParams))
+		if err != nil {
+			return nil, err
+		}
+		tasks[i] = t
+	}
+	return &seiv1alpha1.TaskPlan{
+		ID:    planID,
+		Phase: seiv1alpha1.TaskPlanActive,
+		Tasks: tasks,
+	}, nil
+}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -133,6 +133,28 @@ func insertBefore(prog []string, target, taskType string) []string {
 	return prog
 }
 
+// NeedsNodeUpdate returns true when a Running node needs a NodeUpdate plan
+// to re-initialize the sidecar after a spec change. This is a pure function
+// of CRD state — no sidecar calls.
+func NeedsNodeUpdate(node *seiv1alpha1.SeiNode) bool {
+	if node.Status.Phase != seiv1alpha1.PhaseRunning {
+		return false
+	}
+	if node.Status.Plan != nil {
+		return false
+	}
+	return !isSidecarReady(node)
+}
+
+func isSidecarReady(node *seiv1alpha1.SeiNode) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == seiv1alpha1.ConditionSidecarReady {
+			return c.Status == metav1.ConditionTrue
+		}
+	}
+	return false
+}
+
 // NeedsBootstrap returns true when the node requires a bootstrap Job to
 // populate the PVC before the StatefulSet takes over.
 func NeedsBootstrap(node *seiv1alpha1.SeiNode) bool {

--- a/internal/planner/replay.go
+++ b/internal/planner/replay.go
@@ -32,14 +32,24 @@ func (p *replayerPlanner) Validate(node *seiv1alpha1.SeiNode) error {
 }
 
 func (p *replayerPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
-	params := &task.ConfigApplyParams{
-		Mode:      string(seiconfig.ModeFull),
-		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides()), node.Spec.Overrides),
+	if NeedsNodeUpdate(node) {
+		return buildNodeUpdatePlan(node, p.configApplyParams(node))
 	}
+	if node.Status.Phase != "" && node.Status.Phase != seiv1alpha1.PhasePending {
+		return nil, nil
+	}
+	params := p.configApplyParams(node)
 	if NeedsBootstrap(node) {
 		return buildBootstrapPlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, params)
 	}
 	return buildBasePlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, params)
+}
+
+func (p *replayerPlanner) configApplyParams(node *seiv1alpha1.SeiNode) *task.ConfigApplyParams {
+	return &task.ConfigApplyParams{
+		Mode:      string(seiconfig.ModeFull),
+		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides()), node.Spec.Overrides),
+	}
 }
 
 func (p *replayerPlanner) controllerOverrides() map[string]string {

--- a/internal/planner/validator.go
+++ b/internal/planner/validator.go
@@ -36,16 +36,26 @@ func (p *validatorPlanner) Validate(node *seiv1alpha1.SeiNode) error {
 }
 
 func (p *validatorPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
+	if NeedsNodeUpdate(node) {
+		return buildNodeUpdatePlan(node, p.configApplyParams(node))
+	}
+	if node.Status.Phase != "" && node.Status.Phase != seiv1alpha1.PhasePending {
+		return nil, nil
+	}
 	if isGenesisCeremonyNode(node) {
 		return buildGenesisPlan(node)
 	}
 	v := node.Spec.Validator
-	params := &task.ConfigApplyParams{
-		Mode:      string(seiconfig.ModeValidator),
-		Overrides: mergeOverrides(commonOverrides(node), node.Spec.Overrides),
-	}
+	params := p.configApplyParams(node)
 	if NeedsBootstrap(node) {
 		return buildBootstrapPlan(node, node.Spec.Peers, v.Snapshot, params)
 	}
 	return buildBasePlan(node, node.Spec.Peers, v.Snapshot, params)
+}
+
+func (p *validatorPlanner) configApplyParams(node *seiv1alpha1.SeiNode) *task.ConfigApplyParams {
+	return &task.ConfigApplyParams{
+		Mode:      string(seiconfig.ModeValidator),
+		Overrides: mergeOverrides(commonOverrides(node), node.Spec.Overrides),
+	}
 }


### PR DESCRIPTION
## Summary

- Makes `BuildPlan` phase-aware so the planner returns NodeUpdate plans for Running nodes that need sidecar re-initialization after a spec change (image, config, peers)
- Adds `SidecarReady` and `NodeUpdateInProgress` conditions to SeiNode status, providing an observable interface for the SeiNodeDeployment controller to track convergence without calling sidecars directly
- Extracts shared `drivePlan`/`handlePlanComplete`/`handlePlanFailed` so both Initializing and Running phases use the same plan execution path
- Running-phase plan failure clears the plan and retries rather than transitioning to Failed
- Descopes MonitorTasks from the reconcile loop (dead code, no real use case)

This is M1 of the validator workstream. It provides the SeiNode-side mechanics that M2 (in-place deployment refactor) and M3 (validator BYOI) depend on.

## Test plan

- [ ] `make test` passes — all existing tests pass, 5 MonitorTask tests skipped (descoped)
- [ ] `make lint` passes
- [ ] Verify: BuildPlan returns init plan for Pending nodes, NodeUpdate plan for Running + stale SidecarReady, nil for steady state
- [ ] Verify: plan failure in Running phase clears plan without transitioning to Failed
- [ ] Verify: SidecarReady condition set True at Initializing→Running transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)