### PR TITLE
chore: bump controller image to ef97a16 (component label on ServiceMonitor)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:0ef62a2b2c8515c92f228096bf6a95812c4c8167
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:ef97a166d863ac705b812e87b67dc1268ccf8ce5
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Bumps the default controller image to `ef97a166d863...`, which includes PR #116 (component label emission on generated ServiceMonitors).

After this merges + Flux reconciles the platform repo (which references this repo at `?ref=main`), K8s-managed seid SNDs will start emitting `component` labels — see #115 for the full context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)