### PR TITLE
docs(np): drop stale kubectl-label instruction from allow-metrics-traffic

### DIFF
--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -1,15 +1,6 @@
 # Allows Prometheus to scrape the controller metrics endpoint.
-#
-# Prerequisite: the Prometheus namespace manifest must declaratively carry the
-# label `metrics: enabled` — see the platform repo's per-cluster
-# clusters/<env>/monitoring/namespace.yaml. Without it, scrapes are blocked by
-# the namespaceSelector below.
-#
-# Note: Kubernetes NetworkPolicy is only enforced on CNIs that implement it.
-# AWS VPC CNI accepts NP objects but does not enforce them, so this rule is a
-# silent no-op on VPC CNI clusters. Cilium (with kubeProxyReplacement)
-# enforces natively — missing the label there causes an immediate scrape
-# outage, as discovered during the harbor bring-up.
+# The scraping namespace must carry the label `metrics: enabled`
+# to match the namespaceSelector below.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -1,7 +1,15 @@
 # Allows Prometheus to scrape the controller metrics endpoint.
-# Prerequisite: the Prometheus namespace must carry the label
-#   kubectl label namespace <prometheus-ns> metrics=enabled
-# Without this label, scrapes will be blocked by the namespaceSelector.
+#
+# Prerequisite: the Prometheus namespace manifest must declaratively carry the
+# label `metrics: enabled` — see the platform repo's per-cluster
+# clusters/<env>/monitoring/namespace.yaml. Without it, scrapes are blocked by
+# the namespaceSelector below.
+#
+# Note: Kubernetes NetworkPolicy is only enforced on CNIs that implement it.
+# AWS VPC CNI accepts NP objects but does not enforce them, so this rule is a
+# silent no-op on VPC CNI clusters. Cilium (with kubeProxyReplacement)
+# enforces natively — missing the label there causes an immediate scrape
+# outage, as discovered during the harbor bring-up.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
## Summary

Drops the \`kubectl label namespace <prometheus-ns> metrics=enabled\` instruction from the NP header comment. The label contract is already expressed by the \`namespaceSelector\` in the spec — the imperative out-of-band hint encouraged consumers to drift from IaC without adding anything the spec didn't already say.

New comment is two lines:

\`\`\`
# Allows Prometheus to scrape the controller metrics endpoint.
# The scraping namespace must carry the label \`metrics: enabled\`
# to match the namespaceSelector below.
\`\`\`

No spec change, no runtime change.

## Test plan

- [ ] \`kubectl apply -k config/network-policy/\` still applies cleanly (spec byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)