### PR TITLE
chore: bump controller image to 0ef62a2

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:d122d39d5863a391d879cee2abdab5808a631db3
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:0ef62a2b2c8515c92f228096bf6a95812c4c8167
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Bumps the manager image from `d122d39` to `0ef62a2` (latest `main`). Downstream kustomizations in platform/clusters/{prod,dev,harbor}/sei-k8s-controller all pull this manifest via `?ref=main`, so merging propagates to all three clusters on next Flux reconcile.

## Included since d122d39

- `cc90017` **feat**: wrap ResultExportConfig around use-case sub-structs (#110) — CRD schema refactor; no sidecar consumer, no controller env-var changes
- `75fb627` **feat**: decouple snapshot generation from publishing (#108) — replayer planner split; no manager env-var changes
- Three docs-only commits (#106, #107, #112)

Neither feature PR touched `cmd/main.go` or `internal/platform/platform.go`, so the platform's manager-patch env block (`SEI_GATEWAY_*`, `SEI_SNAPSHOT_*`, `SEI_RESULT_EXPORT_*`, `SEI_GENESIS_*`) is unchanged and still valid.

ECR image already published: `189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:0ef62a2b2c8515c92f228096bf6a95812c4c8167` (built by ECR workflow run 24731453814).

## No other changes required

- No CRD schema-breaking changes requiring `make manifests generate` at deploy time (generator already ran during each merge)
- No RBAC changes
- No manager-patch updates in the platform repo
