### PR TITLE
fix(fork-genesis): fail terminally on a Failed exporter SeiNode

### DIFF
--- a/internal/task/fork_export.go
+++ b/internal/task/fork_export.go
@@ -70,13 +70,12 @@ func (e *createExporterExecution) Execute(ctx context.Context) error {
 		Name: e.params.ExporterName, Namespace: e.params.Namespace,
 	}, existing)
 	if err == nil {
-		// If a previous attempt left a failed exporter, delete it so we
-		// can create a fresh one on the next reconcile.
 		if existing.Status.Phase == seiv1alpha1.PhaseFailed {
-			if delErr := e.cfg.KubeClient.Delete(ctx, existing); delErr != nil && !apierrors.IsNotFound(delErr) {
-				return fmt.Errorf("deleting failed exporter: %w", delErr)
-			}
-			return nil // next reconcile will re-enter Execute and create a new exporter
+			return Terminal(fmt.Errorf(
+				"exporter %s/%s is Failed — drain the SeiNodeDeployment and clear "+
+					"stale artifacts under %s/%s in the genesis-artifacts bucket before retrying",
+				e.params.Namespace, e.params.ExporterName,
+				e.params.SourceChainID, e.params.GroupName))
 		}
 		e.complete()
 		return nil

--- a/internal/task/fork_export_test.go
+++ b/internal/task/fork_export_test.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -149,7 +150,7 @@ func TestCreateExporter_Execute_Idempotent(t *testing.T) {
 	}
 }
 
-func TestCreateExporter_Execute_DeletesFailedExporter(t *testing.T) {
+func TestCreateExporter_Execute_FailsTerminallyOnFailedExporter(t *testing.T) {
 	group := testGroup()
 	failed := &seiv1alpha1.SeiNode{
 		ObjectMeta: metav1.ObjectMeta{
@@ -167,6 +168,7 @@ func TestCreateExporter_Execute_DeletesFailedExporter(t *testing.T) {
 	cfg := testGroupCfg(t, group, failed)
 
 	params := CreateExporterParams{
+		GroupName:     "fork-group",
 		ExporterName:  "fork-group-exporter",
 		Namespace:     "default",
 		SourceChainID: "pacific-1",
@@ -180,20 +182,19 @@ func TestCreateExporter_Execute_DeletesFailedExporter(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := exec.Execute(ctx); err != nil {
-		t.Fatalf("Execute: %v", err)
+	execErr := exec.Execute(ctx)
+	if execErr == nil {
+		t.Fatal("expected Terminal error for Failed exporter, got nil")
 	}
-	// Should NOT be complete — the failed exporter was deleted,
-	// next reconcile will re-enter and create a fresh one.
-	if exec.Status(ctx) != ExecutionRunning {
-		t.Fatalf("expected Running (pending recreate), got %s", exec.Status(ctx))
+	var te *TerminalError
+	if !errors.As(execErr, &te) {
+		t.Fatalf("expected *TerminalError, got %T: %v", execErr, execErr)
 	}
 
-	// Verify the failed exporter was deleted
+	// The Failed exporter must NOT be deleted — operator inspects + manually drains.
 	node := &seiv1alpha1.SeiNode{}
-	err = cfg.KubeClient.Get(ctx, types.NamespacedName{Name: "fork-group-exporter", Namespace: "default"}, node)
-	if !apierrors.IsNotFound(err) {
-		t.Fatalf("expected NotFound after deleting failed exporter, got %v", err)
+	if err := cfg.KubeClient.Get(ctx, types.NamespacedName{Name: "fork-group-exporter", Namespace: "default"}, node); err != nil {
+		t.Fatalf("Failed exporter must remain for operator inspection; got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`create-exporter` previously had auto-retry logic: if the exporter SeiNode existed in `PhaseFailed`, the task would delete it and let the next reconcile create a fresh one. That sounds correct in isolation, but it contaminates the broader fork-genesis ceremony.

## The bug we hit

During a fork-genesis validation deploy on Harbor (`eng-bdchatham`), the bootstrap pod's seid process failed at startup. With `BackoffLimit: 0` the Job marked Failed → exporter SeiNode Failed → SND plan replanned → `create-exporter` deleted the failed exporter → fresh exporter created → fresh bootstrap pod. We saw this cycle repeat.

But each iteration's identity / gentx / assembled-genesis artifacts get uploaded to S3 as the ceremony progresses. The next iteration's freshly-generated identities don't match the validator-set baked into the prior iteration's S3 artifacts. The symptom — caught on iteration 3 of our deploy — was:

```
Witness reports conflicting proposer priorities.
err: validator set's proposer priority hashes do not match
state sync failed; shutting down this node
```

A misleading P2P-state-sync error that's actually about validator-set contamination from stale S3 state.

## The fix

```diff
 if existing.Status.Phase == seiv1alpha1.PhaseFailed {
-    if delErr := e.cfg.KubeClient.Delete(ctx, existing); delErr != nil && !apierrors.IsNotFound(delErr) {
-        return fmt.Errorf("deleting failed exporter: %w", delErr)
-    }
-    return nil // next reconcile will re-enter Execute and create a new exporter
+    return Terminal(fmt.Errorf(
+        "exporter %s/%s is Failed — drain the SeiNodeDeployment and clear "+
+            "stale artifacts under %s/%s in the genesis-artifacts bucket before retrying",
+        e.params.Namespace, e.params.ExporterName,
+        e.params.SourceChainID, e.params.GroupName))
 }
```

Trades automated recovery (which was wrong anyway) for a clear failure signal. The operator inspects the failed exporter, drains the SND, clears stale S3 artifacts under `<sourceChainId>/<groupName>/`, then re-applies. The error message points right at the cleanup target.

## Test plan

- [x] `TestCreateExporter_Execute_FailsTerminallyOnFailedExporter` — asserts Terminal error and that the Failed exporter is preserved for inspection
- [x] `TestCreateExporter_Execute_CreatesSeiNode`, `TestCreateExporter_Execute_Idempotent` — unchanged, still pass
- [x] `make test`, `make lint` clean

## Follow-up worth tracking separately

The S3 artifact cleanup is currently fully manual. A future improvement would have the controller (or a deletion-time hook) clear `<sourceChainId>/<groupName>/` from the genesis-artifacts bucket on SeiNodeDeployment teardown. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)