### PR TITLE
chore: bump controller image to d122d39 (OTel semconv fix)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:20a1a9038725109d434f3940797200afaf75aa44
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:d122d39d5863a391d879cee2abdab5808a631db3
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Picks up #101 (OTel schema-URL fix). The prior pin `20a1a90` is CrashLoopBackOff-ing in prod right now:

```
Failed to initialize OTel MeterProvider
error: building OTel resource: conflicting Schema URL:
  https://opentelemetry.io/schemas/1.40.0 and ...1.26.0
```

## Image

```
189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:d122d39d5863a391d879cee2abdab5808a631db3
sha256:6a0a11bd2b135777d7bf4973f4009553b49a3cd4d2bfe41e08947e6a1780fde4
pushed: 2026-04-17T21:36Z
```

Verified via `aws ecr describe-images`.

## Post-Flux-sync verification

```
kubectl -n sei-k8s-controller-system get pods
# expect: all 3 pods Running on :d122d39..., 0 CrashLoopBackOff
```

Once this is in, the rolling update that's been stuck completes, and the autobake workflow (platform#101) unblocks on the `.status.internalService` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)