### PR TITLE
fix(controllers): enforce optimistic concurrency on status patches (closes #147)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,25 @@ Always use the available subagents for relevant work:
 - No `panic` in controller code. Return errors and let the reconciler retry.
 - Keep reconcile loops idempotent — every reconcile should converge toward desired state regardless of current state.
 
+### Status patches
+
+Status writes must use **optimistic concurrency** so a stale reconcile cannot silently overwrite a fresher one. Two near-simultaneous reconciles can both observe `status.plan == nil`, both build a plan, and without resourceVersion-checked patches the second silently wins — corrupting plan-creation idempotency.
+
+**Use:**
+
+```go
+patch := client.MergeFromWithOptions(obj.DeepCopy(), client.MergeFromWithOptimisticLock{})
+// ... mutate obj.Status ...
+if err := r.Status().Patch(ctx, obj, patch); err != nil { ... }
+```
+
+**Do not use** for status writes:
+- `client.MergeFrom(...)` without the `MergeFromWithOptimisticLock{}` option — produces a merge patch with no resourceVersion precondition; stale writes succeed silently.
+- `client.Status().Update(...)` without resourceVersion verification on the in-memory object.
+- `client.Apply` (server-side apply) on `.status` without explicit resourceVersion handling — field-manager isolation does not by itself prevent stale-write races for our plan-creation invariant.
+
+The single-patch reconcile model means each reconcile snapshots `obj.DeepCopy()` once, accumulates mutations in-memory, and flushes one optimistic-lock-protected `Status().Patch` at the end. Code-review checklist item: every `r.Status().Patch` call site must use a base built with `MergeFromWithOptimisticLock{}`.
+
 ### Testing
 - Tests use `testing` + `gomega` for assertions.
 - Test fixtures for platform config live in `internal/platform/platformtest/`.

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -146,7 +146,7 @@ func (r *SeiNodeDeploymentReconciler) handleDeletion(ctx context.Context, group 
 		return ctrl.Result{}, nil
 	}
 
-	patch := client.MergeFrom(group.DeepCopy())
+	patch := client.MergeFromWithOptions(group.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	group.Status.Phase = seiv1alpha1.GroupPhaseTerminating
 	if err := r.Status().Patch(ctx, group, patch); err != nil {
 		return ctrl.Result{}, fmt.Errorf("setting terminating status: %w", err)

--- a/internal/task/deployment_switch.go
+++ b/internal/task/deployment_switch.go
@@ -45,7 +45,7 @@ func (e *switchTrafficExecution) Execute(ctx context.Context) error {
 		return Terminal(fmt.Errorf("no rollout status on group %s", e.params.GroupName))
 	}
 
-	patch := client.MergeFrom(group.DeepCopy())
+	patch := client.MergeFromWithOptions(group.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	group.Status.Rollout.IncumbentRevision = e.params.EntrantRevision
 	if err := e.cfg.KubeClient.Status().Patch(ctx, group, patch); err != nil {
 		return fmt.Errorf("patching rollout revision: %w", err) // transient

--- a/internal/task/genesis_peers.go
+++ b/internal/task/genesis_peers.go
@@ -86,6 +86,11 @@ func (e *collectAndSetPeersExecution) setPeersOnNodes(ctx context.Context, peers
 		if err := e.cfg.KubeClient.Get(ctx, types.NamespacedName{Name: name, Namespace: e.params.Namespace}, node); err != nil {
 			return fmt.Errorf("getting node %s: %w", name, err)
 		}
+		// Spec patch on a peer SeiNode (not a status patch). Intentional plain
+		// MergeFrom — the optimistic-lock invariant in CLAUDE.md applies to
+		// .status writes; spec patches on peer SeiNodes are idempotent (this
+		// task converges spec.Peers toward the assembled peer list and is
+		// safe to re-run on conflict).
 		patch := client.MergeFrom(node.DeepCopy())
 		node.Spec.Peers = []seiv1alpha1.PeerSource{
 			{Static: &seiv1alpha1.StaticPeerSource{Addresses: peers}},

--- a/internal/task/genesis_peers.go
+++ b/internal/task/genesis_peers.go
@@ -86,11 +86,8 @@ func (e *collectAndSetPeersExecution) setPeersOnNodes(ctx context.Context, peers
 		if err := e.cfg.KubeClient.Get(ctx, types.NamespacedName{Name: name, Namespace: e.params.Namespace}, node); err != nil {
 			return fmt.Errorf("getting node %s: %w", name, err)
 		}
-		// Spec patch on a peer SeiNode (not a status patch). Intentional plain
-		// MergeFrom — the optimistic-lock invariant in CLAUDE.md applies to
-		// .status writes; spec patches on peer SeiNodes are idempotent (this
-		// task converges spec.Peers toward the assembled peer list and is
-		// safe to re-run on conflict).
+		// Spec patch (not status); CLAUDE.md's optimistic-lock invariant
+		// applies to .status writes only. Idempotent under conflict.
 		patch := client.MergeFrom(node.DeepCopy())
 		node.Spec.Peers = []seiv1alpha1.PeerSource{
 			{Static: &seiv1alpha1.StaticPeerSource{Addresses: peers}},


### PR DESCRIPTION
## Summary

Audits the codebase for status patches that could silently overwrite fresher in-flight writes. Fixes 2 sites and documents the invariant in `CLAUDE.md`.

The ValidationRun LLD (PR #143) names plan-creation idempotency under fast double-reconcile as an implementation invariant: status patches must use optimistic concurrency (resourceVersion-checked) so two near-simultaneous reconciles can't both observe `status.plan == nil`, both build a plan, and have the second silently overwrite the first.

## Audit findings — 10 status-patch-relevant call sites in `internal/`

### OK — explicit `client.MergeFromWithOptimisticLock{}` (no change)

| Site | Description |
|---|---|
| `internal/controller/node/controller.go:97-98` + `:125` | Main reconcile statusBase + flush |
| `internal/controller/node/controller.go:201-203` | `handleNodeDeletion` Phase=Terminating |
| `internal/controller/nodedeployment/controller.go:81` + `status.go:50` | Main reconcile statusBase + flush via `updateStatus` |

### NEEDS FIX — `MergeFrom` without optimistic-lock option (now patched)

| Site | Was | Now |
|---|---|---|
| `internal/controller/nodedeployment/controller.go:149` (handleDeletion setting `Phase=Terminating`) | `client.MergeFrom(group.DeepCopy())` | `client.MergeFromWithOptions(group.DeepCopy(), client.MergeFromWithOptimisticLock{})` |
| `internal/task/deployment_switch.go:48` (rollout incumbent revision write) | `client.MergeFrom(group.DeepCopy())` | `client.MergeFromWithOptions(group.DeepCopy(), client.MergeFromWithOptimisticLock{})` |

### Out of scope — not status patches

| Pattern | Sites | Why out of scope |
|---|---|---|
| SSA on owned children (`client.Apply` with field owner) | `nodedeployment/{internal_service,networking,monitoring}.go`, `task/apply_{service,statefulset}.go` | Field-manager isolation handles cross-controller writes; different invariant |
| Finalizer patches | `nodedeployment/controller.go:139,180` | Spec metadata patches |
| Spec patches on owned children | `task/genesis_peers.go:89` (Spec.Peers on SeiNode) | Different invariant; planner-driven cross-resource spec mutation |

## Documentation

Adds a new \"Status patches\" subsection under `CLAUDE.md` § Code Standards documenting the invariant, the use/don't-use patterns, and a code-review checklist item. CLAUDE.md is the de-facto contributor doc for this repo (no `CONTRIBUTING.md` or `.github/PULL_REQUEST_TEMPLATE.md` exists).

## Test infra deferral

Standing up envtest scaffolding to exercise double-reconcile contention is non-trivial in this repo — no existing envtest harness, all current tests are pure-Go. Per the test-infra discussion that surfaced during the #145 review (which deferred admission-test envtest the same way), this PR defers integration-style contention testing to a separate follow-up issue. The audit + fix + documentation all land here; the integration test harness is a separate scope-bounded follow-up that should backfill admission tests + contention tests at once if the project wants integration-style coverage.

Will file the follow-up issue once this PR is reviewed; references the same envtest follow-up #145 deferred.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass
- [x] Manual audit of all `Status().Patch` / `Status().Update` call sites in `internal/` (grep + read)
- [x] Confirmed both fixed sites produce identical Status mutations as before; only the patch base option changes
- [x] (Deferred to follow-up) envtest harness exercising double-reconcile contention against ValidationRun + SeiNode + SND

## Files changed

| File | LoC | Purpose |
|---|---|---|
| `CLAUDE.md` | +19 | Documents the invariant + code-review checklist item |
| `internal/controller/nodedeployment/controller.go` | ±1 | `MergeFrom` → `MergeFromWithOptions(..., MergeFromWithOptimisticLock{})` |
| `internal/task/deployment_switch.go` | ±1 | Same fix for rollout revision write |

## References

- Closes #147
- Related: PR #143 (ValidationRun LLD names this as implementation invariant), #145 (mergeed; admission-test envtest deferral parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)