### PR TITLE
feat(monitoring): stamp chain_id label on generated ServiceMonitor

### DIFF
--- a/internal/controller/nodedeployment/monitoring.go
+++ b/internal/controller/nodedeployment/monitoring.go
@@ -92,15 +92,25 @@ func endpointSpec(group *seiv1alpha1.SeiNodeDeployment, interval string) map[str
 		"port":     "metrics",
 		"interval": interval,
 	}
+	var relabelings []any
 	if component := deriveComponent(&group.Spec.Template.Spec); component != "" {
-		ep["metricRelabelings"] = []any{
-			map[string]any{
-				"action":      "replace",
-				"regex":       ".*",
-				"replacement": component,
-				"targetLabel": "component",
-			},
-		}
+		relabelings = append(relabelings, map[string]any{
+			"action":      "replace",
+			"regex":       ".*",
+			"replacement": component,
+			"targetLabel": "component",
+		})
+	}
+	if chainID := group.Spec.Template.Spec.ChainID; chainID != "" {
+		relabelings = append(relabelings, map[string]any{
+			"action":      "replace",
+			"regex":       ".*",
+			"replacement": chainID,
+			"targetLabel": "chain_id",
+		})
+	}
+	if len(relabelings) > 0 {
+		ep["metricRelabelings"] = relabelings
 	}
 	return ep
 }

--- a/internal/controller/nodedeployment/monitoring_test.go
+++ b/internal/controller/nodedeployment/monitoring_test.go
@@ -103,27 +103,49 @@ func TestGenerateServiceMonitor_ComponentRelabeling(t *testing.T) {
 			spec := sm.Object["spec"].(map[string]any)
 			ep := spec["endpoints"].([]any)[0].(map[string]any)
 			relabelings := ep["metricRelabelings"].([]any)
-			g.Expect(relabelings).To(HaveLen(1))
-			rule := relabelings[0].(map[string]any)
-			g.Expect(rule["action"]).To(Equal("replace"))
-			g.Expect(rule["regex"]).To(Equal(".*"))
-			g.Expect(rule["targetLabel"]).To(Equal("component"))
-			g.Expect(rule["replacement"]).To(Equal(tc.expected))
+			g.Expect(findRelabeling(relabelings, "component")).To(Equal(tc.expected))
 		})
 	}
 }
 
-func TestGenerateServiceMonitor_NoComponentWhenAmbiguous(t *testing.T) {
+func TestGenerateServiceMonitor_ChainIDRelabeling(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("role-test", "sei")
+	group.Spec.Monitoring = &seiv1alpha1.MonitoringConfig{
+		ServiceMonitor: &seiv1alpha1.ServiceMonitorConfig{},
+	}
+
+	sm := generateServiceMonitor(group)
+	spec := sm.Object["spec"].(map[string]any)
+	ep := spec["endpoints"].([]any)[0].(map[string]any)
+	relabelings := ep["metricRelabelings"].([]any)
+	g.Expect(findRelabeling(relabelings, "chain_id")).To(Equal("pacific-1"))
+}
+
+func TestGenerateServiceMonitor_NoRelabelingsWhenNothingDerivable(t *testing.T) {
 	g := NewWithT(t)
 	group := newTestGroup("role-test", "sei")
 	group.Spec.Monitoring = &seiv1alpha1.MonitoringConfig{
 		ServiceMonitor: &seiv1alpha1.ServiceMonitorConfig{},
 	}
 	group.Spec.Template.Spec.FullNode = nil
+	group.Spec.Template.Spec.ChainID = ""
 
 	sm := generateServiceMonitor(group)
 	spec := sm.Object["spec"].(map[string]any)
 	ep := spec["endpoints"].([]any)[0].(map[string]any)
 	_, has := ep["metricRelabelings"]
 	g.Expect(has).To(BeFalse())
+}
+
+// findRelabeling returns the `replacement` string for a metricRelabeling
+// targeting the given label, or "" if no such rule exists.
+func findRelabeling(relabelings []any, targetLabel string) string {
+	for _, r := range relabelings {
+		rule := r.(map[string]any)
+		if rule["targetLabel"] == targetLabel {
+			return rule["replacement"].(string)
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary

Adds a second `metricRelabelings` entry on the generated ServiceMonitor that stamps `chain_id` onto every scraped sample. Mirrors the `component` label pattern from #116.

## Why

Seid self-labels only `tendermint_*` metrics with `chain_id`; app-level metrics (`abci_*`, `cosmos_*`, `iavl_*`, `sei_evm_*`) are emitted without it. EC2-based mainnet nodes pick up `chain_id` via scrape relabeling from EC2 tags. K8s-managed nodes had no equivalent — so `sei_node_monitoring.json` and similar dashboards silently excluded them for every app-level panel.

Observed today on a gprusak soak test: `tendermint_consensus_latest_block_height{chain_id="v6-5-run-3"}` worked, but `abci_begin_block{chain_id="v6-5-run-3"}` returned 0 series despite 48 samples existing in Prometheus without the label.

## Shape

```yaml
metricRelabelings:
  - action: replace
    regex: .*
    replacement: <component-from-role>
    targetLabel: component
  - action: replace
    regex: .*
    replacement: <chain_id-from-spec>
    targetLabel: chain_id
```

Unconditional replace — the SND spec is authoritative for `chain_id`, and overwriting the self-labeled value on tendermint_* metrics is a functional no-op (values agree).

## Scope

- `internal/controller/nodedeployment/monitoring.go` — collects relabelings into a slice, emits both when derivable; omits the entire `metricRelabelings` key when neither is derivable.
- `internal/controller/nodedeployment/monitoring_test.go` — new test for chain_id, updated component test to use a label-lookup helper (more resilient to ordering), new test for empty-spec-yields-no-relabelings.

Additive to existing SMs; the `component` label from #116 continues to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)