### PR TITLE
chore: bump controller image to 20a1a90

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:da0ae1bbfd60a0d7cf632c66990e68bfe33a3da8
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:20a1a9038725109d434f3940797200afaf75aa44
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Picks up the post-#99 controller binary that introduced the `SeiNodeDeployment.status.internalService` field and the per-deployment ClusterIP Service for stateless in-cluster access.

## What changes in-cluster

- `SeiNodeDeployment` controller starts provisioning a per-deployment `{name}-internal` ClusterIP Service selecting all child node pods (rpc/evm-http/rest ports only — stateful protocols deliberately excluded).
- `.status.internalService.{name,namespace,ports.*}` is now populated.
- Purely additive for existing deployments; no behavior change to `.spec.networking`-driven external exposure.

## Why

Unblocks the autobake workflow in `sei-protocol/platform` (M2b) which reads `.status.internalService.name` to dial the chain's RPC.

## Image

```
189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:20a1a9038725109d434f3940797200afaf75aa44
sha256:05ee5a60d3541c10e0409086381284a1e1695aabd771a14b049de170e1ac0a37
pushed: 2026-04-17T12:30:04Z
```

Verified in ECR via `aws ecr describe-images`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)