### PR TITLE
feat(planner): force seid logging.level=info in config-apply overrides

### DIFF
--- a/internal/planner/forced_overrides_test.go
+++ b/internal/planner/forced_overrides_test.go
@@ -1,7 +1,13 @@
 package planner
 
 import (
+	"encoding/json"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/task"
 )
 
 func TestMergeOverrides_ForcesLoggingLevelInfo(t *testing.T) {
@@ -52,5 +58,47 @@ func TestMergeOverrides_NestedCallsConvergeToInfo(t *testing.T) {
 	outer := mergeOverrides(inner, map[string]string{overrideKeyLoggingLevel: "debug"})
 	if got := outer[overrideKeyLoggingLevel]; got != enforcedLoggingLevel {
 		t.Fatalf("nested merge with user debug: logging.level = %q, want %q", got, enforcedLoggingLevel)
+	}
+}
+
+func TestFullNodePlanner_ConfigApplyForcesLoggingLevel(t *testing.T) {
+	node := &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "fullnode-0", Namespace: "pacific-1"},
+		Spec: seiv1alpha1.SeiNodeSpec{
+			ChainID:  "pacific-1",
+			Image:    "seid:v6.4.1",
+			FullNode: &seiv1alpha1.FullNodeSpec{},
+			Overrides: map[string]string{
+				overrideKeyLoggingLevel: "debug",
+			},
+		},
+	}
+
+	plan, err := (&fullNodePlanner{}).BuildPlan(node)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	var configApply *seiv1alpha1.PlannedTask
+	for i := range plan.Tasks {
+		if plan.Tasks[i].Type == TaskConfigApply {
+			configApply = &plan.Tasks[i]
+			break
+		}
+	}
+	if configApply == nil {
+		t.Fatal("no config-apply task in plan")
+	}
+	if configApply.Params == nil {
+		t.Fatal("config-apply task has no params")
+	}
+
+	var params task.ConfigApplyParams
+	if err := json.Unmarshal(configApply.Params.Raw, &params); err != nil {
+		t.Fatalf("unmarshal config-apply params: %v", err)
+	}
+	if got := params.Overrides[overrideKeyLoggingLevel]; got != enforcedLoggingLevel {
+		t.Errorf("config-apply Overrides[%s] = %q, want %q (user-supplied debug should be rejected)",
+			overrideKeyLoggingLevel, got, enforcedLoggingLevel)
 	}
 }

--- a/internal/planner/forced_overrides_test.go
+++ b/internal/planner/forced_overrides_test.go
@@ -1,0 +1,56 @@
+package planner
+
+import (
+	"testing"
+)
+
+func TestMergeOverrides_ForcesLoggingLevelInfo(t *testing.T) {
+	cases := []struct {
+		name string
+		user map[string]string
+	}{
+		{"user_debug", map[string]string{overrideKeyLoggingLevel: "debug"}},
+		{"user_warn", map[string]string{overrideKeyLoggingLevel: "warn"}},
+		{"user_info", map[string]string{overrideKeyLoggingLevel: "info"}},
+		{"user_empty", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			merged := mergeOverrides(nil, tc.user)
+			if got := merged[overrideKeyLoggingLevel]; got != enforcedLoggingLevel {
+				t.Fatalf("logging.level = %q, want %q", got, enforcedLoggingLevel)
+			}
+		})
+	}
+}
+
+func TestMergeOverrides_PreservesNonForcedUserKeys(t *testing.T) {
+	merged := mergeOverrides(
+		map[string]string{"network.p2p.external_address": "ctrl.address:26656"},
+		map[string]string{
+			"network.p2p.external_address": "user.address:26656",
+			"storage.snapshot_interval":    "1000",
+			overrideKeyLoggingLevel:        "debug",
+		},
+	)
+	if got := merged["network.p2p.external_address"]; got != "user.address:26656" {
+		t.Errorf("user override should win for non-forced key: got %q", got)
+	}
+	if got := merged["storage.snapshot_interval"]; got != "1000" {
+		t.Errorf("user key should pass through: got %q", got)
+	}
+	if got := merged[overrideKeyLoggingLevel]; got != enforcedLoggingLevel {
+		t.Errorf("forced key should override user: got %q, want %q", got, enforcedLoggingLevel)
+	}
+}
+
+func TestMergeOverrides_NestedCallsConvergeToInfo(t *testing.T) {
+	inner := mergeOverrides(
+		map[string]string{"a": "1"},
+		map[string]string{"b": "2"},
+	)
+	outer := mergeOverrides(inner, map[string]string{overrideKeyLoggingLevel: "debug"})
+	if got := outer[overrideKeyLoggingLevel]; got != enforcedLoggingLevel {
+		t.Fatalf("nested merge with user debug: logging.level = %q, want %q", got, enforcedLoggingLevel)
+	}
+}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -44,6 +44,11 @@ const (
 	TaskAwaitNodesRunning      = task.TaskTypeAwaitNodesRunning
 )
 
+const (
+	overrideKeyLoggingLevel = "logging.level"
+	enforcedLoggingLevel    = "info"
+)
+
 // baseProgression defines the ordered task sequence for each bootstrap mode.
 var baseProgression = map[string][]string{
 	"snapshot":   {TaskSnapshotRestore, TaskConfigApply, TaskConfigValidate, TaskMarkReady},
@@ -715,11 +720,6 @@ func mergeOverrides(controllerOverrides, userOverrides map[string]string) map[st
 	applyForcedOverrides(merged, userOverrides)
 	return merged
 }
-
-const (
-	overrideKeyLoggingLevel = "logging.level"
-	enforcedLoggingLevel    = "info"
-)
 
 func applyForcedOverrides(merged, userOverrides map[string]string) {
 	if got, ok := userOverrides[overrideKeyLoggingLevel]; ok && got != enforcedLoggingLevel {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/controller/observability"
 	"github.com/sei-protocol/sei-k8s-controller/internal/task"
@@ -707,11 +709,26 @@ func buildNodeUpdatePlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, erro
 // mergeOverrides combines controller-generated overrides with user-specified
 // overrides. User overrides take precedence.
 func mergeOverrides(controllerOverrides, userOverrides map[string]string) map[string]string {
-	if len(controllerOverrides) == 0 && len(userOverrides) == 0 {
-		return nil
-	}
-	merged := make(map[string]string, len(controllerOverrides)+len(userOverrides))
+	merged := make(map[string]string, len(controllerOverrides)+len(userOverrides)+1)
 	maps.Copy(merged, controllerOverrides)
 	maps.Copy(merged, userOverrides)
+	applyForcedOverrides(merged, userOverrides)
 	return merged
+}
+
+const (
+	overrideKeyLoggingLevel = "logging.level"
+	enforcedLoggingLevel    = "info"
+)
+
+func applyForcedOverrides(merged, userOverrides map[string]string) {
+	if got, ok := userOverrides[overrideKeyLoggingLevel]; ok && got != enforcedLoggingLevel {
+		ctrl.Log.WithName("planner").Info(
+			"rejecting user override",
+			"key", overrideKeyLoggingLevel,
+			"user_value", got,
+			"forced_value", enforcedLoggingLevel,
+		)
+	}
+	merged[overrideKeyLoggingLevel] = enforcedLoggingLevel
 }


### PR DESCRIPTION
## Summary

Closes #155. Locks `logging.level=info` in the override map that the controller passes to the sidecar's config-apply task. User-supplied `Spec.Overrides` cannot escape this — `logging.level=debug` at projected validator/RPC volume would 10-50x the Loki ingest rate per round-2 measurements, and could DoS the logging pipeline before any volume-spike alert ([sei-protocol/platform docs/designs/loki-strategy.md](https://github.com/sei-protocol/platform/blob/main/docs/designs/loki-strategy.md)).

## Mechanism

`mergeOverrides` already merges `controllerOverrides + userOverrides` (user wins). New `applyForcedOverrides` runs after the merge and stamps the forced key, logging a rejection line if the user supplied a different value.

```go
const (
    overrideKeyLoggingLevel = "logging.level"
    enforcedLoggingLevel    = "info"
)

func applyForcedOverrides(merged, userOverrides map[string]string) {
    if got, ok := userOverrides[overrideKeyLoggingLevel]; ok && got != enforcedLoggingLevel {
        ctrl.Log.WithName("planner").Info(
            "rejecting user override",
            "key", overrideKeyLoggingLevel,
            "user_value", got,
            "forced_value", enforcedLoggingLevel,
        )
    }
    merged[overrideKeyLoggingLevel] = enforcedLoggingLevel
}
```

Single insertion point covers every role planner (validator, full, archive, replayer) and the bootstrap genesis path — they all flow through `mergeOverrides`. Nested merge calls converge correctly: inner forces info, outer accepts user input that may overwrite it, then re-forces info (with the rejection log).

## One-way doors

This proposal locks the following backward-compat surfaces:
- `logging.level` value on every controller-managed SeiNode is now `info`. Per-node debug escape is explicitly out of scope (issue #155); future need files a separate issue with a TTL-bound CRD field.

## Test plan

- [x] `TestMergeOverrides_ForcesLoggingLevelInfo` — table test covering user_debug / user_warn / user_info / user_empty
- [x] `TestMergeOverrides_PreservesNonForcedUserKeys` — non-forced user overrides still take precedence
- [x] `TestMergeOverrides_NestedCallsConvergeToInfo` — nested merge with debug input still ends at info
- [x] Existing `TestCommonOverrides_*` continue to pass
- [x] `gofmt -s -l` clean
- [x] Existing SeiNodes pick up `info` on next reconcile (no StatefulSet bounce — sidecar config-apply is a hot path, runs without pod restart)

## Notes

- The signature accepts `userOverrides` as the rejection-detection source. In the nested call site (e.g. fullNode/archive), the inner mergeOverrides treats `controllerOverrides()` as `userOverrides`. Since none of the role planners set `logging.level`, no spurious rejection log fires there. Outer call passes `Spec.Overrides`, which is where user input arrives.
- `mergeOverrides` previously returned nil when both inputs were empty; now always returns a map containing at least `logging.level=info`. Callers pass the result to `task.ConfigApplyParams.Overrides` (`omitempty`); the field will now always be present (with at minimum the forced key). Sidecar already handles populated override maps; no compat issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)