### PR TITLE
chore: bump controller image to e7be67d (chain_id label on ServiceMonitor)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:ef97a166d863ac705b812e87b67dc1268ccf8ce5
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:e7be67d4549c4c6c0a4ca0ad71f9c70bd9876f1e
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Bumps the default controller image to `e7be67d4549c...`, which includes PR #118 (chain_id label emission on generated ServiceMonitors alongside the existing component label from #116).

After this merges + Flux reconciles the platform repo, K8s-managed seid SNDs will have their app-level metrics (abci_*, cosmos_*, iavl_*, sei_evm_*) automatically tagged with `chain_id=<spec.chainId>` — no more manual SM patching per chain.