### PR TITLE
chore: bump controller image to 8a30847 (Genesis.Accounts wiring)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:3114b4afe3f1a417b2bee31d02538bd97563e140
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8a3084788d45178ebe436050672c138e9402da65
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Rolls out the controller-side wiring from #162 (closes #160 — fund non-validator accounts at chain genesis via `Spec.Genesis.Accounts[]`) plus the Dockerfile go 1.26 bump from #165.

## Image details

- ECR: `189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8a3084788d45178ebe436050672c138e9402da65`
- Manifest digest: `sha256:cba05c2eef5578bc67c406cc799be6bbadf15623ea740b3c842e7d3174799bb7`
- Built from main commit `8a30847` (= squash-merge of #165 on top of #162's merge)
- ECR build run: https://github.com/sei-protocol/sei-k8s-controller/actions/runs/25280777170

## What rolls out with this image

- `Spec.Genesis.Accounts[]` is now wired through the planner; both fork and non-fork ceremonies fund the listed addresses at chain genesis. Strict bech32 validation surfaces at `kubectl describe seinodedeployment` time.
- `DefaultSidecarImage` pinned to v0.0.36 sidecar (`@sha256:97f9f988...`) which has the server-side `addExternalGenesisAccounts` work.

## Rollout plan

After merge, Flux reconciles `clusters/prod/sei-k8s-controller/` (which pulls `?ref=main`) and the harbor controller deployment picks up the new image. Same flow as #159.

## Closes

- #160

## Related

- #162 (controller wiring + delegating shell)
- #165 (Dockerfile golang 1.26 bump)
- sei-protocol/seictl#120 (sidecar server `addExternalGenesisAccounts`)
- sei-protocol/seictl#121 (client typed wrappers)
- #161 (follow-up: drop `taskParamser`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)