### PR TITLE
feat: single-patch reconcile model

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -159,7 +159,6 @@ func main() {
 		Recorder: nodeRecorder,
 		Platform: platformCfg,
 		PlanExecutor: &planner.Executor[*seiv1alpha1.SeiNode]{
-			Client: kc,
 			ConfigFor: func(_ context.Context, node *seiv1alpha1.SeiNode) task.ExecutionConfig {
 				return task.ExecutionConfig{
 					BuildSidecarClient: func() (task.SidecarClient, error) {
@@ -189,7 +188,6 @@ func main() {
 		GatewayDomain:       platformCfg.GatewayDomain,
 		GatewayPublicDomain: platformCfg.GatewayPublicDomain,
 		PlanExecutor: &planner.Executor[*seiv1alpha1.SeiNodeDeployment]{
-			Client: kc,
 			ConfigFor: func(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) task.ExecutionConfig {
 				var assemblerNode *seiv1alpha1.SeiNode
 				nodes := &seiv1alpha1.SeiNodeList{}

--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -70,6 +70,8 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.handleNodeDeletion(ctx, node)
 	}
 
+	// Finalizer is a metadata Update — must happen before we snapshot
+	// the status patch base because Update changes resourceVersion.
 	if err := r.ensureNodeFinalizer(ctx, node); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -81,38 +83,62 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
+	// --- From here, all status mutations are in-memory. ---
+	// Capture the patch base AFTER the finalizer update so resourceVersion
+	// matches the stored object.
+	statusBase := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	observedPhase := node.Status.Phase
+	statusDirty := false
+
 	// Pre-plan: resolve label-based peers so plan params have fresh data.
-	if err := r.reconcilePeers(ctx, node); err != nil {
+	if dirty, err := r.reconcilePeers(ctx, node); err != nil {
 		return ctrl.Result{}, fmt.Errorf("reconciling peers: %w", err)
+	} else if dirty {
+		statusDirty = true
 	}
 
 	// Resolve or resume plan. ResolvePlan either resumes an active plan or
 	// builds a new one based on the node's phase, stamping it onto
 	// node.Status.Plan (and transitioning Pending → Initializing).
-	observedPhase := node.Status.Phase
 	planAlreadyActive := node.Status.Plan != nil && node.Status.Plan.Phase == seiv1alpha1.TaskPlanActive
-	patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	if err := planner.ResolvePlan(node); err != nil {
 		return ctrl.Result{}, fmt.Errorf("resolving plan: %w", err)
 	}
 
-	if node.Status.Plan == nil {
-		return ctrl.Result{}, nil
+	// Execute the plan. The executor advances tasks in-memory — synchronous
+	// tasks complete in a loop, async tasks return Running with a poll interval.
+	var result ctrl.Result
+	var execErr error
+	if node.Status.Plan != nil && node.Status.Plan.Phase == seiv1alpha1.TaskPlanActive {
+		result, execErr = r.PlanExecutor.ExecutePlan(ctx, node, node.Status.Plan)
+		statusDirty = true
 	}
 
-	// If ResolvePlan built a new plan, persist it before execution.
-	if !planAlreadyActive {
-		if err := r.Status().Patch(ctx, node, patch); err != nil {
-			return ctrl.Result{}, fmt.Errorf("persisting new plan: %w", err)
+	// If ResolvePlan built a new plan (but there's nothing to execute yet
+	// because it was just created this reconcile), mark dirty so it gets persisted.
+	if !planAlreadyActive && node.Status.Plan != nil {
+		statusDirty = true
+	}
+
+	// Running phase: observe image convergence in-memory.
+	if node.Status.Phase == seiv1alpha1.PhaseRunning {
+		if dirty, err := r.observeCurrentImage(ctx, node); err != nil {
+			return ctrl.Result{}, fmt.Errorf("observing current image: %w", err)
+		} else if dirty {
+			statusDirty = true
 		}
-		return planner.ResultRequeueImmediate, nil
 	}
 
-	// Execute the plan. The executor handles phase transitions via
-	// TargetPhase/FailedPhase and sets Conditions on failure.
-	result, err := r.PlanExecutor.ExecutePlan(ctx, node, node.Status.Plan)
-	if err != nil {
-		return result, err
+	// --- Flush all accumulated status mutations in a single patch. ---
+	if statusDirty {
+		if err := r.Status().Patch(ctx, node, statusBase); err != nil {
+			return ctrl.Result{}, fmt.Errorf("flushing status: %w", err)
+		}
+	}
+
+	// Return exec error AFTER the flush so partial progress is persisted.
+	if execErr != nil {
+		return result, execErr
 	}
 
 	// Emit metrics/events if the phase changed.
@@ -130,40 +156,38 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	// Running phase: observe image convergence after plan completes.
-	if node.Status.Phase == seiv1alpha1.PhaseRunning {
-		if err := r.observeCurrentImage(ctx, node); err != nil {
-			return ctrl.Result{}, fmt.Errorf("observing current image: %w", err)
-		}
+	// Running nodes with no active plan requeue on a steady-state interval.
+	// Spec changes trigger immediate reconciles via GenerationChangedPredicate.
+	if node.Status.Phase == seiv1alpha1.PhaseRunning && (node.Status.Plan == nil || node.Status.Plan.Phase != seiv1alpha1.TaskPlanActive) {
 		return ctrl.Result{RequeueAfter: statusPollInterval}, nil
 	}
 
 	return result, nil
 }
 
-func (r *SeiNodeReconciler) observeCurrentImage(ctx context.Context, node *seiv1alpha1.SeiNode) error {
+// observeCurrentImage checks whether the StatefulSet rollout has completed
+// and stamps status.currentImage in-memory. Returns true if the image changed.
+func (r *SeiNodeReconciler) observeCurrentImage(ctx context.Context, node *seiv1alpha1.SeiNode) (bool, error) {
 	sts := &appsv1.StatefulSet{}
 	if err := r.Get(ctx, types.NamespacedName{Name: node.Name, Namespace: node.Namespace}, sts); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
 
-	// Wait for the StatefulSet controller to process the latest spec change.
 	if sts.Status.ObservedGeneration < sts.Generation {
-		return nil
+		return false, nil
 	}
 	if sts.Spec.Replicas == nil || sts.Status.UpdatedReplicas < *sts.Spec.Replicas {
-		return nil
+		return false, nil
 	}
 
 	if node.Status.CurrentImage != node.Spec.Image {
-		patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		node.Status.CurrentImage = node.Spec.Image
-		return r.Status().Patch(ctx, node, patch)
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
@@ -53,6 +54,8 @@ type SeiNodeReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
+// Reconcile drives the SeiNode lifecycle. All status mutations after the
+// finalizer are accumulated in-memory and flushed in a single status patch.
 func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	node := &seiv1alpha1.SeiNode{}
 	if err := r.Get(ctx, req.NamespacedName, node); err != nil {
@@ -83,9 +86,6 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	// --- From here, all status mutations are in-memory. ---
-	// Capture the patch base AFTER the finalizer update so resourceVersion
-	// matches the stored object.
 	statusBase := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	observedPhase := node.Status.Phase
 	statusDirty := false
@@ -129,14 +129,15 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	// --- Flush all accumulated status mutations in a single patch. ---
 	if statusDirty {
 		if err := r.Status().Patch(ctx, node, statusBase); err != nil {
+			if execErr != nil {
+				log.FromContext(ctx).Error(execErr, "plan execution error lost due to status flush failure")
+			}
 			return ctrl.Result{}, fmt.Errorf("flushing status: %w", err)
 		}
 	}
 
-	// Return exec error AFTER the flush so partial progress is persisted.
 	if execErr != nil {
 		return result, execErr
 	}

--- a/internal/controller/node/peers.go
+++ b/internal/controller/node/peers.go
@@ -12,10 +12,9 @@ import (
 
 // reconcilePeers resolves label-based peer sources by listing matching
 // SeiNode resources and writing their stable DNS hostnames to
-// status.resolvedPeers. This runs on every reconcile so the resolved
-// list stays current. EC2Tags and Static sources are handled by the
-// sidecar at task execution time and do not appear here.
-func (r *SeiNodeReconciler) reconcilePeers(ctx context.Context, node *seiv1alpha1.SeiNode) error {
+// status.resolvedPeers in-memory. The caller is responsible for persisting
+// the change. Returns true if the resolved peers changed.
+func (r *SeiNodeReconciler) reconcilePeers(ctx context.Context, node *seiv1alpha1.SeiNode) (bool, error) {
 	var resolved []string
 	for _, src := range node.Spec.Peers {
 		if src.Label == nil {
@@ -23,7 +22,7 @@ func (r *SeiNodeReconciler) reconcilePeers(ctx context.Context, node *seiv1alpha
 		}
 		endpoints, err := r.resolveLabelPeers(ctx, node, src.Label)
 		if err != nil {
-			return err
+			return false, err
 		}
 		resolved = append(resolved, endpoints...)
 	}
@@ -32,13 +31,10 @@ func (r *SeiNodeReconciler) reconcilePeers(ctx context.Context, node *seiv1alpha
 	resolved = slices.Compact(resolved)
 
 	if !slices.Equal(node.Status.ResolvedPeers, resolved) {
-		patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		node.Status.ResolvedPeers = resolved
-		if err := r.Status().Patch(ctx, node, patch); err != nil {
-			return fmt.Errorf("patching resolved peers: %w", err)
-		}
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
 // resolveLabelPeers lists SeiNode resources matching the label selector

--- a/internal/controller/node/peers_test.go
+++ b/internal/controller/node/peers_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
@@ -39,28 +38,23 @@ func TestReconcilePeers_ResolvesLabelSource(t *testing.T) {
 		Spec: seiv1alpha1.SeiNodeSpec{ChainID: "test-1", Image: "sei:latest", FullNode: &seiv1alpha1.FullNodeSpec{}},
 	}
 
-	r, c := newNodeReconciler(t, node, peer1, peer2)
+	r, _ := newNodeReconciler(t, node, peer1, peer2)
 	ctx := context.Background()
 
-	if err := r.reconcilePeers(ctx, node); err != nil {
+	if _, err := r.reconcilePeers(ctx, node); err != nil {
 		t.Fatalf("reconcilePeers: %v", err)
 	}
 
-	got := &seiv1alpha1.SeiNode{}
-	if err := c.Get(ctx, types.NamespacedName{Name: "my-node", Namespace: "default"}, got); err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-
-	if len(got.Status.ResolvedPeers) != 2 {
-		t.Fatalf("expected 2 resolved peers, got %d: %v", len(got.Status.ResolvedPeers), got.Status.ResolvedPeers)
+	if len(node.Status.ResolvedPeers) != 2 {
+		t.Fatalf("expected 2 resolved peers, got %d: %v", len(node.Status.ResolvedPeers), node.Status.ResolvedPeers)
 	}
 	want := []string{
 		"peer-1-0.peer-1.default.svc.cluster.local",
 		"peer-2-0.peer-2.default.svc.cluster.local",
 	}
 	for i, w := range want {
-		if got.Status.ResolvedPeers[i] != w {
-			t.Errorf("resolvedPeers[%d] = %q, want %q", i, got.Status.ResolvedPeers[i], w)
+		if node.Status.ResolvedPeers[i] != w {
+			t.Errorf("resolvedPeers[%d] = %q, want %q", i, node.Status.ResolvedPeers[i], w)
 		}
 	}
 }
@@ -90,23 +84,18 @@ func TestReconcilePeers_ExcludesSelf(t *testing.T) {
 		Spec: seiv1alpha1.SeiNodeSpec{ChainID: "test-1", Image: "sei:latest", FullNode: &seiv1alpha1.FullNodeSpec{}},
 	}
 
-	r, c := newNodeReconciler(t, node, peer)
+	r, _ := newNodeReconciler(t, node, peer)
 	ctx := context.Background()
 
-	if err := r.reconcilePeers(ctx, node); err != nil {
+	if _, err := r.reconcilePeers(ctx, node); err != nil {
 		t.Fatalf("reconcilePeers: %v", err)
 	}
 
-	got := &seiv1alpha1.SeiNode{}
-	if err := c.Get(ctx, types.NamespacedName{Name: "my-node", Namespace: "default"}, got); err != nil {
-		t.Fatalf("Get: %v", err)
+	if len(node.Status.ResolvedPeers) != 1 {
+		t.Fatalf("expected 1 resolved peer (self excluded), got %d: %v", len(node.Status.ResolvedPeers), node.Status.ResolvedPeers)
 	}
-
-	if len(got.Status.ResolvedPeers) != 1 {
-		t.Fatalf("expected 1 resolved peer (self excluded), got %d: %v", len(got.Status.ResolvedPeers), got.Status.ResolvedPeers)
-	}
-	if got.Status.ResolvedPeers[0] != "other-node-0.other-node.default.svc.cluster.local" {
-		t.Errorf("resolvedPeers[0] = %q", got.Status.ResolvedPeers[0])
+	if node.Status.ResolvedPeers[0] != "other-node-0.other-node.default.svc.cluster.local" {
+		t.Errorf("resolvedPeers[0] = %q", node.Status.ResolvedPeers[0])
 	}
 }
 
@@ -134,20 +123,15 @@ func TestReconcilePeers_CrossNamespace_DoesNotExcludeMatchingName(t *testing.T) 
 		Spec: seiv1alpha1.SeiNodeSpec{ChainID: "test-1", Image: "sei:latest", FullNode: &seiv1alpha1.FullNodeSpec{}},
 	}
 
-	r, c := newNodeReconciler(t, node, peerSameName)
+	r, _ := newNodeReconciler(t, node, peerSameName)
 	ctx := context.Background()
 
-	if err := r.reconcilePeers(ctx, node); err != nil {
+	if _, err := r.reconcilePeers(ctx, node); err != nil {
 		t.Fatalf("reconcilePeers: %v", err)
 	}
 
-	got := &seiv1alpha1.SeiNode{}
-	if err := c.Get(ctx, types.NamespacedName{Name: "shared-name", Namespace: "ns-a"}, got); err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-
-	if len(got.Status.ResolvedPeers) != 1 {
-		t.Fatalf("expected 1 peer (same name, different ns), got %d: %v", len(got.Status.ResolvedPeers), got.Status.ResolvedPeers)
+	if len(node.Status.ResolvedPeers) != 1 {
+		t.Fatalf("expected 1 peer (same name, different ns), got %d: %v", len(node.Status.ResolvedPeers), node.Status.ResolvedPeers)
 	}
 }
 
@@ -179,7 +163,7 @@ func TestReconcilePeers_NoPatchWhenUnchanged(t *testing.T) {
 	r, _ := newNodeReconciler(t, node, peer)
 
 	// Should not error — resolved peers match, no patch needed
-	if err := r.reconcilePeers(context.Background(), node); err != nil {
+	if _, err := r.reconcilePeers(context.Background(), node); err != nil {
 		t.Fatalf("reconcilePeers: %v", err)
 	}
 }
@@ -199,7 +183,7 @@ func TestReconcilePeers_NoLabelSources_NoPatch(t *testing.T) {
 
 	r, _ := newNodeReconciler(t, node)
 
-	if err := r.reconcilePeers(context.Background(), node); err != nil {
+	if _, err := r.reconcilePeers(context.Background(), node); err != nil {
 		t.Fatalf("reconcilePeers: %v", err)
 	}
 	// No label sources means no resolved peers, no patch — just verifying no error
@@ -234,19 +218,14 @@ func TestReconcilePeers_DeduplicatesOverlappingSources(t *testing.T) {
 		Spec: seiv1alpha1.SeiNodeSpec{ChainID: "test-1", Image: "sei:latest", FullNode: &seiv1alpha1.FullNodeSpec{}},
 	}
 
-	r, c := newNodeReconciler(t, node, peer)
+	r, _ := newNodeReconciler(t, node, peer)
 	ctx := context.Background()
 
-	if err := r.reconcilePeers(ctx, node); err != nil {
+	if _, err := r.reconcilePeers(ctx, node); err != nil {
 		t.Fatalf("reconcilePeers: %v", err)
 	}
 
-	got := &seiv1alpha1.SeiNode{}
-	if err := c.Get(ctx, types.NamespacedName{Name: "my-node", Namespace: "default"}, got); err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-
-	if len(got.Status.ResolvedPeers) != 1 {
-		t.Fatalf("expected 1 deduplicated peer, got %d: %v", len(got.Status.ResolvedPeers), got.Status.ResolvedPeers)
+	if len(node.Status.ResolvedPeers) != 1 {
+		t.Fatalf("expected 1 deduplicated peer, got %d: %v", len(node.Status.ResolvedPeers), node.Status.ResolvedPeers)
 	}
 }

--- a/internal/controller/node/plan_execution_integration_test.go
+++ b/internal/controller/node/plan_execution_integration_test.go
@@ -12,13 +12,12 @@ import (
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/planner"
-	"github.com/sei-protocol/sei-k8s-controller/internal/task"
 )
 
-// driveTask submits one task and completes it. For fire-and-forget tasks
-// (config-validate, mark-ready, infrastructure tasks), the task completes
-// in a single ExecutePlan call. For normal tasks, mock results are set and
-// a second call is made.
+// driveTask submits one task and completes it via the full Reconcile pipeline.
+// For fire-and-forget tasks (config-validate, mark-ready, infrastructure tasks),
+// the task completes in a single reconcile. For normal sidecar tasks, mock
+// results are set and a second reconcile is made.
 func driveTask(
 	t *testing.T,
 	g Gomega,
@@ -37,8 +36,7 @@ func driveTask(
 	taskUUID, err := uuid.Parse(ct.ID)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	_, err = r.PlanExecutor.ExecutePlan(context.Background(), node, node.Status.Plan)
-	g.Expect(err).NotTo(HaveOccurred())
+	reconcileOnce(t, g, r, node.Name, node.Namespace)
 
 	// Check if already complete (fire-and-forget tasks complete in one call)
 	node = fetch()
@@ -54,9 +52,7 @@ func driveTask(
 			taskUUID: completedResult(taskUUID, taskType, nil),
 		}
 	}
-	node = fetch()
-	_, err = r.PlanExecutor.ExecutePlan(context.Background(), node, node.Status.Plan)
-	g.Expect(err).NotTo(HaveOccurred())
+	reconcileOnce(t, g, r, node.Name, node.Namespace)
 }
 
 // reconcileOnce runs a single Reconcile call for the given node.
@@ -81,30 +77,23 @@ func TestIntegrationFullProgressionSnapshotMode(t *testing.T) {
 		return n
 	}
 
-	// First Reconcile: ResolvePlan builds the plan and transitions to Initializing.
+	// First Reconcile: builds plan, transitions to Initializing, completes
+	// all synchronous infrastructure tasks, and submits the first sidecar task.
 	reconcileOnce(t, g, r, node.Name, node.Namespace)
 	node = fetch()
 	g.Expect(node.Status.Plan).NotTo(BeNil())
 	g.Expect(node.Status.Phase).To(Equal(seiv1alpha1.PhaseInitializing))
 
-	// Drive infrastructure tasks (fire-and-forget, complete in one call each).
-	driveTask(t, g, r, mock, fetch, task.TaskTypeEnsureDataPVC)
-	driveTask(t, g, r, mock, fetch, task.TaskTypeApplyStatefulSet)
-	driveTask(t, g, r, mock, fetch, task.TaskTypeApplyService)
-
-	// Drive sidecar tasks.
+	// Drive sidecar tasks (infrastructure tasks already completed in first reconcile).
 	driveTask(t, g, r, mock, fetch, planner.TaskSnapshotRestore)
 	driveTask(t, g, r, mock, fetch, planner.TaskConfigureGenesis)
 	driveTask(t, g, r, mock, fetch, planner.TaskConfigApply)
+	// Completing configure-state-sync also chain-completes the trailing
+	// fire-and-forget tasks (config-validate, mark-ready) and the plan,
+	// transitioning the node to Running.
 	driveTask(t, g, r, mock, fetch, planner.TaskConfigureStateSync)
-	driveTask(t, g, r, mock, fetch, planner.TaskConfigValidate)
-	driveTask(t, g, r, mock, fetch, planner.TaskMarkReady)
 
-	// Final ExecutePlan marks the plan complete and transitions to Running.
 	updated := fetch()
-	_, err := r.PlanExecutor.ExecutePlan(ctx, updated, updated.Status.Plan)
-	g.Expect(err).NotTo(HaveOccurred())
-	updated = fetch()
 	g.Expect(updated.Status.Phase).To(Equal(seiv1alpha1.PhaseRunning))
 }
 
@@ -122,27 +111,19 @@ func TestIntegrationFullProgressionGenesisMode(t *testing.T) {
 		return n
 	}
 
-	// First Reconcile: ResolvePlan builds the plan and transitions to Initializing.
+	// First Reconcile: builds plan, transitions to Initializing, completes
+	// all synchronous infrastructure tasks, and submits the first sidecar task.
 	reconcileOnce(t, g, r, node.Name, node.Namespace)
 	node = fetch()
 	g.Expect(node.Status.Plan).NotTo(BeNil())
 
-	// Drive infrastructure tasks.
-	driveTask(t, g, r, mock, fetch, task.TaskTypeEnsureDataPVC)
-	driveTask(t, g, r, mock, fetch, task.TaskTypeApplyStatefulSet)
-	driveTask(t, g, r, mock, fetch, task.TaskTypeApplyService)
-
-	// Drive sidecar tasks.
+	// Drive sidecar tasks (infrastructure tasks already completed in first reconcile).
 	driveTask(t, g, r, mock, fetch, planner.TaskConfigureGenesis)
+	// Completing config-apply also chain-completes the trailing fire-and-forget
+	// tasks (config-validate, mark-ready) and the plan, transitioning to Running.
 	driveTask(t, g, r, mock, fetch, planner.TaskConfigApply)
-	driveTask(t, g, r, mock, fetch, planner.TaskConfigValidate)
-	driveTask(t, g, r, mock, fetch, planner.TaskMarkReady)
 
-	// Final ExecutePlan marks the plan complete and transitions to Running.
 	updated := fetch()
-	_, err := r.PlanExecutor.ExecutePlan(ctx, updated, updated.Status.Plan)
-	g.Expect(err).NotTo(HaveOccurred())
-	updated = fetch()
 	g.Expect(updated.Status.Phase).To(Equal(seiv1alpha1.PhaseRunning))
 }
 
@@ -160,17 +141,13 @@ func TestIntegrationTaskFailure_FailsPlan(t *testing.T) {
 		return n
 	}
 
-	// First Reconcile: builds plan and transitions to Initializing.
+	// First Reconcile: builds plan, transitions to Initializing, completes
+	// all synchronous infrastructure tasks, and submits the first sidecar task.
 	reconcileOnce(t, g, r, node.Name, node.Namespace)
 	node = fetch()
 	g.Expect(node.Status.Plan).NotTo(BeNil())
 
-	// Drive infrastructure tasks past the fire-and-forget phase.
-	driveTask(t, g, r, mock, fetch, task.TaskTypeEnsureDataPVC)
-	driveTask(t, g, r, mock, fetch, task.TaskTypeApplyStatefulSet)
-	driveTask(t, g, r, mock, fetch, task.TaskTypeApplyService)
-
-	// Drive snapshot-restore: submit it.
+	// Drive snapshot-restore: the first reconcile already submitted it.
 	node = fetch()
 	ct := planner.CurrentTask(node.Status.Plan)
 	g.Expect(ct).NotTo(BeNil())
@@ -178,18 +155,15 @@ func TestIntegrationTaskFailure_FailsPlan(t *testing.T) {
 	taskUUID, err := uuid.Parse(ct.ID)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	_, err = r.PlanExecutor.ExecutePlan(ctx, node, node.Status.Plan)
-	g.Expect(err).NotTo(HaveOccurred())
+	reconcileOnce(t, g, r, node.Name, node.Namespace)
 
 	// Fail the snapshot-restore task.
 	mock.taskResults = map[uuid.UUID]*sidecar.TaskResult{
 		taskUUID: completedResult(taskUUID, planner.TaskSnapshotRestore, strPtr("S3 access denied")),
 	}
-	updated := fetch()
-	_, err = r.PlanExecutor.ExecutePlan(ctx, updated, updated.Status.Plan)
-	g.Expect(err).NotTo(HaveOccurred())
+	reconcileOnce(t, g, r, node.Name, node.Namespace)
 
-	updated = fetch()
+	updated := fetch()
 	g.Expect(updated.Status.Plan.Phase).To(Equal(seiv1alpha1.TaskPlanFailed))
 	g.Expect(updated.Status.Phase).To(Equal(seiv1alpha1.PhaseFailed))
 
@@ -199,9 +173,8 @@ func TestIntegrationTaskFailure_FailsPlan(t *testing.T) {
 	g.Expect(failedTask.Status).To(Equal(seiv1alpha1.TaskFailed))
 	g.Expect(failedTask.Error).To(Equal("S3 access denied"))
 
-	// Subsequent ExecutePlan is a no-op on failed plans.
+	// Subsequent reconcile is a no-op on failed plans.
 	mock.submitted = nil
-	_, err = r.PlanExecutor.ExecutePlan(ctx, updated, updated.Status.Plan)
-	g.Expect(err).NotTo(HaveOccurred())
+	reconcileOnce(t, g, r, node.Name, node.Namespace)
 	g.Expect(mock.submitted).To(BeEmpty())
 }

--- a/internal/controller/node/plan_execution_test.go
+++ b/internal/controller/node/plan_execution_test.go
@@ -113,7 +113,6 @@ func newProgressionReconciler(t *testing.T, mock *mockSidecarClient, objs ...cli
 		Recorder: record.NewFakeRecorder(100),
 		Platform: platformtest.Config(),
 		PlanExecutor: &planner.Executor[*seiv1alpha1.SeiNode]{
-			Client: c,
 			ConfigFor: func(_ context.Context, node *seiv1alpha1.SeiNode) task.ExecutionConfig {
 				return task.ExecutionConfig{
 					BuildSidecarClient: func() (task.SidecarClient, error) { return mock, nil },
@@ -437,7 +436,7 @@ func TestReconcile_SubmitsFirstPendingTask(t *testing.T) {
 	mock := &mockSidecarClient{}
 	node := snapshotNode()
 	mustBuildPlan(t, node)
-	r, c := newProgressionReconciler(t, mock, node)
+	r, _ := newProgressionReconciler(t, mock, node)
 	ctx := context.Background()
 
 	// First task is ensure-data-pvc (controller-side, no sidecar submission).
@@ -446,8 +445,7 @@ func TestReconcile_SubmitsFirstPendingTask(t *testing.T) {
 		t.Fatalf("error = %v", err)
 	}
 
-	updated := fetchNode(t, c, node.Name, node.Namespace)
-	firstTask := updated.Status.Plan.Tasks[0]
+	firstTask := node.Status.Plan.Tasks[0]
 	if firstTask.Type != task.TaskTypeEnsureDataPVC {
 		t.Errorf("first task = %q, want %q", firstTask.Type, task.TaskTypeEnsureDataPVC)
 	}
@@ -464,7 +462,7 @@ func TestReconcile_AllTasksComplete_MarksPlanComplete(t *testing.T) {
 		node.Status.Plan.Tasks[i].Status = seiv1alpha1.TaskComplete
 	}
 
-	r, c := newProgressionReconciler(t, mock, node)
+	r, _ := newProgressionReconciler(t, mock, node)
 	ctx := context.Background()
 
 	result, err := r.PlanExecutor.ExecutePlan(ctx, node, node.Status.Plan)
@@ -475,9 +473,8 @@ func TestReconcile_AllTasksComplete_MarksPlanComplete(t *testing.T) {
 		t.Error("expected requeue when marking plan complete")
 	}
 
-	updated := fetchNode(t, c, node.Name, node.Namespace)
-	if updated.Status.Plan.Phase != seiv1alpha1.TaskPlanComplete {
-		t.Errorf("plan phase = %q, want Complete", updated.Status.Plan.Phase)
+	if node.Status.Plan.Phase != seiv1alpha1.TaskPlanComplete {
+		t.Errorf("plan phase = %q, want Complete", node.Status.Plan.Phase)
 	}
 }
 
@@ -516,7 +513,7 @@ func TestReconcile_SubmitError_RequeuesGracefully(t *testing.T) {
 		}
 	}
 
-	r, c := newProgressionReconciler(t, mock, node)
+	r, _ := newProgressionReconciler(t, mock, node)
 	ctx := context.Background()
 
 	// The first sidecar task (snapshot-restore) will fail to submit.
@@ -527,8 +524,7 @@ func TestReconcile_SubmitError_RequeuesGracefully(t *testing.T) {
 	if result.RequeueAfter != planner.TaskPollInterval {
 		t.Errorf("RequeueAfter = %v, want %v", result.RequeueAfter, planner.TaskPollInterval)
 	}
-	updated := fetchNode(t, c, node.Name, node.Namespace)
-	snapshotTask := findPlannedTask(updated.Status.Plan, planner.TaskSnapshotRestore)
+	snapshotTask := findPlannedTask(node.Status.Plan, planner.TaskSnapshotRestore)
 	if snapshotTask == nil {
 		t.Fatal("expected snapshot-restore task in plan")
 	}
@@ -673,13 +669,12 @@ func TestExecutePlan_AllComplete_TransitionsToTargetPhase(t *testing.T) {
 		node.Status.Plan.Tasks[i].Status = seiv1alpha1.TaskComplete
 	}
 
-	r, c := newProgressionReconciler(t, mock, node)
+	r, _ := newProgressionReconciler(t, mock, node)
 	_, err := r.PlanExecutor.ExecutePlan(context.Background(), node, node.Status.Plan)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	updated := fetchNode(t, c, node.Name, node.Namespace)
-	g.Expect(updated.Status.Phase).To(Equal(seiv1alpha1.PhaseRunning), "executor should transition to TargetPhase")
-	g.Expect(updated.Status.Plan.Phase).To(Equal(seiv1alpha1.TaskPlanComplete))
+	g.Expect(node.Status.Phase).To(Equal(seiv1alpha1.PhaseRunning), "executor should transition to TargetPhase")
+	g.Expect(node.Status.Plan.Phase).To(Equal(seiv1alpha1.TaskPlanComplete))
 }
 
 func TestExecutePlan_ConvergencePlan_NilsOnCompletion(t *testing.T) {
@@ -697,13 +692,12 @@ func TestExecutePlan_ConvergencePlan_NilsOnCompletion(t *testing.T) {
 		node.Status.Plan.Tasks[i].Status = seiv1alpha1.TaskComplete
 	}
 
-	r, c := newProgressionReconciler(t, mock, node)
+	r, _ := newProgressionReconciler(t, mock, node)
 	_, err := r.PlanExecutor.ExecutePlan(context.Background(), node, node.Status.Plan)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	updated := fetchNode(t, c, node.Name, node.Namespace)
-	g.Expect(updated.Status.Plan).To(BeNil(), "convergence plan should be nilled after completion")
-	g.Expect(updated.Status.Phase).To(Equal(seiv1alpha1.PhaseRunning), "phase should stay Running")
+	g.Expect(node.Status.Plan).To(BeNil(), "convergence plan should be nilled after completion")
+	g.Expect(node.Status.Phase).To(Equal(seiv1alpha1.PhaseRunning), "phase should stay Running")
 }
 
 func TestExecutePlan_TaskFailure_SetsPlanFailedCondition(t *testing.T) {
@@ -719,7 +713,7 @@ func TestExecutePlan_TaskFailure_SetsPlanFailedCondition(t *testing.T) {
 			node.Status.Plan.Tasks[i].Status = seiv1alpha1.TaskComplete
 		}
 	}
-	r, c := newProgressionReconciler(t, mock, node)
+	r, _ := newProgressionReconciler(t, mock, node)
 	ctx := context.Background()
 
 	// Submit snapshot-restore.
@@ -734,16 +728,14 @@ func TestExecutePlan_TaskFailure_SetsPlanFailedCondition(t *testing.T) {
 	mock.taskResults = map[uuid.UUID]*sidecar.TaskResult{
 		taskUUID: completedResult(taskUUID, planner.TaskSnapshotRestore, strPtr("boom")),
 	}
-	node = fetchNode(t, c, node.Name, node.Namespace)
 	_, err = r.PlanExecutor.ExecutePlan(ctx, node, node.Status.Plan)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	updated := fetchNode(t, c, node.Name, node.Namespace)
-	g.Expect(updated.Status.Plan.Phase).To(Equal(seiv1alpha1.TaskPlanFailed))
+	g.Expect(node.Status.Plan.Phase).To(Equal(seiv1alpha1.TaskPlanFailed))
 
 	// Verify PlanFailed condition was set.
 	var found bool
-	for _, cond := range updated.Status.Conditions {
+	for _, cond := range node.Status.Conditions {
 		if cond.Type == planner.ConditionPlanFailed {
 			g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			g.Expect(cond.Reason).To(Equal("TaskFailed"))
@@ -786,7 +778,6 @@ func TestReconcileInitializing_SidecarClientError_Requeues(t *testing.T) {
 		Recorder: record.NewFakeRecorder(100),
 		Platform: platformtest.Config(),
 		PlanExecutor: &planner.Executor[*seiv1alpha1.SeiNode]{
-			Client: c,
 			ConfigFor: func(_ context.Context, n *seiv1alpha1.SeiNode) task.ExecutionConfig {
 				return task.ExecutionConfig{
 					BuildSidecarClient: func() (task.SidecarClient, error) {

--- a/internal/controller/node/reconciler_test.go
+++ b/internal/controller/node/reconciler_test.go
@@ -50,7 +50,6 @@ func newNodeReconciler(t *testing.T, objs ...client.Object) (*SeiNodeReconciler,
 		Recorder: record.NewFakeRecorder(100),
 		Platform: platformtest.Config(),
 		PlanExecutor: &planner.Executor[*seiv1alpha1.SeiNode]{
-			Client: c,
 			ConfigFor: func(_ context.Context, node *seiv1alpha1.SeiNode) task.ExecutionConfig {
 				return task.ExecutionConfig{
 					BuildSidecarClient: func() (task.SidecarClient, error) { return mock, nil },
@@ -259,10 +258,10 @@ func TestObserveCurrentImage_UpdatesWhenConverged(t *testing.T) {
 	g.Expect(c.Status().Update(ctx, sts)).To(Succeed())
 
 	r := &SeiNodeReconciler{Client: c, Scheme: s}
-	g.Expect(r.observeCurrentImage(ctx, node)).To(Succeed())
+	_, err := r.observeCurrentImage(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
 
-	fetched := getSeiNode(t, ctx, c, "mynet-0", "default")
-	g.Expect(fetched.Status.CurrentImage).To(Equal(testImageV2))
+	g.Expect(node.Status.CurrentImage).To(Equal(testImageV2))
 }
 
 func TestObserveCurrentImage_SkipsWhenStaleGeneration(t *testing.T) {
@@ -299,10 +298,10 @@ func TestObserveCurrentImage_SkipsWhenStaleGeneration(t *testing.T) {
 	g.Expect(c.Status().Update(ctx, sts)).To(Succeed())
 
 	r := &SeiNodeReconciler{Client: c, Scheme: s}
-	g.Expect(r.observeCurrentImage(ctx, node)).To(Succeed())
+	_, err := r.observeCurrentImage(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
 
-	fetched := getSeiNode(t, ctx, c, "mynet-0", "default")
-	g.Expect(fetched.Status.CurrentImage).To(BeEmpty())
+	g.Expect(node.Status.CurrentImage).To(BeEmpty())
 }
 
 func TestObserveCurrentImage_SkipsWhenRolling(t *testing.T) {
@@ -339,10 +338,10 @@ func TestObserveCurrentImage_SkipsWhenRolling(t *testing.T) {
 	g.Expect(c.Status().Update(ctx, sts)).To(Succeed())
 
 	r := &SeiNodeReconciler{Client: c, Scheme: s}
-	g.Expect(r.observeCurrentImage(ctx, node)).To(Succeed())
+	_, err := r.observeCurrentImage(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
 
-	fetched := getSeiNode(t, ctx, c, "mynet-0", "default")
-	g.Expect(fetched.Status.CurrentImage).To(BeEmpty())
+	g.Expect(node.Status.CurrentImage).To(BeEmpty())
 }
 
 func TestObserveCurrentImage_SkipsWhenReadyReplicasZero(t *testing.T) {
@@ -380,10 +379,10 @@ func TestObserveCurrentImage_SkipsWhenReadyReplicasZero(t *testing.T) {
 	g.Expect(c.Status().Update(ctx, sts)).To(Succeed())
 
 	r := &SeiNodeReconciler{Client: c, Scheme: s}
-	g.Expect(r.observeCurrentImage(ctx, node)).To(Succeed())
+	_, err := r.observeCurrentImage(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
 
-	fetched := getSeiNode(t, ctx, c, "mynet-0", "default")
-	g.Expect(fetched.Status.CurrentImage).To(BeEmpty())
+	g.Expect(node.Status.CurrentImage).To(BeEmpty())
 }
 
 func TestObserveCurrentImage_SkipsWhenEmptyRevision(t *testing.T) {
@@ -421,10 +420,10 @@ func TestObserveCurrentImage_SkipsWhenEmptyRevision(t *testing.T) {
 	g.Expect(c.Status().Update(ctx, sts)).To(Succeed())
 
 	r := &SeiNodeReconciler{Client: c, Scheme: s}
-	g.Expect(r.observeCurrentImage(ctx, node)).To(Succeed())
+	_, err := r.observeCurrentImage(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
 
-	fetched := getSeiNode(t, ctx, c, "mynet-0", "default")
-	g.Expect(fetched.Status.CurrentImage).To(BeEmpty())
+	g.Expect(node.Status.CurrentImage).To(BeEmpty())
 }
 
 func TestObserveCurrentImage_NoopWhenAlreadyCurrent(t *testing.T) {
@@ -463,10 +462,10 @@ func TestObserveCurrentImage_NoopWhenAlreadyCurrent(t *testing.T) {
 	g.Expect(c.Status().Update(ctx, sts)).To(Succeed())
 
 	r := &SeiNodeReconciler{Client: c, Scheme: s}
-	g.Expect(r.observeCurrentImage(ctx, node)).To(Succeed())
+	_, err := r.observeCurrentImage(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
 
-	fetched := getSeiNode(t, ctx, c, "mynet-0", "default")
-	g.Expect(fetched.Status.CurrentImage).To(Equal(testImageV2))
+	g.Expect(node.Status.CurrentImage).To(Equal(testImageV2))
 }
 
 func TestObserveCurrentImage_StatefulSetNotFound(t *testing.T) {
@@ -486,10 +485,10 @@ func TestObserveCurrentImage_StatefulSetNotFound(t *testing.T) {
 		Build()
 
 	r := &SeiNodeReconciler{Client: c, Scheme: s}
-	g.Expect(r.observeCurrentImage(ctx, node)).To(Succeed())
+	_, err := r.observeCurrentImage(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
 
-	fetched := getSeiNode(t, ctx, c, "mynet-0", "default")
-	g.Expect(fetched.Status.CurrentImage).To(BeEmpty())
+	g.Expect(node.Status.CurrentImage).To(BeEmpty())
 }
 
 func ptrInt32(v int32) *int32 { return &v }

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -109,7 +109,7 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("reconciling SeiNodes: %w", err)
 	}
 
-	planResult, planErr := r.reconcilePlan(ctx, group, statusBase)
+	planResult, planErr := r.reconcilePlan(ctx, group)
 	if planErr != nil {
 		logger.Error(planErr, "reconciling plan")
 		observability.ReconcileErrorsTotal.WithLabelValues(controllerName, ns, name).Inc()

--- a/internal/controller/nodedeployment/plan.go
+++ b/internal/controller/nodedeployment/plan.go
@@ -8,7 +8,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
@@ -17,8 +16,9 @@ import (
 
 // reconcilePlan is the single entry point for plan-driven orchestration.
 // It drives an active plan to completion, or builds a new plan if the
-// planner determines one is needed.
-func (r *SeiNodeDeploymentReconciler) reconcilePlan(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment, statusBase client.Patch) (ctrl.Result, error) {
+// planner determines one is needed. All status mutations are in-memory;
+// the caller flushes via a single status patch.
+func (r *SeiNodeDeploymentReconciler) reconcilePlan(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) (ctrl.Result, error) {
 	// Drive active plan.
 	if group.Status.Plan != nil && group.Status.Plan.Phase == seiv1alpha1.TaskPlanActive {
 		return r.drivePlan(ctx, group)
@@ -35,7 +35,8 @@ func (r *SeiNodeDeploymentReconciler) reconcilePlan(ctx context.Context, group *
 		return ctrl.Result{}, fmt.Errorf("building plan: %w", err)
 	}
 
-	return r.startPlan(ctx, group, statusBase, plan)
+	r.startPlan(ctx, group, plan)
+	return planner.ResultRequeueImmediate, nil
 }
 
 func (r *SeiNodeDeploymentReconciler) drivePlan(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) (ctrl.Result, error) {
@@ -46,47 +47,36 @@ func (r *SeiNodeDeploymentReconciler) drivePlan(ctx context.Context, group *seiv
 
 	switch group.Status.Plan.Phase {
 	case seiv1alpha1.TaskPlanComplete:
-		return r.completePlan(ctx, group)
+		r.completePlan(ctx, group)
 	case seiv1alpha1.TaskPlanFailed:
-		return r.failPlan(ctx, group)
+		r.failPlan(ctx, group)
 	}
 
 	return result, nil
 }
 
-func (r *SeiNodeDeploymentReconciler) startPlan(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment, statusBase client.Patch, plan *seiv1alpha1.TaskPlan) (ctrl.Result, error) {
+// startPlan stamps the plan onto the group and sets the PlanInProgress condition.
+// All mutations are in-memory.
+func (r *SeiNodeDeploymentReconciler) startPlan(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment, plan *seiv1alpha1.TaskPlan) {
 	logger := log.FromContext(ctx)
 
 	group.Status.Plan = plan
 	setPlanInProgress(group, "PlanStarted", "Plan execution started")
 
-	if err := r.Status().Patch(ctx, group, statusBase); err != nil {
-		return ctrl.Result{}, fmt.Errorf("writing plan status: %w", err)
-	}
-
 	r.Recorder.Event(group, corev1.EventTypeNormal, "PlanStarted", "Plan execution started")
 	logger.Info("plan started", "tasks", len(plan.Tasks))
-
-	return planner.ResultRequeueImmediate, nil
 }
 
-func (r *SeiNodeDeploymentReconciler) completePlan(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) (ctrl.Result, error) {
+// completePlan finalizes a completed plan. All mutations are in-memory.
+func (r *SeiNodeDeploymentReconciler) completePlan(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) {
 	logger := log.FromContext(ctx)
-
-	// Re-read to get a fresh resourceVersion. The plan executor patches
-	// status mid-reconcile (task/plan completion), which invalidates the
-	// statusBase computed at the start of Reconcile.
-	if err := r.Get(ctx, client.ObjectKeyFromObject(group), group); err != nil {
-		return ctrl.Result{}, fmt.Errorf("re-reading group for completePlan: %w", err)
-	}
-	status := client.MergeFromWithOptions(group.DeepCopy(), client.MergeFromWithOptimisticLock{})
 
 	isDeploymentPlan := group.Status.Rollout != nil
 
 	if isDeploymentPlan {
 		group.Status.ObservedGeneration = group.Generation
 		if err := r.reconcileNetworking(ctx, group); err != nil {
-			return ctrl.Result{}, fmt.Errorf("reconciling networking after deployment: %w", err)
+			logger.Error(err, "reconciling networking after deployment")
 		}
 		group.Status.Rollout = nil
 		setCondition(group, seiv1alpha1.ConditionRolloutInProgress, metav1.ConditionFalse,
@@ -104,20 +94,11 @@ func (r *SeiNodeDeploymentReconciler) completePlan(ctx context.Context, group *s
 
 	r.Recorder.Event(group, corev1.EventTypeNormal, "PlanComplete", "Plan completed successfully")
 	logger.Info("plan completed")
-
-	if err := r.updateStatus(ctx, group, status); err != nil {
-		return ctrl.Result{}, fmt.Errorf("updating status after plan completion: %w", err)
-	}
-	return planner.ResultRequeueImmediate, nil
 }
 
-func (r *SeiNodeDeploymentReconciler) failPlan(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) (ctrl.Result, error) {
+// failPlan handles a failed plan. All mutations are in-memory.
+func (r *SeiNodeDeploymentReconciler) failPlan(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) {
 	logger := log.FromContext(ctx)
-
-	if err := r.Get(ctx, client.ObjectKeyFromObject(group), group); err != nil {
-		return ctrl.Result{}, fmt.Errorf("re-reading group for failPlan: %w", err)
-	}
-	status := client.MergeFromWithOptions(group.DeepCopy(), client.MergeFromWithOptimisticLock{})
 
 	group.Status.Phase = seiv1alpha1.GroupPhaseDegraded
 	group.Status.Plan = nil
@@ -130,11 +111,6 @@ func (r *SeiNodeDeploymentReconciler) failPlan(ctx context.Context, group *seiv1
 
 	r.Recorder.Event(group, corev1.EventTypeWarning, "PlanFailed", "Plan failed")
 	logger.Info("plan failed")
-
-	if err := r.updateStatus(ctx, group, status); err != nil {
-		return ctrl.Result{}, fmt.Errorf("updating status after plan failure: %w", err)
-	}
-	return planner.ResultRequeueImmediate, nil
 }
 
 func setPlanInProgress(group *seiv1alpha1.SeiNodeDeployment, reason, message string) {

--- a/internal/controller/nodedeployment/plan_test.go
+++ b/internal/controller/nodedeployment/plan_test.go
@@ -28,7 +28,7 @@ func newPlanTestScheme(t *testing.T) *k8sruntime.Scheme {
 	return s
 }
 
-func newPlanTestReconciler(t *testing.T, objs ...client.Object) (*SeiNodeDeploymentReconciler, client.Client) {
+func newPlanTestReconciler(t *testing.T, objs ...client.Object) *SeiNodeDeploymentReconciler {
 	t.Helper()
 	s := newPlanTestScheme(t)
 	c := fake.NewClientBuilder().
@@ -36,12 +36,11 @@ func newPlanTestReconciler(t *testing.T, objs ...client.Object) (*SeiNodeDeploym
 		WithObjects(objs...).
 		WithStatusSubresource(&seiv1alpha1.SeiNodeDeployment{}).
 		Build()
-	r := &SeiNodeDeploymentReconciler{
+	return &SeiNodeDeploymentReconciler{
 		Client:   c,
 		Scheme:   s,
 		Recorder: record.NewFakeRecorder(100),
 	}
-	return r, c
 }
 
 func TestCompletePlan_ClearsRolloutInProgress(t *testing.T) {
@@ -76,23 +75,19 @@ func TestCompletePlan_ClearsRolloutInProgress(t *testing.T) {
 		Status: seiv1alpha1.SeiNodeStatus{Phase: seiv1alpha1.PhaseRunning},
 	}
 
-	r, c := newPlanTestReconciler(t, group, childNode)
+	r := newPlanTestReconciler(t, group, childNode)
 
-	_, err := r.completePlan(ctx, group)
-	g.Expect(err).NotTo(HaveOccurred())
+	r.completePlan(ctx, group)
 
-	fetched := &seiv1alpha1.SeiNodeDeployment{}
-	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(group), fetched)).To(Succeed())
+	g.Expect(group.Status.Rollout).To(BeNil())
+	g.Expect(group.Status.Plan).To(BeNil())
 
-	g.Expect(fetched.Status.Rollout).To(BeNil())
-	g.Expect(fetched.Status.Plan).To(BeNil())
-
-	rolloutCond := apimeta.FindStatusCondition(fetched.Status.Conditions, seiv1alpha1.ConditionRolloutInProgress)
+	rolloutCond := apimeta.FindStatusCondition(group.Status.Conditions, seiv1alpha1.ConditionRolloutInProgress)
 	g.Expect(rolloutCond).NotTo(BeNil())
 	g.Expect(rolloutCond.Status).To(Equal(metav1.ConditionFalse))
 	g.Expect(rolloutCond.Reason).To(Equal("RolloutComplete"))
 
-	planCond := apimeta.FindStatusCondition(fetched.Status.Conditions, seiv1alpha1.ConditionPlanInProgress)
+	planCond := apimeta.FindStatusCondition(group.Status.Conditions, seiv1alpha1.ConditionPlanInProgress)
 	g.Expect(planCond).NotTo(BeNil())
 	g.Expect(planCond.Status).To(Equal(metav1.ConditionFalse))
 }
@@ -145,24 +140,20 @@ func TestFailPlan_ClearsRolloutInProgress(t *testing.T) {
 		Status: seiv1alpha1.SeiNodeStatus{Phase: seiv1alpha1.PhaseFailed},
 	}
 
-	r, c := newPlanTestReconciler(t, group, childRunning, childFailed, childFailed2)
+	r := newPlanTestReconciler(t, group, childRunning, childFailed, childFailed2)
 
-	_, err := r.failPlan(ctx, group)
-	g.Expect(err).NotTo(HaveOccurred())
+	r.failPlan(ctx, group)
 
-	fetched := &seiv1alpha1.SeiNodeDeployment{}
-	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(group), fetched)).To(Succeed())
+	g.Expect(group.Status.Rollout).To(BeNil())
+	g.Expect(group.Status.Plan).To(BeNil())
+	g.Expect(group.Status.Phase).To(Equal(seiv1alpha1.GroupPhaseDegraded))
 
-	g.Expect(fetched.Status.Rollout).To(BeNil())
-	g.Expect(fetched.Status.Plan).To(BeNil())
-	g.Expect(fetched.Status.Phase).To(Equal(seiv1alpha1.GroupPhaseDegraded))
-
-	rolloutCond := apimeta.FindStatusCondition(fetched.Status.Conditions, seiv1alpha1.ConditionRolloutInProgress)
+	rolloutCond := apimeta.FindStatusCondition(group.Status.Conditions, seiv1alpha1.ConditionRolloutInProgress)
 	g.Expect(rolloutCond).NotTo(BeNil())
 	g.Expect(rolloutCond.Status).To(Equal(metav1.ConditionFalse))
 	g.Expect(rolloutCond.Reason).To(Equal("RolloutFailed"))
 
-	planCond := apimeta.FindStatusCondition(fetched.Status.Conditions, seiv1alpha1.ConditionPlanInProgress)
+	planCond := apimeta.FindStatusCondition(group.Status.Conditions, seiv1alpha1.ConditionPlanInProgress)
 	g.Expect(planCond).NotTo(BeNil())
 	g.Expect(planCond.Status).To(Equal(metav1.ConditionFalse))
 }

--- a/internal/planner/executor.go
+++ b/internal/planner/executor.go
@@ -121,8 +121,6 @@ func executePlan(
 		if t.Status != seiv1alpha1.TaskComplete {
 			return result, nil
 		}
-
-		// Task completed synchronously — continue to the next task.
 	}
 }
 
@@ -143,7 +141,7 @@ func advanceTask(
 
 	exec, err := task.Deserialize(t.Type, t.ID, paramsRaw, cfg)
 	if err != nil {
-		failTask(obj, cn, plan, t, err.Error())
+		failTask(ctx, obj, cn, plan, t, err.Error())
 		return ctrl.Result{}
 	}
 
@@ -151,7 +149,7 @@ func advanceTask(
 		if err := exec.Execute(ctx); err != nil {
 			var termErr *task.TerminalError
 			if errors.As(err, &termErr) {
-				failTask(obj, cn, plan, t, err.Error())
+				failTask(ctx, obj, cn, plan, t, err.Error())
 				return ctrl.Result{}
 			}
 			log.FromContext(ctx).Info("task execution failed, will retry",
@@ -190,7 +188,7 @@ func advanceTask(
 				"task", t.Type, "retry", t.RetryCount, "maxRetries", t.MaxRetries, "lastError", errMsg)
 			return ctrl.Result{RequeueAfter: retryBackoff(t.RetryCount)}
 		}
-		failTask(obj, cn, plan, t, errMsg)
+		failTask(ctx, obj, cn, plan, t, errMsg)
 		return ctrl.Result{}
 
 	default:
@@ -202,13 +200,14 @@ func advanceTask(
 // Sets FailedPhase on the node and a PlanFailed condition. All mutations
 // are in-memory.
 func failTask(
+	ctx context.Context,
 	obj client.Object,
 	controller string,
 	plan *seiv1alpha1.TaskPlan,
 	t *seiv1alpha1.PlannedTask,
 	errMsg string,
 ) {
-	log.Log.Error(fmt.Errorf("task failed: %s", errMsg), "task plan failed", "task", t.Type)
+	log.FromContext(ctx).Error(fmt.Errorf("task failed: %s", errMsg), "task plan failed", "task", t.Type)
 
 	taskFailuresTotal.WithLabelValues(controller, obj.GetNamespace(), t.Type).Inc()
 

--- a/internal/planner/executor.go
+++ b/internal/planner/executor.go
@@ -114,10 +114,7 @@ func executePlan(
 			return ResultRequeueImmediate, nil
 		}
 
-		result, err := advanceTask(ctx, obj, cn, plan, t, cfg)
-		if err != nil {
-			return result, err
-		}
+		result := advanceTask(ctx, obj, cn, plan, t, cfg)
 
 		// If the task is not yet complete, stop the loop — the result
 		// carries the appropriate requeue interval.
@@ -138,7 +135,7 @@ func advanceTask(
 	plan *seiv1alpha1.TaskPlan,
 	t *seiv1alpha1.PlannedTask,
 	cfg task.ExecutionConfig,
-) (ctrl.Result, error) {
+) ctrl.Result {
 	var paramsRaw []byte
 	if t.Params != nil {
 		paramsRaw = t.Params.Raw
@@ -147,7 +144,7 @@ func advanceTask(
 	exec, err := task.Deserialize(t.Type, t.ID, paramsRaw, cfg)
 	if err != nil {
 		failTask(obj, cn, plan, t, err.Error())
-		return ctrl.Result{}, nil
+		return ctrl.Result{}
 	}
 
 	if needsSubmission(t) {
@@ -155,11 +152,11 @@ func advanceTask(
 			var termErr *task.TerminalError
 			if errors.As(err, &termErr) {
 				failTask(obj, cn, plan, t, err.Error())
-				return ctrl.Result{}, nil
+				return ctrl.Result{}
 			}
 			log.FromContext(ctx).Info("task execution failed, will retry",
 				"task", t.Type, "error", err)
-			return ctrl.Result{RequeueAfter: TaskPollInterval}, nil
+			return ctrl.Result{RequeueAfter: TaskPollInterval}
 		}
 		if t.SubmittedAt == nil {
 			now := metav1.Now()
@@ -172,11 +169,11 @@ func advanceTask(
 
 	switch status {
 	case task.ExecutionRunning:
-		return ctrl.Result{RequeueAfter: TaskPollInterval}, nil
+		return ctrl.Result{RequeueAfter: TaskPollInterval}
 
 	case task.ExecutionComplete:
 		t.Status = seiv1alpha1.TaskComplete
-		return ResultRequeueImmediate, nil
+		return ResultRequeueImmediate
 
 	case task.ExecutionFailed:
 		errMsg := "unknown error"
@@ -191,13 +188,13 @@ func advanceTask(
 			t.SubmittedAt = nil
 			log.FromContext(ctx).Info("retrying failed task",
 				"task", t.Type, "retry", t.RetryCount, "maxRetries", t.MaxRetries, "lastError", errMsg)
-			return ctrl.Result{RequeueAfter: retryBackoff(t.RetryCount)}, nil
+			return ctrl.Result{RequeueAfter: retryBackoff(t.RetryCount)}
 		}
 		failTask(obj, cn, plan, t, errMsg)
-		return ctrl.Result{}, nil
+		return ctrl.Result{}
 
 	default:
-		return ctrl.Result{RequeueAfter: TaskPollInterval}, nil
+		return ctrl.Result{RequeueAfter: TaskPollInterval}
 	}
 }
 

--- a/internal/planner/executor.go
+++ b/internal/planner/executor.go
@@ -36,23 +36,21 @@ type PlanExecutor[T client.Object] interface {
 
 // Executor[T] is the concrete implementation of PlanExecutor. It is stateless
 // per reconcile — each call re-deserializes the current task from the plan's
-// embedded params and calls Status/Execute.
+// embedded params and calls Execute/Status.
+//
+// ExecutePlan performs all mutations in-memory on the owning object. The
+// caller is responsible for persisting status changes via a single patch.
 //
 // ConfigFor is a factory that builds the ExecutionConfig for the given
 // resource. This is where the sidecar client, kube client, and other
-// dependencies are resolved per-reconcile. The context is forwarded from
-// the reconcile call in case the factory needs to make API calls.
+// dependencies are resolved per-reconcile.
 type Executor[T client.Object] struct {
-	Client    client.Client
 	ConfigFor func(ctx context.Context, obj T) task.ExecutionConfig
 }
 
 // needsSubmission reports whether the task should be submitted (or resubmitted)
 // to the sidecar. This is true when the CRD task status is Pending, which
-// covers both first-time submission and retries after failure. We submit
-// before polling Status because the sidecar may still hold a stale Failed
-// result from a previous run — the sidecar's cloud-API Submit transparently
-// re-executes failed tasks when resubmitted with the same stable ID.
+// covers both first-time submission and retries after failure.
 func needsSubmission(t *seiv1alpha1.PlannedTask) bool {
 	return t.Status == seiv1alpha1.TaskPending
 }
@@ -68,9 +66,10 @@ func CurrentTask(plan *seiv1alpha1.TaskPlan) *seiv1alpha1.PlannedTask {
 	return nil
 }
 
-// ExecutePlan drives a TaskPlan one step forward. The plan pointer must
-// reference a field inside the object's status so that status patches
-// capture mutations.
+// ExecutePlan drives a TaskPlan forward, mutating obj's status in-memory.
+// Synchronous tasks (those that complete within Execute) advance in a loop
+// so that multiple fire-and-forget tasks complete in a single reconcile.
+// The caller is responsible for persisting all status mutations.
 func (e *Executor[T]) ExecutePlan(
 	ctx context.Context,
 	obj T,
@@ -82,14 +81,14 @@ func (e *Executor[T]) ExecutePlan(
 	}
 
 	cfg := e.ConfigFor(ctx, obj)
-	return executePlan(ctx, e.Client, obj, plan, cfg)
+	return executePlan(ctx, obj, plan, cfg)
 }
 
-// executePlan is the core plan execution loop. It deserializes the current
-// task, polls/submits it, and patches the owning object's status.
+// executePlan is the core plan execution loop. It advances synchronous tasks
+// in sequence, stopping at the first async (Running) task, error, or when
+// the plan completes. All mutations are in-memory.
 func executePlan(
 	ctx context.Context,
-	kc client.Client,
 	obj client.Object,
 	plan *seiv1alpha1.TaskPlan,
 	cfg task.ExecutionConfig,
@@ -101,23 +100,45 @@ func executePlan(
 		return ctrl.Result{}, nil
 	}
 
-	// Mark the plan as active for this resource.
 	planActive.WithLabelValues(cn, obj.GetNamespace(), obj.GetName()).Set(1)
 
-	t := CurrentTask(plan)
-	if t == nil {
-		prevPhase := currentPhase(obj)
-		patch := client.MergeFromWithOptions(obj.DeepCopyObject().(client.Object), client.MergeFromWithOptimisticLock{})
-		plan.Phase = seiv1alpha1.TaskPlanComplete
-		setTargetPhase(obj, plan.TargetPhase)
-		clearCompletedConvergencePlan(obj, prevPhase, plan.TargetPhase)
-		if err := kc.Status().Patch(ctx, obj, patch); err != nil {
-			return ctrl.Result{}, fmt.Errorf("marking plan complete: %w", err)
+	for {
+		t := CurrentTask(plan)
+		if t == nil {
+			// All tasks complete — finalize the plan.
+			prevPhase := currentPhase(obj)
+			plan.Phase = seiv1alpha1.TaskPlanComplete
+			setTargetPhase(obj, plan.TargetPhase)
+			clearCompletedConvergencePlan(obj, prevPhase, plan.TargetPhase)
+			planActive.WithLabelValues(cn, obj.GetNamespace(), obj.GetName()).Set(0)
+			return ResultRequeueImmediate, nil
 		}
-		planActive.WithLabelValues(cn, obj.GetNamespace(), obj.GetName()).Set(0)
-		return ResultRequeueImmediate, nil
-	}
 
+		result, err := advanceTask(ctx, obj, cn, plan, t, cfg)
+		if err != nil {
+			return result, err
+		}
+
+		// If the task is not yet complete, stop the loop — the result
+		// carries the appropriate requeue interval.
+		if t.Status != seiv1alpha1.TaskComplete {
+			return result, nil
+		}
+
+		// Task completed synchronously — continue to the next task.
+	}
+}
+
+// advanceTask drives a single task one step forward: submit if pending,
+// then check status. All mutations are in-memory.
+func advanceTask(
+	ctx context.Context,
+	obj client.Object,
+	cn string,
+	plan *seiv1alpha1.TaskPlan,
+	t *seiv1alpha1.PlannedTask,
+	cfg task.ExecutionConfig,
+) (ctrl.Result, error) {
 	var paramsRaw []byte
 	if t.Params != nil {
 		paramsRaw = t.Params.Raw
@@ -125,14 +146,16 @@ func executePlan(
 
 	exec, err := task.Deserialize(t.Type, t.ID, paramsRaw, cfg)
 	if err != nil {
-		return failTask(ctx, kc, obj, cn, plan, t, err.Error())
+		failTask(obj, cn, plan, t, err.Error())
+		return ctrl.Result{}, nil
 	}
 
 	if needsSubmission(t) {
 		if err := exec.Execute(ctx); err != nil {
 			var termErr *task.TerminalError
 			if errors.As(err, &termErr) {
-				return failTask(ctx, kc, obj, cn, plan, t, err.Error())
+				failTask(obj, cn, plan, t, err.Error())
+				return ctrl.Result{}, nil
 			}
 			log.FromContext(ctx).Info("task execution failed, will retry",
 				"task", t.Type, "error", err)
@@ -142,7 +165,7 @@ func executePlan(
 			now := metav1.Now()
 			t.SubmittedAt = &now
 		}
-		log.FromContext(ctx).Info("task submitted to sidecar", "task", t.Type, "id", t.ID)
+		log.FromContext(ctx).Info("task submitted", "task", t.Type, "id", t.ID)
 	}
 
 	status := exec.Status(ctx)
@@ -152,11 +175,7 @@ func executePlan(
 		return ctrl.Result{RequeueAfter: TaskPollInterval}, nil
 
 	case task.ExecutionComplete:
-		patch := client.MergeFromWithOptions(obj.DeepCopyObject().(client.Object), client.MergeFromWithOptimisticLock{})
 		t.Status = seiv1alpha1.TaskComplete
-		if err := kc.Status().Patch(ctx, obj, patch); err != nil {
-			return ctrl.Result{}, fmt.Errorf("marking task complete: %w", err)
-		}
 		return ResultRequeueImmediate, nil
 
 	case task.ExecutionFailed:
@@ -166,19 +185,16 @@ func executePlan(
 		}
 		if t.MaxRetries > 0 && t.RetryCount < t.MaxRetries {
 			taskRetriesTotal.WithLabelValues(cn, obj.GetNamespace(), t.Type).Inc()
-			patch := client.MergeFromWithOptions(obj.DeepCopyObject().(client.Object), client.MergeFromWithOptimisticLock{})
 			t.RetryCount++
 			t.Status = seiv1alpha1.TaskPending
 			t.Error = ""
 			t.SubmittedAt = nil
 			log.FromContext(ctx).Info("retrying failed task",
 				"task", t.Type, "retry", t.RetryCount, "maxRetries", t.MaxRetries, "lastError", errMsg)
-			if err := kc.Status().Patch(ctx, obj, patch); err != nil {
-				return ctrl.Result{}, fmt.Errorf("resetting task for retry: %w", err)
-			}
 			return ctrl.Result{RequeueAfter: retryBackoff(t.RetryCount)}, nil
 		}
-		return failTask(ctx, kc, obj, cn, plan, t, errMsg)
+		failTask(obj, cn, plan, t, errMsg)
+		return ctrl.Result{}, nil
 
 	default:
 		return ctrl.Result{RequeueAfter: TaskPollInterval}, nil
@@ -186,21 +202,19 @@ func executePlan(
 }
 
 // failTask marks an individual task and the overall plan as Failed.
-// It sets the FailedPhase on the node and a PlanFailed condition.
+// Sets FailedPhase on the node and a PlanFailed condition. All mutations
+// are in-memory.
 func failTask(
-	ctx context.Context,
-	kc client.Client,
 	obj client.Object,
 	controller string,
 	plan *seiv1alpha1.TaskPlan,
 	t *seiv1alpha1.PlannedTask,
 	errMsg string,
-) (ctrl.Result, error) {
-	log.FromContext(ctx).Error(fmt.Errorf("task failed: %s", errMsg), "task plan failed", "task", t.Type)
+) {
+	log.Log.Error(fmt.Errorf("task failed: %s", errMsg), "task plan failed", "task", t.Type)
 
 	taskFailuresTotal.WithLabelValues(controller, obj.GetNamespace(), t.Type).Inc()
 
-	patch := client.MergeFromWithOptions(obj.DeepCopyObject().(client.Object), client.MergeFromWithOptimisticLock{})
 	t.Status = seiv1alpha1.TaskFailed
 	t.Error = errMsg
 	plan.Phase = seiv1alpha1.TaskPlanFailed
@@ -219,11 +233,7 @@ func failTask(
 		RetryCount: t.RetryCount,
 		MaxRetries: t.MaxRetries,
 	}
-	if err := kc.Status().Patch(ctx, obj, patch); err != nil {
-		return ctrl.Result{}, fmt.Errorf("marking task failed: %w", err)
-	}
 	planActive.WithLabelValues(controller, obj.GetNamespace(), obj.GetName()).Set(0)
-	return ctrl.Result{}, nil
 }
 
 // retryBackoff returns an exponential backoff duration capped at maxRetryBackoff.
@@ -269,9 +279,9 @@ func currentPhase(obj client.Object) seiv1alpha1.SeiNodePhase {
 	return ""
 }
 
-// clearCompletedConvergencePlan nils the plan on the object's status when the plan's
-// target phase matches the phase the node was already in before the plan
-// completed (convergence — the node stays in the same phase). Init plans
+// clearCompletedConvergencePlan nils the plan on the object's status when the
+// plan's target phase matches the phase the node was already in before the
+// plan completed (convergence — the node stays in the same phase). Init plans
 // that transition to a new phase keep their completed plan visible in status.
 func clearCompletedConvergencePlan(obj client.Object, prevPhase, targetPhase seiv1alpha1.SeiNodePhase) {
 	if targetPhase == "" {

--- a/internal/planner/executor_test.go
+++ b/internal/planner/executor_test.go
@@ -13,7 +13,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -97,7 +96,6 @@ func configGenesisParams(t *testing.T) *apiextensionsv1.JSON {
 func nodeExecutor(c *fake.ClientBuilder, s *k8sruntime.Scheme, mock *mockSidecarClient) *Executor[*seiv1alpha1.SeiNode] {
 	fc := c.Build()
 	return &Executor[*seiv1alpha1.SeiNode]{
-		Client: fc,
 		ConfigFor: func(_ context.Context, node *seiv1alpha1.SeiNode) task.ExecutionConfig {
 			return task.ExecutionConfig{
 				BuildSidecarClient: func() (task.SidecarClient, error) { return mock, nil },
@@ -159,12 +157,8 @@ func TestExecutePlan_RetryOnFailure(t *testing.T) {
 		t.Fatalf("expected 1 submission, got %d", len(mock.submitted))
 	}
 
-	updated := &seiv1alpha1.SeiNode{}
-	if err := executor.Client.Get(ctx, keyFor(node), updated); err != nil {
-		t.Fatalf("get node: %v", err)
-	}
-
-	tsk := &updated.Status.Plan.Tasks[0]
+	// Executor mutates in-memory — assert directly on the node.
+	tsk := &node.Status.Plan.Tasks[0]
 	if tsk.Status != seiv1alpha1.TaskPending {
 		t.Errorf("task status = %q, want Pending (reset for retry)", tsk.Status)
 	}
@@ -174,7 +168,7 @@ func TestExecutePlan_RetryOnFailure(t *testing.T) {
 	if tsk.ID != taskID {
 		t.Errorf("task ID changed after retry: got %q, want %q", tsk.ID, taskID)
 	}
-	if updated.Status.Plan.Phase == seiv1alpha1.TaskPlanFailed {
+	if node.Status.Plan.Phase == seiv1alpha1.TaskPlanFailed {
 		t.Error("plan should NOT be failed — retries remain")
 	}
 	if result.RequeueAfter == 0 {
@@ -229,34 +223,30 @@ func TestExecutePlan_ExhaustedRetries_FailsPlan(t *testing.T) {
 		t.Fatalf("ExecutePlan: %v", err)
 	}
 
-	updated := &seiv1alpha1.SeiNode{}
-	if err := executor.Client.Get(ctx, keyFor(node), updated); err != nil {
-		t.Fatalf("get node: %v", err)
+	// Executor mutates in-memory — assert directly on the node.
+	if node.Status.Plan.Phase != seiv1alpha1.TaskPlanFailed {
+		t.Errorf("plan phase = %q, want Failed", node.Status.Plan.Phase)
 	}
-
-	if updated.Status.Plan.Phase != seiv1alpha1.TaskPlanFailed {
-		t.Errorf("plan phase = %q, want Failed", updated.Status.Plan.Phase)
+	if node.Status.Plan.Tasks[0].Status != seiv1alpha1.TaskFailed {
+		t.Errorf("task status = %q, want Failed", node.Status.Plan.Tasks[0].Status)
 	}
-	if updated.Status.Plan.Tasks[0].Status != seiv1alpha1.TaskFailed {
-		t.Errorf("task status = %q, want Failed", updated.Status.Plan.Tasks[0].Status)
-	}
-	if updated.Status.Plan.FailedTaskIndex == nil {
+	if node.Status.Plan.FailedTaskIndex == nil {
 		t.Fatal("FailedTaskIndex should not be nil")
 	}
-	if *updated.Status.Plan.FailedTaskIndex != 0 {
-		t.Errorf("FailedTaskIndex = %d, want 0", *updated.Status.Plan.FailedTaskIndex)
+	if *node.Status.Plan.FailedTaskIndex != 0 {
+		t.Errorf("FailedTaskIndex = %d, want 0", *node.Status.Plan.FailedTaskIndex)
 	}
-	if updated.Status.Plan.FailedTaskDetail == nil {
+	if node.Status.Plan.FailedTaskDetail == nil {
 		t.Fatal("FailedTaskDetail should not be nil")
 	}
-	if updated.Status.Plan.FailedTaskDetail.Type != sidecar.TaskTypeConfigureGenesis {
-		t.Errorf("FailedTaskDetail.Type = %q, want %q", updated.Status.Plan.FailedTaskDetail.Type, sidecar.TaskTypeConfigureGenesis)
+	if node.Status.Plan.FailedTaskDetail.Type != sidecar.TaskTypeConfigureGenesis {
+		t.Errorf("FailedTaskDetail.Type = %q, want %q", node.Status.Plan.FailedTaskDetail.Type, sidecar.TaskTypeConfigureGenesis)
 	}
-	if updated.Status.Plan.FailedTaskDetail.RetryCount != 2 {
-		t.Errorf("FailedTaskDetail.RetryCount = %d, want 2", updated.Status.Plan.FailedTaskDetail.RetryCount)
+	if node.Status.Plan.FailedTaskDetail.RetryCount != 2 {
+		t.Errorf("FailedTaskDetail.RetryCount = %d, want 2", node.Status.Plan.FailedTaskDetail.RetryCount)
 	}
-	if updated.Status.Plan.FailedTaskDetail.MaxRetries != 2 {
-		t.Errorf("FailedTaskDetail.MaxRetries = %d, want 2", updated.Status.Plan.FailedTaskDetail.MaxRetries)
+	if node.Status.Plan.FailedTaskDetail.MaxRetries != 2 {
+		t.Errorf("FailedTaskDetail.MaxRetries = %d, want 2", node.Status.Plan.FailedTaskDetail.MaxRetries)
 	}
 }
 
@@ -311,7 +301,6 @@ func TestExecuteGroupPlan_CompletesSuccessfully(t *testing.T) {
 		Build()
 
 	executor := &Executor[*seiv1alpha1.SeiNodeDeployment]{
-		Client: fc,
 		ConfigFor: func(_ context.Context, g *seiv1alpha1.SeiNodeDeployment) task.ExecutionConfig {
 			return task.ExecutionConfig{
 				BuildSidecarClient: func() (task.SidecarClient, error) { return mock, nil },
@@ -332,13 +321,9 @@ func TestExecuteGroupPlan_CompletesSuccessfully(t *testing.T) {
 		t.Fatalf("expected 1 submission, got %d", len(mock.submitted))
 	}
 
-	updated := &seiv1alpha1.SeiNodeDeployment{}
-	if err := fc.Get(ctx, keyForGroup(group), updated); err != nil {
-		t.Fatalf("get group: %v", err)
-	}
-
-	if updated.Status.Plan.Tasks[0].Status != seiv1alpha1.TaskComplete {
-		t.Errorf("task status = %q, want Complete", updated.Status.Plan.Tasks[0].Status)
+	// Executor mutates in-memory — assert directly on the group.
+	if group.Status.Plan.Tasks[0].Status != seiv1alpha1.TaskComplete {
+		t.Errorf("task status = %q, want Complete", group.Status.Plan.Tasks[0].Status)
 	}
 	if result.RequeueAfter == 0 {
 		t.Error("expected non-zero RequeueAfter after task completion")
@@ -358,11 +343,3 @@ func TestRetryBackoff(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
-
-func keyFor(node *seiv1alpha1.SeiNode) types.NamespacedName {
-	return types.NamespacedName{Name: node.Name, Namespace: node.Namespace}
-}
-
-func keyForGroup(group *seiv1alpha1.SeiNodeDeployment) types.NamespacedName {
-	return types.NamespacedName{Name: group.Name, Namespace: group.Namespace}
-}


### PR DESCRIPTION
## Summary

Both controllers now accumulate all status mutations in-memory and flush with a single `Status().Patch()` at the end of Reconcile. This eliminates the class of optimistic lock conflicts between tasks and the executor, and establishes a clean ownership model.

- **Executor**: Removes `Client` field entirely — pure in-memory mutation engine. Synchronous tasks advance in a loop without intermediate patches. `failTask` is void.
- **Node controller**: Single `statusBase` captured after finalizer. `reconcilePeers` and `observeCurrentImage` return dirty flags. One flush at the end.
- **NodeDeployment controller**: `completePlan`/`failPlan` are now void in-memory mutations. No more re-read after executor patches (because there are none).

### Ownership model

| Layer | Writes to |
|-------|-----------|
| Tasks | Owned resources (StatefulSets, Services, PVCs, sidecar) |
| Executor | In-memory plan state on owning resource |
| Reconciler | Single `Status().Patch()` flush at end |

### What this unblocks

Tasks can now freely mutate the owning resource's status fields (e.g., `status.currentImage`, conditions) because everything is in-memory until the flush. This is the foundation for NodeUpdate plans where tasks need to set conditions and stamp image state.

## Test plan

- [x] `make build` — compiles cleanly
- [x] `make test` — all tests pass (84.6% node controller, 43.5% planner, 32.9% nodedeployment)
- [x] `make lint` — zero issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)