### PR TITLE
chore(platform): bump DefaultSidecarImage to post-#128 GHCR image

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -5,7 +5,7 @@ import "fmt"
 const (
 	// DefaultSidecarImage is the seictl sidecar image used when not overridden
 	// by the SeiNode spec. Shared between the node controller and bootstrap task.
-	DefaultSidecarImage = "ghcr.io/sei-protocol/seictl@sha256:97f9f98836847cc78b15cda4da397ad350e6521ec467ebfc058c5b32810f4c74"
+	DefaultSidecarImage = "ghcr.io/sei-protocol/seictl@sha256:f3ed12978d1e7a5376ca89d97e2dfc7fd21a506dd9e05b8ae131d1a711fbbfb7"
 
 	// DataDir is the mount path for the sei data volume inside node pods.
 	DataDir = "/sei"


### PR DESCRIPTION
## Summary

Bumps \`internal/platform/platform.go:DefaultSidecarImage\` to pull in seictl#128 (the metadata.db file-vs-directory dispatch fix).

\`\`\`
- ghcr.io/sei-protocol/seictl@sha256:97f9f988…   (pre-#128, broken on directory metadata.db)
+ ghcr.io/sei-protocol/seictl@sha256:f3ed1297…   (post-#128, multi-arch)
\`\`\`

## Why

The old default image hardcoded \`addFileToTar\` for \`/sei/data/snapshots/metadata.db\`, which fails with \`is a directory\` when metadata.db is a LevelDB directory (the actual cosmos-sdk layout). The new image dispatches on \`info.IsDir()\` and falls back to \`addFileToTar\` only for the file case.

## Verified end-to-end

Pacific-1/syncer-0-0-0 was patched onto the new sidecar image and a manually-fired \`snapshot-upload\` task ran. Logs showed the file streaming through without the \"is a directory\" failure that bricked the prior attempt at the metadata.db tar entry.

## Effect on consumers

SNDs that don't pin \`spec.template.spec.sidecar.image\` will inherit this image once the controller rebuilds. SNDs with explicit pins (e.g., the protocol manifests in the platform repo, or the fork-test) get their own bumps tracked separately.

## Test plan

- [x] \`go build ./...\` clean.
- [x] Tests touching the constant pass (\`internal/task/...\`, \`internal/noderesource/...\`).
- [x] After merge → GHA builds new controller image → standard "chore: bump controller image" sync follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)