### PR TITLE
feat(monitoring): stamp EC2-compat labels on ServiceMonitor

### DIFF
--- a/internal/controller/nodedeployment/monitoring.go
+++ b/internal/controller/nodedeployment/monitoring.go
@@ -109,9 +109,22 @@ func endpointSpec(group *seiv1alpha1.SeiNodeDeployment, interval string) map[str
 			"targetLabel": "chain_id",
 		})
 	}
-	if len(relabelings) > 0 {
-		ep["metricRelabelings"] = relabelings
-	}
+	// EC2-compat shim: stamp legacy labels from `pod` so dashboards that
+	// filter on instance_name / public_dns work for both EC2 and k8s scrapes.
+	// TODO(sei-protocol/sei-k8s-controller#122): remove after EC2 scrape decommission.
+	relabelings = append(relabelings,
+		map[string]any{
+			"action":       "replace",
+			"sourceLabels": []any{"pod"},
+			"targetLabel":  "instance_name",
+		},
+		map[string]any{
+			"action":       "replace",
+			"sourceLabels": []any{"pod"},
+			"targetLabel":  "public_dns",
+		},
+	)
+	ep["metricRelabelings"] = relabelings
 	return ep
 }
 

--- a/internal/controller/nodedeployment/monitoring_test.go
+++ b/internal/controller/nodedeployment/monitoring_test.go
@@ -122,7 +122,7 @@ func TestGenerateServiceMonitor_ChainIDRelabeling(t *testing.T) {
 	g.Expect(findRelabeling(relabelings, "chain_id")).To(Equal("pacific-1"))
 }
 
-func TestGenerateServiceMonitor_NoRelabelingsWhenNothingDerivable(t *testing.T) {
+func TestGenerateServiceMonitor_OnlyEC2CompatWhenNothingDerivable(t *testing.T) {
 	g := NewWithT(t)
 	group := newTestGroup("role-test", "sei")
 	group.Spec.Monitoring = &seiv1alpha1.MonitoringConfig{
@@ -134,8 +134,26 @@ func TestGenerateServiceMonitor_NoRelabelingsWhenNothingDerivable(t *testing.T) 
 	sm := generateServiceMonitor(group)
 	spec := sm.Object["spec"].(map[string]any)
 	ep := spec["endpoints"].([]any)[0].(map[string]any)
-	_, has := ep["metricRelabelings"]
-	g.Expect(has).To(BeFalse())
+	relabelings := ep["metricRelabelings"].([]any)
+	g.Expect(findRelabeling(relabelings, "component")).To(Equal(""))
+	g.Expect(findRelabeling(relabelings, "chain_id")).To(Equal(""))
+	g.Expect(findSourceRelabeling(relabelings, "instance_name")).To(Equal("pod"))
+	g.Expect(findSourceRelabeling(relabelings, "public_dns")).To(Equal("pod"))
+}
+
+func TestGenerateServiceMonitor_EC2CompatLabels(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("role-test", "sei")
+	group.Spec.Monitoring = &seiv1alpha1.MonitoringConfig{
+		ServiceMonitor: &seiv1alpha1.ServiceMonitorConfig{},
+	}
+
+	sm := generateServiceMonitor(group)
+	spec := sm.Object["spec"].(map[string]any)
+	ep := spec["endpoints"].([]any)[0].(map[string]any)
+	relabelings := ep["metricRelabelings"].([]any)
+	g.Expect(findSourceRelabeling(relabelings, "instance_name")).To(Equal("pod"))
+	g.Expect(findSourceRelabeling(relabelings, "public_dns")).To(Equal("pod"))
 }
 
 // findRelabeling returns the `replacement` string for a metricRelabeling
@@ -143,9 +161,31 @@ func TestGenerateServiceMonitor_NoRelabelingsWhenNothingDerivable(t *testing.T) 
 func findRelabeling(relabelings []any, targetLabel string) string {
 	for _, r := range relabelings {
 		rule := r.(map[string]any)
-		if rule["targetLabel"] == targetLabel {
-			return rule["replacement"].(string)
+		if rule["targetLabel"] != targetLabel {
+			continue
 		}
+		repl, ok := rule["replacement"].(string)
+		if !ok {
+			continue
+		}
+		return repl
+	}
+	return ""
+}
+
+// findSourceRelabeling returns the first sourceLabels entry for a metricRelabeling
+// targeting the given label, or "" if no such rule exists.
+func findSourceRelabeling(relabelings []any, targetLabel string) string {
+	for _, r := range relabelings {
+		rule := r.(map[string]any)
+		if rule["targetLabel"] != targetLabel {
+			continue
+		}
+		src, ok := rule["sourceLabels"].([]any)
+		if !ok || len(src) == 0 {
+			continue
+		}
+		return src[0].(string)
 	}
 	return ""
 }


### PR DESCRIPTION
## What
Copy the k8s-scraped `pod` label into legacy EC2 labels `instance_name` and `public_dns` via `metricRelabelings` on the controller-emitted ServiceMonitor.

## Why
During the EC2 → k8s migration for sei-chain nodes, our Grafana dashboards filter on EC2-only labels (`instance_name`, `public_dns`) that Prometheus's EC2 service discovery stamps onto scraped samples. K8s-scraped pods don't have these labels, so panels like Block Size, Blocks Behind, IAVL Tree Size, and Chain State Growth show nothing for k8s-managed nodes (e.g. the v6-5 soak chain).

Stamping the k8s pod name into these labels (semantically dishonest but pragmatically effective) lets every existing dashboard query work across both scrape paths without any dashboard changes.

## Migration path
This is a compatibility shim with a clear end state, tracked in #122:

1. **Now:** controller stamps both labels; EC2 + k8s views unify.
2. **When EC2 scraping is decommissioned:** migrate dashboards from `instance_name`/`public_dns` → `pod` in one sweep.
3. **Afterwards:** delete the two compat rules (clearly marked with `TODO(#122)` in `endpointSpec`).

## Tests
- New: `TestGenerateServiceMonitor_EC2CompatLabels` — asserts both rules are always emitted.
- Renamed: `TestGenerateServiceMonitor_NoRelabelingsWhenNothingDerivable` → `..._OnlyEC2CompatWhenNothingDerivable` — asserts compat rules are present even when component/chain_id can't be derived.
- New helper: `findSourceRelabeling` for rules that use `sourceLabels` instead of `replacement`.

## Test plan
- [x] `go test ./internal/controller/nodedeployment/` passes
- [ ] After merge + image bump: verify on prod `v6-5-run-3` that scraped samples carry `instance_name`/`public_dns` labels matching pod names, and that Block Size / Blocks Behind panels populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)