### PR TITLE
chore: bump controller image to f24b7cf (fork-genesis non-retryable)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:16bb007c2759cbfaf5051a22fe23a9c2d4695b03
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:f24b7cffde34fb32bd805eed3e2b1f272945aa29
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Bumps the controller image in `config/manager/manager.yaml`:

- **Old:** `16bb007c2759cbfaf5051a22fe23a9c2d4695b03`
- **New:** `f24b7cffde34fb32bd805eed3e2b1f272945aa29`

The new image includes:

- **PR #152** — `create-exporter` task now fails terminally on a Failed exporter SeiNode instead of auto-deleting + recreating it. Eliminates a silent S3-artifact-contamination loop in fork-genesis ceremonies that produced misleading Tendermint state-sync errors (`validator set's proposer priority hashes do not match`).

[ECR build run](https://github.com/sei-protocol/sei-k8s-controller/actions/runs/25180503568) succeeded for commit `f24b7cf`.

## Test plan

- [x] ECR build for `f24b7cf` completed successfully
- [x] Manifest diff is the single image-SHA line
- [x] Apply to Harbor cluster, observe controller pod restart with new image
- [x] Re-add SND fork-test fixture (revert of platform PR #293) and confirm: a Failed exporter now leaves the SND plan in Failed state instead of cycling through silent retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)