### PR TITLE
chore: bump controller image to ab7faf0 (drop metrics port from external Service)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:e7be67d4549c4c6c0a4ca0ad71f9c70bd9876f1e
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:ab7faf0a4b1910728a065658bfbef468fc54f74a
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Bumps the default controller image to `ab7faf0a4b...`, which includes PR #120 (drop `metrics` port from the external Service generator).

After this merges + Flux reconciles, k8s-managed seid pods will be scraped exactly once each (via the per-pod headless Service), instead of twice (per-pod + external).