### PR TITLE
fix: reject SeiNodeDeployment with genesis on non-validator-role at admission (closes #145)

### DIFF
--- a/api/v1alpha1/seinodedeployment_types.go
+++ b/api/v1alpha1/seinodedeployment_types.go
@@ -5,6 +5,8 @@ import (
 )
 
 // SeiNodeDeploymentSpec defines the desired state of a SeiNodeDeployment.
+//
+// +kubebuilder:validation:XValidation:rule="!has(self.genesis) || has(self.template.spec.validator)",message="genesis is meaningful only for validator-role deployments (full nodes inherit genesis from the validator ceremony's S3 artifact); remove spec.genesis or set template.spec.validator: {}"
 type SeiNodeDeploymentSpec struct {
 	// Replicas is the number of SeiNode instances to create.
 	// +kubebuilder:validation:Minimum=1

--- a/config/crd/sei.io_seinodedeployments.yaml
+++ b/config/crd/sei.io_seinodedeployments.yaml
@@ -862,6 +862,11 @@ spec:
             - template
             - updateStrategy
             type: object
+            x-kubernetes-validations:
+            - message: 'genesis is meaningful only for validator-role deployments
+                (full nodes inherit genesis from the validator ceremony''s S3 artifact);
+                remove spec.genesis or set template.spec.validator: {}'
+              rule: '!has(self.genesis) || has(self.template.spec.validator)'
           status:
             description: SeiNodeDeploymentStatus defines the observed state of a SeiNodeDeployment.
             properties:

--- a/manifests/sei.io_seinodedeployments.yaml
+++ b/manifests/sei.io_seinodedeployments.yaml
@@ -862,6 +862,11 @@ spec:
             - template
             - updateStrategy
             type: object
+            x-kubernetes-validations:
+            - message: 'genesis is meaningful only for validator-role deployments
+                (full nodes inherit genesis from the validator ceremony''s S3 artifact);
+                remove spec.genesis or set template.spec.validator: {}'
+              rule: '!has(self.genesis) || has(self.template.spec.validator)'
           status:
             description: SeiNodeDeploymentStatus defines the observed state of a SeiNodeDeployment.
             properties:


### PR DESCRIPTION
## Summary

Adds a CEL `XValidation` rule on `SeiNodeDeploymentSpec` rejecting `genesis` when `template.spec.validator` is unset (i.e., the deployment is full-node / archive / replayer-role, or has no role discriminator yet).

Previously, the controller silently dropped a user-supplied genesis spec on non-validator-role deployments — `internal/controller/nodedeployment/nodes.go` only stamps `GenesisCeremonyNodeConfig` when `spec.Validator != nil`, so genesis was ignored at runtime with no admission feedback. Operators who copy-pasted from a validator template into a full-node manifest got silent misconfiguration; now admission rejects with a clear message naming the field and the fix.

This is the SND-side analog of ValidationRun's webhook-level rejection of `chain.fullNodes.genesis` (per LLD merged in PR #143). Putting the rule at the SND admission boundary covers both ValidationRun-materialized SNDs and direct-`kubectl-apply` operators in one place.

## Predicate choice — Option A

Considered two predicate shapes:
- **A. `!has(self.genesis) || has(self.template.spec.validator)`** *(landed)* — rejects genesis on full-node, archive, replayer, missing-discriminator. SND has a 4-role discriminator; this matches the SND-side framing of \"genesis is meaningful only for validator-role.\"
- B. `!has(self.genesis) || !has(self.template.spec.fullNode)` — rejects only the `fullNode` case; would mirror ValidationRun's CEL exactly but ValidationRun's `role` enum knows only `validator|fullNode`, leaving archive/replayer in the silent-drop trap at the SND boundary.

A is strictly stronger and aligns with the runtime behavior — `nodedeployment/nodes.go` only stamps genesis when `spec.Validator != nil` regardless of which other discriminator is set.

## Test plan

- [x] `make manifests generate` — regenerates CRD YAML; verified the new XValidation entry appears in both `config/crd/sei.io_seinodedeployments.yaml` and `manifests/sei.io_seinodedeployments.yaml`
- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass
- [x] Existing samples verified to admit unchanged: `genesis-ceremony.yaml` (validator + genesis ✓), `fork-genesis-ceremony.yaml` (validator + genesis with fork ✓), `pacific-1-rpc-group.yaml` (fullNode, no genesis ✓)

### Deferred — admission test infra

The repo has no existing CEL admission tests under `api/v1alpha1/` (the four other `XValidation` rules in the file rely on the generated CRD YAML diff as the contract). Standing up envtest + admission-test scaffolding to cover this one rule would mix scope; following the repo convention here. If the project wants admission tests broadly, that's a follow-up that should backfill all five existing `XValidation` rules at once.

## Files changed

| File | LoC | Source/generated |
|---|---|---|
| `api/v1alpha1/seinodedeployment_types.go` | +2 | source |
| `manifests/sei.io_seinodedeployments.yaml` | +5 | generated |
| `config/crd/sei.io_seinodedeployments.yaml` | +5 | generated |

## References

- Closes #145
- Related: PR #143 (ValidationRun LLD), companion issues #144 #146 #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)