### PR TITLE
fix: align semconv import with OTel SDK schema URL (controller CrashLoop)

### DIFF
--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -11,7 +11,7 @@ import (
 	promexporter "go.opentelemetry.io/otel/exporters/prometheus"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 


### PR DESCRIPTION
## TL;DR

**Controller pods crash on startup** after the #100 image bump. Root cause is a semconv schema-URL mismatch from the OTel work in #97/#98, not #99. One-character import bump fixes it; verified locally.

## Crash

```
{"level":"error","ts":"...","logger":"setup",
 "msg":"Failed to initialize OTel MeterProvider",
 "error":"building OTel resource: conflicting Schema URL:
         https://opentelemetry.io/schemas/1.40.0 and
         https://opentelemetry.io/schemas/1.26.0",
 "stacktrace":"main.main\n\t/workspace/cmd/main.go:107\n..."}
```

## Root cause

`resource.Merge(resource.Default(), resource.NewWithAttributes(semconv.SchemaURL, ...))` rejects merging resources with differing non-empty schema URLs.

- `resource.Default()` reports schema URL `https://opentelemetry.io/schemas/1.40.0` — the schema embedded in the OTel SDK (we're on `go.opentelemetry.io/otel/sdk v1.43.0`).
- `cmd/telemetry.go:14` hardcoded `semconv "go.opentelemetry.io/otel/semconv/v1.26.0"` which contributed `https://opentelemetry.io/schemas/1.26.0`.

Bumping to `semconv/v1.40.0` aligns the two schema URLs. All three symbols used (`semconv.SchemaURL`, `ServiceName`, `ServiceVersion`) are stable across semconv versions — drop-in.

## Diff

```go
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
```

No `go.mod` / `go.sum` churn — semconv subpackages are siblings under the otel module, already resolved.

## Verified locally

- `go mod tidy` — no changes.
- `go build ./...` — clean.
- `make lint` — 0 issues.
- `make test` — green.

## Current prod impact

- Deployment has 4 pods instead of 3 (1 CrashLooping new pod + 3 healthy old pods on pre-bump image). Rolling update stuck at `maxUnavailable=0`.
- **Existing chains (pacific-1, atlantic-2, arctic-1) are unaffected** — old pods continue reconciling.
- **Autobake M2b is blocked** — old pods don't populate `.status.internalService`.

## Apply plan

1. Merge this PR.
2. `ecr.yml` workflow auto-publishes the new image on push to main.
3. Open a chore/bump PR bumping `config/manager/manager.yaml` to the new SHA. (I'm happy to do that one-liner once this lands.)
4. Flux reconciles → new pods roll out cleanly → old pods terminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)