### PR TITLE
chore: bump controller image to 5ca4c27 (sidecar mark-ready re-apply)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:9cf9ce4215d7173d81a8951d06e1654e29227072
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:5ca4c275e34d19d66e5f0af2a4cda90c83bb8f30
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Rolls out #129 — the controller now detects stale sidecar mark-ready gates on pod replacement and auto-reissues via a one-task plan. No more manual `port-forward` + POST.

Closes #127 in terms of deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)