### PR TITLE
chore: bump controller image to 16bb007 (validator nodeKey)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8cd6847d21446043f8a9dd1134e3df97874a0793
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:16bb007c2759cbfaf5051a22fe23a9c2d4695b03
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Bumps the controller image in `config/manager/manager.yaml` to the build produced from the PR #140 merge commit.

- **Old:** `8cd6847d21446043f8a9dd1134e3df97874a0793`
- **New:** `16bb007c2759cbfaf5051a22fe23a9c2d4695b03`

The new image includes:

- **PR #140** — validator `nodeKey` configuration on SeiNode (closes #138). Adds `spec.validator.nodeKey.secret.secretName` for migrating validators' P2P node keys, with the production-only mount, distinct-secretName CEL guard, and `validate-node-key` pre-flight task.

[ECR build run](https://github.com/sei-protocol/sei-k8s-controller/actions/runs/25076978674) succeeded for commit `16bb007`.

## Test plan

- [x] ECR build for `16bb007` completed successfully
- [x] Manifest diff is the single image-SHA line
- [x] Apply to staging cluster, observe validator SeiNode with `nodeKey` set boots production pod with `node_key.json` mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)