### PR TITLE
chore: bump controller image to 8cd6847 (SeiNode import-existing-PVC)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:5ca4c275e34d19d66e5f0af2a4cda90c83bb8f30
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8cd6847d21446043f8a9dd1134e3df97874a0793
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Picks up #113. Includes:

- New `spec.dataVolume.import.pvcName` on SeiNode to adopt a pre-existing PVC
- New `ImportPVCReady` condition (`PVCValidated` / `PVCNotReady` / `PVCInvalid`)
- Ensure-data-pvc create path refactored to Get-then-Create with ownership check (closes #104)
- Finalizer skips PVC deletion when import is configured
- RBAC: `persistentvolumes: get/list/watch`

Image: `189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8cd6847d21446043f8a9dd1134e3df97874a0793`

🤖 Generated with [Claude Code](https://claude.com/claude-code)