### PR TITLE
chore(dockerfile): bump golang 1.25 → 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary

ECR build on main started failing after #162 merged:

\`\`\`
#14 [builder 5/7] RUN go mod download
#14 0.052 go: go.mod requires go >= 1.26.0 (running go 1.25.9; GOTOOLCHAIN=local)
\`\`\`

#162 bumped seictl to v0.0.37 which dragged \`go.mod\`'s \`go\` directive to \`1.26.0\`. The Dockerfile's builder image still pinned \`golang:1.25\`, which has go 1.25.9 — too old.

One-line bump: \`FROM golang:1.25\` → \`FROM golang:1.26\`.

## Verification

- ECR build run that failed: https://github.com/sei-protocol/sei-k8s-controller/actions/runs/25266347172
- Once this lands and builds, the resulting image SHA replaces the current \`DefaultSidecarImage\` upstream-side reference and unblocks the harbor controller-image bump in platform-seictl-smoke (last hop to close out #160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)