### PR TITLE
chore: bump controller image to 9cf9ce4 (propagate template labels to pods)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:2b2aed134ba0fef3e591bb9b0c4e4eae3fbd16a2
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:9cf9ce4215d7173d81a8951d06e1654e29227072
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Rolls out #125 — propagates `SeiNodeDeployment.spec.template.metadata.labels` onto pods, matching stock K8s Deployment semantics.

Tracking: sei-protocol/sei-k8s-controller#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)