### PR TITLE
fix: propagate template.metadata.labels to pods

### DIFF
--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -221,11 +221,14 @@ func generateSeiNode(group *seiv1alpha1.SeiNodeDeployment, ordinal int) *seiv1al
 	annotations := seiNodeAnnotations(group)
 
 	spec := group.Spec.Template.Spec.DeepCopy()
-	if spec.PodLabels == nil {
-		spec.PodLabels = make(map[string]string)
+	podLabels := make(map[string]string)
+	if group.Spec.Template.Metadata != nil {
+		maps.Copy(podLabels, group.Spec.Template.Metadata.Labels)
 	}
-	spec.PodLabels[groupLabel] = group.Name
-	spec.PodLabels[revisionLabel] = activeRevision(group)
+	maps.Copy(podLabels, spec.PodLabels)
+	podLabels[groupLabel] = group.Name
+	podLabels[revisionLabel] = activeRevision(group)
+	spec.PodLabels = podLabels
 
 	if gc := group.Spec.Genesis; gc != nil && spec.Validator != nil {
 		if spec.ChainID == "" {

--- a/internal/controller/nodedeployment/nodes_test.go
+++ b/internal/controller/nodedeployment/nodes_test.go
@@ -109,6 +109,57 @@ func TestGenerateSeiNode_PreservesExistingPodLabels(t *testing.T) {
 	g.Expect(node.Spec.PodLabels).To(HaveKeyWithValue(groupLabel, "archive-rpc"))
 }
 
+func TestGenerateSeiNode_PropagatesTemplateMetadataLabelsToPods(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("archive-rpc", "sei")
+	group.Spec.Template.Metadata = &seiv1alpha1.SeiNodeTemplateMeta{
+		Labels: map[string]string{
+			"sei.io/chain-id": "pacific-1",
+			"sei.io/role":     "archive",
+		},
+	}
+
+	node := generateSeiNode(group, 0)
+
+	g.Expect(node.Spec.PodLabels).To(HaveKeyWithValue("sei.io/chain-id", "pacific-1"))
+	g.Expect(node.Spec.PodLabels).To(HaveKeyWithValue("sei.io/role", "archive"))
+	g.Expect(node.Spec.PodLabels).To(HaveKeyWithValue(groupLabel, "archive-rpc"))
+}
+
+func TestGenerateSeiNode_PodLabelsOverrideTemplateMetadataLabels(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("archive-rpc", "sei")
+	group.Spec.Template.Metadata = &seiv1alpha1.SeiNodeTemplateMeta{
+		Labels: map[string]string{
+			"key": "from-metadata",
+		},
+	}
+	group.Spec.Template.Spec.PodLabels = map[string]string{
+		"key": "from-pod-labels",
+	}
+
+	node := generateSeiNode(group, 0)
+
+	g.Expect(node.Spec.PodLabels).To(HaveKeyWithValue("key", "from-pod-labels"))
+}
+
+func TestGenerateSeiNode_SystemLabelsOverrideUserLabels(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("archive-rpc", "sei")
+	group.Spec.Template.Metadata = &seiv1alpha1.SeiNodeTemplateMeta{
+		Labels: map[string]string{
+			groupLabel: "user-attempt-to-override",
+		},
+	}
+	group.Spec.Template.Spec.PodLabels = map[string]string{
+		groupLabel: "another-override-attempt",
+	}
+
+	node := generateSeiNode(group, 0)
+
+	g.Expect(node.Spec.PodLabels).To(HaveKeyWithValue(groupLabel, "archive-rpc"))
+}
+
 func TestGenerateSeiNode_CopiesSpec(t *testing.T) {
 	g := NewWithT(t)
 	group := newTestGroup("full-node", "pacific-1")


### PR DESCRIPTION
Closes #103.

## Summary

Match stock K8s \`Deployment\` semantics: labels declared on \`spec.template.metadata.labels\` now land on pods. Prior behavior left them on the child SeiNode CR only, a footgun for anyone reaching for the Deployment mental model.

## Change

In \`generateSeiNode\`, seed \`SeiNode.Spec.PodLabels\` with \`template.metadata.labels\`, then overlay \`template.spec.podLabels\`, then apply system labels. Explicit \`podLabels\` win on key collision with metadata labels; system labels always win over both.

## Tests

Three new cases in \`nodes_test.go\`:
- \`PropagatesTemplateMetadataLabelsToPods\` — metadata labels reach \`PodLabels\`.
- \`PodLabelsOverrideTemplateMetadataLabels\` — explicit \`podLabels\` wins on collision.
- \`SystemLabelsOverrideUserLabels\` — \`groupLabel\` is unoverrideable.

Existing \`PreservesExistingPodLabels\` still passes (strict-superset change).

## Rollout considerations

- **Additive on existing SNDs.** Old SNDs without \`template.metadata.labels\` are unaffected. SNDs that already set them gain the labels on pods on next reconcile — no existing consumer loses labels.
- **Selector impact.** StatefulSet selectors are immutable, but \`spec.selector.matchLabels\` only requires a subset match of pod template labels. Adding new labels to pod template is safe; selectors keep working.

## Motivation

Surfaced while wiring chaos-mesh selectors for release-6-5 on dev. Intuitive selectors like \`sei.io/chain-id: release-6-5\` silently matched zero seid pods because the label was on SNDs but not pods. See platform repo chaos-selector workaround PRs for the current hack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)