### PR TITLE
refactor(task): make bootstrap helpers SeiNode-free via BootstrapPodInputs

### DIFF
--- a/internal/controller/node/plan_execution_test.go
+++ b/internal/controller/node/plan_execution_test.go
@@ -11,8 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	seiconfig "github.com/sei-protocol/sei-config"
 	sidecar "github.com/sei-protocol/seictl/sidecar/client"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -840,124 +838,6 @@ func TestNeedsBootstrap(t *testing.T) {
 				t.Errorf("NeedsBootstrap() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-// --- Bootstrap resource builder tests (task package) ---
-
-func TestTaskGenerateBootstrapJob(t *testing.T) {
-	node := replayerNode()
-	node.Spec.Replayer.Snapshot.BootstrapImage = testBootstrapImageV1
-	snap := node.Spec.SnapshotSource()
-	job, err := task.GenerateBootstrapJob(node, snap, platformtest.Config())
-	if err != nil {
-		t.Fatalf("GenerateBootstrapJob error: %v", err)
-	}
-
-	wantName := "test-replayer-bootstrap"
-	if job.Name != wantName {
-		t.Errorf("Job name = %q, want %q", job.Name, wantName)
-	}
-
-	spec := job.Spec.Template.Spec
-	if spec.RestartPolicy != corev1.RestartPolicyNever {
-		t.Errorf("RestartPolicy = %q, want Never", spec.RestartPolicy)
-	}
-	if spec.Containers[0].Image != testBootstrapImageV1 {
-		t.Errorf("main container image = %q, want %q", spec.Containers[0].Image, testBootstrapImageV1)
-	}
-}
-
-func TestTaskGenerateBootstrapJob_NilSnapshot(t *testing.T) {
-	node := replayerNode()
-	_, err := task.GenerateBootstrapJob(node, nil, platformtest.Config())
-	if err == nil {
-		t.Fatal("expected error for nil snapshot, got nil")
-	}
-}
-
-func TestTaskGenerateBootstrapJob_SidecarResources(t *testing.T) {
-	node := replayerNode()
-	node.Spec.Replayer.Snapshot.BootstrapImage = testBootstrapImageV1
-	node.Spec.Sidecar = &seiv1alpha1.SidecarConfig{
-		Resources: &corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("500m"),
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
-			},
-		},
-	}
-	snap := node.Spec.SnapshotSource()
-	job, err := task.GenerateBootstrapJob(node, snap, platformtest.Config())
-	if err != nil {
-		t.Fatalf("GenerateBootstrapJob error: %v", err)
-	}
-	spec := job.Spec.Template.Spec
-
-	sc := spec.InitContainers[1]
-	cpuReq := sc.Resources.Requests[corev1.ResourceCPU]
-	if cpuReq.String() != "500m" {
-		t.Errorf("sidecar CPU request = %q, want %q", cpuReq.String(), "500m")
-	}
-}
-
-// TestTaskGenerateBootstrapJob_NeverHasIdentityVolumes is the safety
-// regression guard for the load-bearing invariants on validator identity
-// material. The bootstrap pod must never carry the consensus signing key
-// (slashing risk, LLD §3) AND must never carry the validator's permanent
-// node key (peer-reputation pollution risk — bootstrap pods crash, halt,
-// and restart, and that misbehavior must not attribute to the validator's
-// permanent libp2p identity).
-func TestTaskGenerateBootstrapJob_NeverHasIdentityVolumes(t *testing.T) {
-	node := &seiv1alpha1.SeiNode{
-		ObjectMeta: metav1.ObjectMeta{Name: "validator-0", Namespace: "default"},
-		Spec: seiv1alpha1.SeiNodeSpec{
-			ChainID: "atlantic-2",
-			Image:   "ghcr.io/sei-protocol/seid:latest",
-			Validator: &seiv1alpha1.ValidatorSpec{
-				Snapshot: &seiv1alpha1.SnapshotSource{
-					BootstrapImage: testBootstrapImageV1,
-					S3:             &seiv1alpha1.S3SnapshotSource{TargetHeight: 100000000},
-				},
-				SigningKey: &seiv1alpha1.SigningKeySource{
-					Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: "validator-0-key"},
-				},
-				NodeKey: &seiv1alpha1.NodeKeySource{
-					Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: "validator-0-nodekey"},
-				},
-			},
-		},
-	}
-	snap := node.Spec.SnapshotSource()
-	job, err := task.GenerateBootstrapJob(node, snap, platformtest.Config())
-	if err != nil {
-		t.Fatalf("GenerateBootstrapJob error: %v", err)
-	}
-	forbiddenVolumeNames := map[string]string{
-		"signing-key": "consensus signing material — slashing risk (LLD §3)",
-		"node-key":    "validator permanent node ID — peer-reputation pollution risk",
-	}
-	forbiddenSecretNames := map[string]string{
-		"validator-0-key":     "consensus signing Secret",
-		"validator-0-nodekey": "validator node-key Secret",
-	}
-	for _, v := range job.Spec.Template.Spec.Volumes {
-		if reason, forbidden := forbiddenVolumeNames[v.Name]; forbidden {
-			t.Fatalf("bootstrap Job pod-spec must NEVER include volume %q (%s); found %+v", v.Name, reason, v)
-		}
-		if v.Secret != nil {
-			if reason, forbidden := forbiddenSecretNames[v.Secret.SecretName]; forbidden {
-				t.Fatalf("bootstrap Job pod-spec must NEVER mount Secret %q (%s); found volume %q",
-					v.Secret.SecretName, reason, v.Name)
-			}
-		}
-	}
-	for _, c := range job.Spec.Template.Spec.Containers {
-		for _, m := range c.VolumeMounts {
-			if reason, forbidden := forbiddenVolumeNames[m.Name]; forbidden {
-				t.Fatalf("bootstrap Job container %q must NEVER mount %q (%s)", c.Name, m.Name, reason)
-			}
-		}
 	}
 }
 

--- a/internal/planner/bootstrap.go
+++ b/internal/planner/bootstrap.go
@@ -21,7 +21,7 @@ func buildBootstrapPlan(
 	planID := uuid.New().String()
 	planIndex := 0
 
-	jobName := task.BootstrapJobName(node)
+	jobName := task.BootstrapJobName(node.Name)
 	serviceName := node.Name
 
 	bootstrapProg, err := buildSidecarProgression(snap, peers)

--- a/internal/task/bootstrap_job.go
+++ b/internal/task/bootstrap_job.go
@@ -49,9 +49,6 @@ func (e *deployBootstrapJobExecution) Execute(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("generating bootstrap job spec: %w", err)
 	}
-	if err := assertNoSigningKeyOnBootstrapPod(node, &job.Spec.Template.Spec); err != nil {
-		return err
-	}
 	if err := ctrl.SetControllerReference(node, job, e.cfg.Scheme); err != nil {
 		return fmt.Errorf("setting owner reference on bootstrap job: %w", err)
 	}

--- a/internal/task/bootstrap_job.go
+++ b/internal/task/bootstrap_job.go
@@ -44,9 +44,13 @@ func (e *deployBootstrapJobExecution) Execute(ctx context.Context) error {
 		return err
 	}
 	snap := node.Spec.SnapshotSource()
-	job, err := GenerateBootstrapJob(node, snap, e.cfg.Platform)
+	inputs := nodeToBootstrapInputs(node, snap)
+	job, err := GenerateBootstrapJob(inputs, e.cfg.Platform)
 	if err != nil {
 		return fmt.Errorf("generating bootstrap job spec: %w", err)
+	}
+	if err := assertNoSigningKeyOnBootstrapPod(node, &job.Spec.Template.Spec); err != nil {
+		return err
 	}
 	if err := ctrl.SetControllerReference(node, job, e.cfg.Scheme); err != nil {
 		return fmt.Errorf("setting owner reference on bootstrap job: %w", err)

--- a/internal/task/bootstrap_node_adapter.go
+++ b/internal/task/bootstrap_node_adapter.go
@@ -32,7 +32,7 @@ func nodeToBootstrapInputs(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.Snapshot
 		sidecarImage = node.Spec.Sidecar.Image
 	}
 
-	sidecarPort := int32(seiconfig.PortSidecar)
+	sidecarPort := seiconfig.PortSidecar
 	if node.Spec.Sidecar != nil && node.Spec.Sidecar.Port != 0 {
 		sidecarPort = node.Spec.Sidecar.Port
 	}

--- a/internal/task/bootstrap_node_adapter.go
+++ b/internal/task/bootstrap_node_adapter.go
@@ -1,8 +1,6 @@
 package task
 
 import (
-	"fmt"
-
 	seiconfig "github.com/sei-protocol/sei-config"
 	corev1 "k8s.io/api/core/v1"
 
@@ -10,26 +8,23 @@ import (
 )
 
 // nodeToBootstrapInputs translates a SeiNode (and its resolved SnapshotSource,
-// when present) into the value-typed BootstrapPodInputs consumed by the
-// SeiNode-free bootstrap helpers in bootstrap_resources.go.
+// when present) into the value-typed BootstrapPodInputs.
 //
-// snap may be nil. The Service path (bootstrap_service.go) does not have a
-// snapshot in scope; only Name/Namespace/SidecarPort are read by the Service
-// builder, so this adapter still produces a usable struct in that case.
-// GenerateBootstrapJob enforces the Job-side invariants (BootstrapImage,
-// HaltHeight) directly.
+// snap may be nil; the Service path doesn't have a snapshot in scope and only
+// reads Name/Namespace/SidecarPort. GenerateBootstrapJob enforces the rest.
 //
 // Resolution rules:
-//   - BootstrapImage: snap.BootstrapImage if non-empty, else node.Spec.Image.
-//     SeidImage is set to the same value — both seid containers (init + main)
-//     share the bootstrap-resolved image today.
+//   - Image: snap.BootstrapImage if non-empty, else node.Spec.Image.
 //   - SidecarImage / SidecarPort: SeiNode override if set, else platform default.
-//   - Mode: derived from which Spec.{Archive,Validator} block is set.
+//   - Mode: derived from which Spec.{Archive,Validator} block is set; full otherwise.
 //   - HaltHeight: snap.S3.TargetHeight when snap.S3 is set; 0 otherwise.
+//   - ForbiddenSecretNames: validator's signing-key and node-key Secret names
+//     when the SeiNode is a validator. GenerateBootstrapJob fails closed if
+//     either ever lands as a Volume on the bootstrap pod.
 func nodeToBootstrapInputs(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.SnapshotSource) BootstrapPodInputs {
-	bootstrapImage := node.Spec.Image
+	image := node.Spec.Image
 	if snap != nil && snap.BootstrapImage != "" {
-		bootstrapImage = snap.BootstrapImage
+		image = snap.BootstrapImage
 	}
 
 	sidecarImage := bootstrapDefaultSidecarImage
@@ -63,40 +58,32 @@ func nodeToBootstrapInputs(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.Snapshot
 	}
 
 	return BootstrapPodInputs{
-		Name:             node.Name,
-		Namespace:        node.Namespace,
-		ChainID:          node.Spec.ChainID,
-		SeidImage:        bootstrapImage,
-		BootstrapImage:   bootstrapImage,
-		SidecarImage:     sidecarImage,
-		SidecarPort:      sidecarPort,
-		SidecarResources: sidecarResources,
-		Mode:             mode,
-		HaltHeight:       haltHeight,
+		Name:                 node.Name,
+		Namespace:            node.Namespace,
+		ChainID:              node.Spec.ChainID,
+		Image:                image,
+		SidecarImage:         sidecarImage,
+		SidecarPort:          sidecarPort,
+		SidecarResources:     sidecarResources,
+		Mode:                 mode,
+		HaltHeight:           haltHeight,
+		ForbiddenSecretNames: validatorSecretNames(node),
 	}
 }
 
-// assertNoSigningKeyOnBootstrapPod fails closed if a future refactor
-// accidentally lands the validator's signing-key Secret on the bootstrap
-// pod-spec. The bootstrap path must never carry consensus signing material.
-//
-// Lives at the per-SeiNode adapter boundary because it reads
-// node.Spec.Validator.SigningKey.Secret.SecretName, which doesn't exist
-// in BootstrapPodInputs. SND fork-genesis paths physically cannot leak
-// signing material — there is no SeiNode and no Validator config in scope.
-func assertNoSigningKeyOnBootstrapPod(node *seiv1alpha1.SeiNode, spec *corev1.PodSpec) error {
-	if node.Spec.Validator == nil ||
-		node.Spec.Validator.SigningKey == nil ||
-		node.Spec.Validator.SigningKey.Secret == nil {
+// validatorSecretNames returns the Secret names referenced by a validator's
+// signing-key and node-key sources, so GenerateBootstrapJob can refuse to
+// produce a bootstrap pod that mounts either.
+func validatorSecretNames(node *seiv1alpha1.SeiNode) []string {
+	if node.Spec.Validator == nil {
 		return nil
 	}
-	secretName := node.Spec.Validator.SigningKey.Secret.SecretName
-	for _, v := range spec.Volumes {
-		if v.Secret != nil && v.Secret.SecretName == secretName {
-			return fmt.Errorf("bootstrap pod-spec for %s/%s references signing-key Secret %q on volume %q; "+
-				"bootstrap pods must never carry consensus signing material",
-				node.Namespace, node.Name, secretName, v.Name)
-		}
+	var names []string
+	if k := node.Spec.Validator.SigningKey; k != nil && k.Secret != nil && k.Secret.SecretName != "" {
+		names = append(names, k.Secret.SecretName)
 	}
-	return nil
+	if k := node.Spec.Validator.NodeKey; k != nil && k.Secret != nil && k.Secret.SecretName != "" {
+		names = append(names, k.Secret.SecretName)
+	}
+	return names
 }

--- a/internal/task/bootstrap_node_adapter.go
+++ b/internal/task/bootstrap_node_adapter.go
@@ -1,0 +1,102 @@
+package task
+
+import (
+	"fmt"
+
+	seiconfig "github.com/sei-protocol/sei-config"
+	corev1 "k8s.io/api/core/v1"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+)
+
+// nodeToBootstrapInputs translates a SeiNode (and its resolved SnapshotSource,
+// when present) into the value-typed BootstrapPodInputs consumed by the
+// SeiNode-free bootstrap helpers in bootstrap_resources.go.
+//
+// snap may be nil. The Service path (bootstrap_service.go) does not have a
+// snapshot in scope; only Name/Namespace/SidecarPort are read by the Service
+// builder, so this adapter still produces a usable struct in that case.
+// GenerateBootstrapJob enforces the Job-side invariants (BootstrapImage,
+// HaltHeight) directly.
+//
+// Resolution rules:
+//   - BootstrapImage: snap.BootstrapImage if non-empty, else node.Spec.Image.
+//     SeidImage is set to the same value — both seid containers (init + main)
+//     share the bootstrap-resolved image today.
+//   - SidecarImage / SidecarPort: SeiNode override if set, else platform default.
+//   - Mode: derived from which Spec.{Archive,Validator} block is set.
+//   - HaltHeight: snap.S3.TargetHeight when snap.S3 is set; 0 otherwise.
+func nodeToBootstrapInputs(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.SnapshotSource) BootstrapPodInputs {
+	bootstrapImage := node.Spec.Image
+	if snap != nil && snap.BootstrapImage != "" {
+		bootstrapImage = snap.BootstrapImage
+	}
+
+	sidecarImage := bootstrapDefaultSidecarImage
+	if node.Spec.Sidecar != nil && node.Spec.Sidecar.Image != "" {
+		sidecarImage = node.Spec.Sidecar.Image
+	}
+
+	sidecarPort := int32(seiconfig.PortSidecar)
+	if node.Spec.Sidecar != nil && node.Spec.Sidecar.Port != 0 {
+		sidecarPort = node.Spec.Sidecar.Port
+	}
+
+	var sidecarResources *corev1.ResourceRequirements
+	if node.Spec.Sidecar != nil && node.Spec.Sidecar.Resources != nil {
+		sidecarResources = node.Spec.Sidecar.Resources
+	}
+
+	var mode string
+	switch {
+	case node.Spec.Archive != nil:
+		mode = string(seiconfig.ModeArchive)
+	case node.Spec.Validator != nil:
+		mode = string(seiconfig.ModeValidator)
+	default:
+		mode = string(seiconfig.ModeFull)
+	}
+
+	var haltHeight int64
+	if snap != nil && snap.S3 != nil {
+		haltHeight = snap.S3.TargetHeight
+	}
+
+	return BootstrapPodInputs{
+		Name:             node.Name,
+		Namespace:        node.Namespace,
+		ChainID:          node.Spec.ChainID,
+		SeidImage:        bootstrapImage,
+		BootstrapImage:   bootstrapImage,
+		SidecarImage:     sidecarImage,
+		SidecarPort:      sidecarPort,
+		SidecarResources: sidecarResources,
+		Mode:             mode,
+		HaltHeight:       haltHeight,
+	}
+}
+
+// assertNoSigningKeyOnBootstrapPod fails closed if a future refactor
+// accidentally lands the validator's signing-key Secret on the bootstrap
+// pod-spec. The bootstrap path must never carry consensus signing material.
+//
+// Lives at the per-SeiNode adapter boundary because it reads
+// node.Spec.Validator.SigningKey.Secret.SecretName, which doesn't exist
+// in BootstrapPodInputs. SND fork-genesis paths physically cannot leak
+// signing material — there is no SeiNode and no Validator config in scope.
+func assertNoSigningKeyOnBootstrapPod(node *seiv1alpha1.SeiNode, spec *corev1.PodSpec) error {
+	if node.Spec.Validator == nil ||
+		node.Spec.Validator.SigningKey == nil ||
+		node.Spec.Validator.SigningKey.Secret == nil {
+		return nil
+	}
+	secretName := node.Spec.Validator.SigningKey.Secret.SecretName
+	for _, v := range spec.Volumes {
+		if v.Secret != nil && v.Secret.SecretName == secretName {
+			return fmt.Errorf("bootstrap pod-spec for %s/%s references signing-key Secret %q on volume %q; "+
+				"bootstrap pods must never carry consensus signing material",
+				node.Namespace, node.Name, secretName, v.Name)
+		}
+	}
+	return nil
+}

--- a/internal/task/bootstrap_resources.go
+++ b/internal/task/bootstrap_resources.go
@@ -23,13 +23,7 @@ const (
 )
 
 // BootstrapPodInputs is the resolved pod-shape contract for a bootstrap Job
-// and its sibling headless Service. Built once per call by an adapter that
-// has the upstream context (today: a SeiNode for per-node bootstrap).
-// Helpers below operate on this struct only — they no longer reach into a
-// SeiNode.
-//
-// The Service path uses only Name, Namespace, and SidecarPort and tolerates
-// the rest being zero-valued; GenerateBootstrapJob enforces the full set.
+// and its sibling headless Service.
 type BootstrapPodInputs struct {
 	// Name is the resource name root used for both the Job and the Service.
 	// Pod hostname becomes "<Name>-0" so the in-cluster sidecar URL is
@@ -43,19 +37,10 @@ type BootstrapPodInputs struct {
 	// directory and what the sidecar advertises as its SEI_CHAIN_ID.
 	ChainID string
 
-	// SeidImage is the image for the seid-init container (runs `seid init`
-	// once before the main containers).
-	SeidImage string
+	// Image is the seid image used by both the seid-init container and the
+	// main "seid" container that runs `seid start --halt-height N`.
+	Image string
 
-	// BootstrapImage is the image for the main "seid" container that runs
-	// `seid start --halt-height N`. The per-SeiNode adapter resolves this
-	// to snap.BootstrapImage when set, else node.Spec.Image, and assigns
-	// the same value to SeidImage.
-	BootstrapImage string
-
-	// SidecarImage / SidecarPort / SidecarResources are resolved at the
-	// adapter (with platform defaults applied) so the helpers below can
-	// stay value-driven.
 	SidecarImage     string
 	SidecarPort      int32
 	SidecarResources *corev1.ResourceRequirements
@@ -64,13 +49,20 @@ type BootstrapPodInputs struct {
 	// Drives nodepool selection and resource sizing via platform.Config.
 	Mode string
 
-	// HaltHeight is the seid --halt-height value. Required for Job; ignored
-	// for Service.
+	// HaltHeight is the seid --halt-height value.
 	HaltHeight int64
+
+	// ForbiddenSecretNames are Secret names that MUST NOT appear as Volume
+	// sources on the produced PodSpec. GenerateBootstrapJob fails closed if
+	// any are mounted, so the bootstrap pod cannot carry validator signing
+	// material even if a future caller wires a Secret volume by accident.
+	// Adapters with a validator in scope populate this with the validator's
+	// signing-key and node-key Secret names; adapters with no validator in
+	// scope leave it nil.
+	ForbiddenSecretNames []string
 }
 
 // BootstrapJobName returns the bootstrap Job name for a given resource root.
-// Pure string formatter — no SeiNode required.
 func BootstrapJobName(name string) string {
 	return fmt.Sprintf("%s-bootstrap", name)
 }
@@ -84,33 +76,33 @@ func BootstrapLabels(name string) map[string]string {
 }
 
 // GenerateBootstrapJob creates the batch Job that runs seid with --halt-height
-// to populate a PVC before the consumer (a StatefulSet today, an export Job
-// tomorrow) takes over.
-//
-// The pod-spec deliberately omits validator signing material. The per-SeiNode
-// adapter calls assertNoSigningKeyOnBootstrapPod after this returns to enforce
-// that invariant; the SND fork-genesis adapter has no SeiNode and physically
-// cannot leak signing material.
-func GenerateBootstrapJob(in BootstrapPodInputs, platformCfg platform.Config) (*batchv1.Job, error) {
-	if in.Name == "" || in.Namespace == "" {
-		return nil, fmt.Errorf("bootstrap job requires Name and Namespace (got %q/%q)", in.Namespace, in.Name)
+// to populate a PVC before the consumer takes over. Fails closed if any
+// inputs.ForbiddenSecretNames Secret is mounted on the resulting PodSpec, so
+// bootstrap pods cannot carry validator signing material regardless of caller.
+func GenerateBootstrapJob(inputs BootstrapPodInputs, platformCfg platform.Config) (*batchv1.Job, error) {
+	if inputs.Name == "" || inputs.Namespace == "" {
+		return nil, fmt.Errorf("bootstrap job requires Name and Namespace (got %q/%q)", inputs.Namespace, inputs.Name)
 	}
-	if in.ChainID == "" {
-		return nil, fmt.Errorf("bootstrap job requires ChainID (%s/%s)", in.Namespace, in.Name)
+	if inputs.ChainID == "" {
+		return nil, fmt.Errorf("bootstrap job requires ChainID (%s/%s)", inputs.Namespace, inputs.Name)
 	}
-	if in.SeidImage == "" || in.BootstrapImage == "" {
-		return nil, fmt.Errorf("bootstrap job requires SeidImage and BootstrapImage (%s/%s)", in.Namespace, in.Name)
+	if inputs.Image == "" {
+		return nil, fmt.Errorf("bootstrap job requires Image (%s/%s)", inputs.Namespace, inputs.Name)
 	}
-	if in.HaltHeight <= 0 {
-		return nil, fmt.Errorf("bootstrap job requires HaltHeight > 0 (got %d for %s/%s)", in.HaltHeight, in.Namespace, in.Name)
+	if inputs.HaltHeight <= 0 {
+		return nil, fmt.Errorf("bootstrap job requires HaltHeight > 0 (got %d for %s/%s)", inputs.HaltHeight, inputs.Namespace, inputs.Name)
 	}
-	labels := BootstrapLabels(in.Name)
-	podSpec := buildBootstrapPodSpec(in, platformCfg)
+	labels := BootstrapLabels(inputs.Name)
+	podSpec := buildBootstrapPodSpec(inputs, platformCfg)
+
+	if err := rejectForbiddenSecretMounts(&podSpec, inputs.ForbiddenSecretNames); err != nil {
+		return nil, fmt.Errorf("bootstrap pod-spec for %s/%s: %w", inputs.Namespace, inputs.Name, err)
+	}
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      BootstrapJobName(in.Name),
-			Namespace: in.Namespace,
+			Name:      BootstrapJobName(inputs.Name),
+			Namespace: inputs.Namespace,
 			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
@@ -129,19 +121,14 @@ func GenerateBootstrapJob(in BootstrapPodInputs, platformCfg platform.Config) (*
 	}, nil
 }
 
-// GenerateBootstrapService creates a headless Service that provides stable
-// DNS for the bootstrap Job pod. The pod registers as
-// <Name>-0.<Name>.<Namespace>.svc.cluster.local. On the per-SeiNode bootstrap
-// path the Service name matches the eventual StatefulSet's headless Service
-// name so the sidecar URL is consistent across both phases. On the SND fork
-// path the Service is owned by the SeiNodeDeployment and named after the
-// exporter resource root.
-func GenerateBootstrapService(in BootstrapPodInputs) *corev1.Service {
-	labels := BootstrapLabels(in.Name)
+// GenerateBootstrapService creates a headless Service so the bootstrap pod
+// registers as <Name>-0.<Name>.<Namespace>.svc.cluster.local.
+func GenerateBootstrapService(inputs BootstrapPodInputs) *corev1.Service {
+	labels := BootstrapLabels(inputs.Name)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      in.Name,
-			Namespace: in.Namespace,
+			Name:      inputs.Name,
+			Namespace: inputs.Namespace,
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
@@ -149,30 +136,53 @@ func GenerateBootstrapService(in BootstrapPodInputs) *corev1.Service {
 			Selector:                 labels,
 			PublishNotReadyAddresses: true,
 			Ports: []corev1.ServicePort{
-				{Name: "sidecar", Port: in.SidecarPort, TargetPort: intstr.FromInt32(in.SidecarPort), Protocol: corev1.ProtocolTCP},
+				{Name: "sidecar", Port: inputs.SidecarPort, TargetPort: intstr.FromInt32(inputs.SidecarPort), Protocol: corev1.ProtocolTCP},
 			},
 		},
 	}
 }
 
-func buildBootstrapPodSpec(in BootstrapPodInputs, platformCfg platform.Config) corev1.PodSpec {
+// rejectForbiddenSecretMounts fails closed if podSpec mounts any Secret whose
+// name is in forbidden. Returns nil for an empty forbidden list.
+func rejectForbiddenSecretMounts(podSpec *corev1.PodSpec, forbidden []string) error {
+	if len(forbidden) == 0 {
+		return nil
+	}
+	forbiddenSet := make(map[string]struct{}, len(forbidden))
+	for _, name := range forbidden {
+		if name != "" {
+			forbiddenSet[name] = struct{}{}
+		}
+	}
+	for _, vol := range podSpec.Volumes {
+		if vol.Secret == nil {
+			continue
+		}
+		if _, isForbidden := forbiddenSet[vol.Secret.SecretName]; isForbidden {
+			return fmt.Errorf("forbidden Secret %q mounted on volume %q", vol.Secret.SecretName, vol.Name)
+		}
+	}
+	return nil
+}
+
+func buildBootstrapPodSpec(inputs BootstrapPodInputs, platformCfg platform.Config) corev1.PodSpec {
 	dataVolume := corev1.Volume{
 		Name: "data",
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-				ClaimName: fmt.Sprintf("data-%s", in.Name),
+				ClaimName: fmt.Sprintf("data-%s", inputs.Name),
 			},
 		},
 	}
 
 	sidecar := corev1.Container{
 		Name:          "sei-sidecar",
-		Image:         in.SidecarImage,
+		Image:         inputs.SidecarImage,
 		Command:       []string{"seictl", "serve"},
 		RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
 		Env: []corev1.EnvVar{
-			{Name: "SEI_CHAIN_ID", Value: in.ChainID},
-			{Name: "SEI_SIDECAR_PORT", Value: fmt.Sprintf("%d", in.SidecarPort)},
+			{Name: "SEI_CHAIN_ID", Value: inputs.ChainID},
+			{Name: "SEI_SIDECAR_PORT", Value: fmt.Sprintf("%d", inputs.SidecarPort)},
 			{Name: "SEI_HOME", Value: bootstrapDataDir},
 			{Name: "SEI_GENESIS_BUCKET", Value: platformCfg.GenesisBucket},
 			{Name: "SEI_GENESIS_REGION", Value: platformCfg.GenesisRegion},
@@ -180,20 +190,20 @@ func buildBootstrapPodSpec(in BootstrapPodInputs, platformCfg platform.Config) c
 			{Name: "SEI_SNAPSHOT_REGION", Value: platformCfg.SnapshotRegion},
 		},
 		Ports: []corev1.ContainerPort{
-			{Name: "sidecar", ContainerPort: in.SidecarPort, Protocol: corev1.ProtocolTCP},
+			{Name: "sidecar", ContainerPort: inputs.SidecarPort, Protocol: corev1.ProtocolTCP},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: bootstrapDataDir},
 		},
 	}
-	if in.SidecarResources != nil {
-		sidecar.Resources = *in.SidecarResources
+	if inputs.SidecarResources != nil {
+		sidecar.Resources = *inputs.SidecarResources
 	}
 
-	seidCmd, seidArgs := bootstrapWaitCommand(in.SidecarPort, in.HaltHeight)
+	seidCmd, seidArgs := bootstrapWaitCommand(inputs.SidecarPort, inputs.HaltHeight)
 	seidContainer := corev1.Container{
 		Name:    "seid",
-		Image:   in.BootstrapImage,
+		Image:   inputs.Image,
 		Command: seidCmd,
 		Args:    seidArgs,
 		Env: []corev1.EnvVar{
@@ -202,16 +212,16 @@ func buildBootstrapPodSpec(in BootstrapPodInputs, platformCfg platform.Config) c
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: bootstrapDataDir},
 		},
-		Resources: bootstrapResourcesForMode(in.Mode, platformCfg),
+		Resources: bootstrapResourcesForMode(inputs.Mode, platformCfg),
 	}
 
-	seidInit := bootstrapSeidInitContainer(in)
+	seidInit := bootstrapSeidInitContainer(inputs)
 
-	pool := platformCfg.NodepoolForMode(in.Mode)
+	pool := platformCfg.NodepoolForMode(inputs.Mode)
 
 	return corev1.PodSpec{
-		Hostname:                      fmt.Sprintf("%s-0", in.Name),
-		Subdomain:                     in.Name,
+		Hostname:                      fmt.Sprintf("%s-0", inputs.Name),
+		Subdomain:                     inputs.Name,
 		ServiceAccountName:            platformCfg.ServiceAccount,
 		ShareProcessNamespace:         ptr.To(true),
 		RestartPolicy:                 corev1.RestartPolicyNever,
@@ -266,14 +276,14 @@ func bootstrapWaitCommand(port int32, haltHeight int64) (command []string, args 
 	return []string{"/bin/bash", "-c"}, []string{script}
 }
 
-func bootstrapSeidInitContainer(in BootstrapPodInputs) corev1.Container {
+func bootstrapSeidInitContainer(inputs BootstrapPodInputs) corev1.Container {
 	script := fmt.Sprintf(
 		`if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
-		bootstrapDataDir, in.ChainID, in.ChainID, bootstrapDataDir, bootstrapDataDir,
+		bootstrapDataDir, inputs.ChainID, inputs.ChainID, bootstrapDataDir, bootstrapDataDir,
 	)
 	return corev1.Container{
 		Name:  "seid-init",
-		Image: in.SeidImage,
+		Image: inputs.Image,
 		Command: []string{
 			"/bin/sh", "-c", script,
 		},

--- a/internal/task/bootstrap_resources.go
+++ b/internal/task/bootstrap_resources.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
-	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/platform"
 )
 
@@ -23,44 +22,95 @@ const (
 	bootstrapComponentLabel         = "sei.io/component"
 )
 
-// BootstrapJobName returns the bootstrap Job name for a node.
-func BootstrapJobName(node *seiv1alpha1.SeiNode) string {
-	return fmt.Sprintf("%s-bootstrap", node.Name)
+// BootstrapPodInputs is the resolved pod-shape contract for a bootstrap Job
+// and its sibling headless Service. Built once per call by an adapter that
+// has the upstream context (today: a SeiNode for per-node bootstrap).
+// Helpers below operate on this struct only — they no longer reach into a
+// SeiNode.
+//
+// The Service path uses only Name, Namespace, and SidecarPort and tolerates
+// the rest being zero-valued; GenerateBootstrapJob enforces the full set.
+type BootstrapPodInputs struct {
+	// Name is the resource name root used for both the Job and the Service.
+	// Pod hostname becomes "<Name>-0" so the in-cluster sidecar URL is
+	// "<Name>-0.<Name>.<Namespace>.svc.cluster.local". The data PVC the pod
+	// mounts at /sei is "data-<Name>".
+	Name string
+
+	Namespace string
+
+	// ChainID is what the seid-init container uses to materialise the data
+	// directory and what the sidecar advertises as its SEI_CHAIN_ID.
+	ChainID string
+
+	// SeidImage is the image for the seid-init container (runs `seid init`
+	// once before the main containers).
+	SeidImage string
+
+	// BootstrapImage is the image for the main "seid" container that runs
+	// `seid start --halt-height N`. The per-SeiNode adapter resolves this
+	// to snap.BootstrapImage when set, else node.Spec.Image, and assigns
+	// the same value to SeidImage.
+	BootstrapImage string
+
+	// SidecarImage / SidecarPort / SidecarResources are resolved at the
+	// adapter (with platform defaults applied) so the helpers below can
+	// stay value-driven.
+	SidecarImage     string
+	SidecarPort      int32
+	SidecarResources *corev1.ResourceRequirements
+
+	// Mode is the sei-config mode string ("full", "archive", "validator").
+	// Drives nodepool selection and resource sizing via platform.Config.
+	Mode string
+
+	// HaltHeight is the seid --halt-height value. Required for Job; ignored
+	// for Service.
+	HaltHeight int64
+}
+
+// BootstrapJobName returns the bootstrap Job name for a given resource root.
+// Pure string formatter — no SeiNode required.
+func BootstrapJobName(name string) string {
+	return fmt.Sprintf("%s-bootstrap", name)
 }
 
 // BootstrapLabels returns labels for bootstrap Job resources.
-func BootstrapLabels(node *seiv1alpha1.SeiNode) map[string]string {
+func BootstrapLabels(name string) map[string]string {
 	return map[string]string{
-		bootstrapNodeLabel:      node.Name,
+		bootstrapNodeLabel:      name,
 		bootstrapComponentLabel: "bootstrap",
 	}
 }
 
 // GenerateBootstrapJob creates the batch Job that runs seid with --halt-height
-// to populate a PVC before the StatefulSet takes over.
+// to populate a PVC before the consumer (a StatefulSet today, an export Job
+// tomorrow) takes over.
 //
-// The pod-spec must never carry consensus signing material — bootstrap pods
-// are physically incapable of signing because no validator key file is on
-// their filesystem. assertNoSigningKeyOnBootstrapPod is the runtime guard.
-func GenerateBootstrapJob(
-	node *seiv1alpha1.SeiNode,
-	snap *seiv1alpha1.SnapshotSource,
-	platformCfg platform.Config,
-) (*batchv1.Job, error) {
-	if snap == nil || snap.S3 == nil {
-		return nil, fmt.Errorf("bootstrap job requires an S3 snapshot source (node %s/%s)", node.Namespace, node.Name)
+// The pod-spec deliberately omits validator signing material. The per-SeiNode
+// adapter calls assertNoSigningKeyOnBootstrapPod after this returns to enforce
+// that invariant; the SND fork-genesis adapter has no SeiNode and physically
+// cannot leak signing material.
+func GenerateBootstrapJob(in BootstrapPodInputs, platformCfg platform.Config) (*batchv1.Job, error) {
+	if in.Name == "" || in.Namespace == "" {
+		return nil, fmt.Errorf("bootstrap job requires Name and Namespace (got %q/%q)", in.Namespace, in.Name)
 	}
-	labels := BootstrapLabels(node)
-	podSpec := buildBootstrapPodSpec(node, snap, platformCfg)
-
-	if err := assertNoSigningKeyOnBootstrapPod(node, &podSpec); err != nil {
-		return nil, err
+	if in.ChainID == "" {
+		return nil, fmt.Errorf("bootstrap job requires ChainID (%s/%s)", in.Namespace, in.Name)
 	}
+	if in.SeidImage == "" || in.BootstrapImage == "" {
+		return nil, fmt.Errorf("bootstrap job requires SeidImage and BootstrapImage (%s/%s)", in.Namespace, in.Name)
+	}
+	if in.HaltHeight <= 0 {
+		return nil, fmt.Errorf("bootstrap job requires HaltHeight > 0 (got %d for %s/%s)", in.HaltHeight, in.Namespace, in.Name)
+	}
+	labels := BootstrapLabels(in.Name)
+	podSpec := buildBootstrapPodSpec(in, platformCfg)
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      BootstrapJobName(node),
-			Namespace: node.Namespace,
+			Name:      BootstrapJobName(in.Name),
+			Namespace: in.Namespace,
 			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
@@ -79,22 +129,19 @@ func GenerateBootstrapJob(
 	}, nil
 }
 
-// GenerateBootstrapService creates a headless Service that provides stable DNS
-// for the bootstrap Job pod. The pod registers as
-// <hostname>.<service-name>.<namespace>.svc.cluster.local.
-//
-// The Service deliberately uses node.Name — the same name as the production
-// headless Service created by the StatefulSet reconciler. The bootstrap
-// teardown task deletes this Service before the StatefulSet is created,
-// so the sidecar URL (node-0.node.ns.svc.cluster.local) is consistent
-// across both phases without overlap.
-func GenerateBootstrapService(node *seiv1alpha1.SeiNode) *corev1.Service {
-	labels := BootstrapLabels(node)
-	port := bootstrapSidecarPort(node)
+// GenerateBootstrapService creates a headless Service that provides stable
+// DNS for the bootstrap Job pod. The pod registers as
+// <Name>-0.<Name>.<Namespace>.svc.cluster.local. On the per-SeiNode bootstrap
+// path the Service name matches the eventual StatefulSet's headless Service
+// name so the sidecar URL is consistent across both phases. On the SND fork
+// path the Service is owned by the SeiNodeDeployment and named after the
+// exporter resource root.
+func GenerateBootstrapService(in BootstrapPodInputs) *corev1.Service {
+	labels := BootstrapLabels(in.Name)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      node.Name,
-			Namespace: node.Namespace,
+			Name:      in.Name,
+			Namespace: in.Namespace,
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
@@ -102,33 +149,30 @@ func GenerateBootstrapService(node *seiv1alpha1.SeiNode) *corev1.Service {
 			Selector:                 labels,
 			PublishNotReadyAddresses: true,
 			Ports: []corev1.ServicePort{
-				{Name: "sidecar", Port: port, TargetPort: intstr.FromInt32(port), Protocol: corev1.ProtocolTCP},
+				{Name: "sidecar", Port: in.SidecarPort, TargetPort: intstr.FromInt32(in.SidecarPort), Protocol: corev1.ProtocolTCP},
 			},
 		},
 	}
 }
 
-func buildBootstrapPodSpec(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.SnapshotSource, platformCfg platform.Config) corev1.PodSpec {
-	serviceName := node.Name
-
+func buildBootstrapPodSpec(in BootstrapPodInputs, platformCfg platform.Config) corev1.PodSpec {
 	dataVolume := corev1.Volume{
 		Name: "data",
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-				ClaimName: bootstrapPVCClaimName(node),
+				ClaimName: fmt.Sprintf("data-%s", in.Name),
 			},
 		},
 	}
 
-	port := bootstrapSidecarPort(node)
 	sidecar := corev1.Container{
 		Name:          "sei-sidecar",
-		Image:         bootstrapSidecarImage(node),
+		Image:         in.SidecarImage,
 		Command:       []string{"seictl", "serve"},
 		RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
 		Env: []corev1.EnvVar{
-			{Name: "SEI_CHAIN_ID", Value: node.Spec.ChainID},
-			{Name: "SEI_SIDECAR_PORT", Value: fmt.Sprintf("%d", port)},
+			{Name: "SEI_CHAIN_ID", Value: in.ChainID},
+			{Name: "SEI_SIDECAR_PORT", Value: fmt.Sprintf("%d", in.SidecarPort)},
 			{Name: "SEI_HOME", Value: bootstrapDataDir},
 			{Name: "SEI_GENESIS_BUCKET", Value: platformCfg.GenesisBucket},
 			{Name: "SEI_GENESIS_REGION", Value: platformCfg.GenesisRegion},
@@ -136,26 +180,20 @@ func buildBootstrapPodSpec(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.Snapshot
 			{Name: "SEI_SNAPSHOT_REGION", Value: platformCfg.SnapshotRegion},
 		},
 		Ports: []corev1.ContainerPort{
-			{Name: "sidecar", ContainerPort: port, Protocol: corev1.ProtocolTCP},
+			{Name: "sidecar", ContainerPort: in.SidecarPort, Protocol: corev1.ProtocolTCP},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: bootstrapDataDir},
 		},
 	}
-	if node.Spec.Sidecar != nil && node.Spec.Sidecar.Resources != nil {
-		sidecar.Resources = *node.Spec.Sidecar.Resources
+	if in.SidecarResources != nil {
+		sidecar.Resources = *in.SidecarResources
 	}
 
-	bootstrapImage := node.Spec.Image
-	if snap != nil && snap.BootstrapImage != "" {
-		bootstrapImage = snap.BootstrapImage
-	}
-
-	haltHeight := snap.S3.TargetHeight
-	seidCmd, seidArgs := bootstrapWaitCommand(bootstrapSidecarPort(node), haltHeight)
+	seidCmd, seidArgs := bootstrapWaitCommand(in.SidecarPort, in.HaltHeight)
 	seidContainer := corev1.Container{
 		Name:    "seid",
-		Image:   bootstrapImage,
+		Image:   in.BootstrapImage,
 		Command: seidCmd,
 		Args:    seidArgs,
 		Env: []corev1.EnvVar{
@@ -164,17 +202,16 @@ func buildBootstrapPodSpec(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.Snapshot
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: bootstrapDataDir},
 		},
-		Resources: bootstrapResourcesForMode(bootstrapNodeMode(node), platformCfg),
+		Resources: bootstrapResourcesForMode(in.Mode, platformCfg),
 	}
 
-	seidInit := bootstrapSeidInitContainer(node)
-	seidInit.Image = bootstrapImage
+	seidInit := bootstrapSeidInitContainer(in)
 
-	pool := platformCfg.NodepoolForMode(bootstrapNodeMode(node))
+	pool := platformCfg.NodepoolForMode(in.Mode)
 
 	return corev1.PodSpec{
-		Hostname:                      fmt.Sprintf("%s-0", node.Name),
-		Subdomain:                     serviceName,
+		Hostname:                      fmt.Sprintf("%s-0", in.Name),
+		Subdomain:                     in.Name,
 		ServiceAccountName:            platformCfg.ServiceAccount,
 		ShareProcessNamespace:         ptr.To(true),
 		RestartPolicy:                 corev1.RestartPolicyNever,
@@ -229,52 +266,20 @@ func bootstrapWaitCommand(port int32, haltHeight int64) (command []string, args 
 	return []string{"/bin/bash", "-c"}, []string{script}
 }
 
-func bootstrapSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
+func bootstrapSeidInitContainer(in BootstrapPodInputs) corev1.Container {
 	script := fmt.Sprintf(
 		`if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
-		bootstrapDataDir, node.Spec.ChainID, node.Spec.ChainID, bootstrapDataDir, bootstrapDataDir,
+		bootstrapDataDir, in.ChainID, in.ChainID, bootstrapDataDir, bootstrapDataDir,
 	)
 	return corev1.Container{
 		Name:  "seid-init",
-		Image: node.Spec.Image,
+		Image: in.SeidImage,
 		Command: []string{
 			"/bin/sh", "-c", script,
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: bootstrapDataDir},
 		},
-	}
-}
-
-func bootstrapSidecarImage(node *seiv1alpha1.SeiNode) string {
-	if node.Spec.Sidecar != nil && node.Spec.Sidecar.Image != "" {
-		return node.Spec.Sidecar.Image
-	}
-	return bootstrapDefaultSidecarImage
-}
-
-func bootstrapSidecarPort(node *seiv1alpha1.SeiNode) int32 {
-	if node.Spec.Sidecar != nil && node.Spec.Sidecar.Port != 0 {
-		return node.Spec.Sidecar.Port
-	}
-	return seiconfig.PortSidecar
-}
-
-func bootstrapPVCClaimName(node *seiv1alpha1.SeiNode) string {
-	return fmt.Sprintf("data-%s", node.Name)
-}
-
-// bootstrapNodeMode determines the sei-config mode string from the node spec.
-func bootstrapNodeMode(node *seiv1alpha1.SeiNode) string {
-	switch {
-	case node.Spec.Archive != nil:
-		return string(seiconfig.ModeArchive)
-	case node.Spec.Validator != nil:
-		return string(seiconfig.ModeValidator)
-	case node.Spec.Replayer != nil:
-		return string(seiconfig.ModeFull)
-	default:
-		return string(seiconfig.ModeFull)
 	}
 }
 
@@ -325,24 +330,4 @@ func JobFailureReason(job *batchv1.Job) string {
 		}
 	}
 	return "bootstrap job failed"
-}
-
-// assertNoSigningKeyOnBootstrapPod fails closed if a future refactor
-// accidentally lands the validator's signing-key Secret on the bootstrap
-// pod-spec. The bootstrap path must never carry consensus signing material.
-func assertNoSigningKeyOnBootstrapPod(node *seiv1alpha1.SeiNode, spec *corev1.PodSpec) error {
-	if node.Spec.Validator == nil ||
-		node.Spec.Validator.SigningKey == nil ||
-		node.Spec.Validator.SigningKey.Secret == nil {
-		return nil
-	}
-	secretName := node.Spec.Validator.SigningKey.Secret.SecretName
-	for _, v := range spec.Volumes {
-		if v.Secret != nil && v.Secret.SecretName == secretName {
-			return fmt.Errorf("bootstrap pod-spec for %s/%s references signing-key Secret %q on volume %q; "+
-				"bootstrap pods must never carry consensus signing material",
-				node.Namespace, node.Name, secretName, v.Name)
-		}
-	}
-	return nil
 }

--- a/internal/task/bootstrap_resources_test.go
+++ b/internal/task/bootstrap_resources_test.go
@@ -1,8 +1,10 @@
 package task
 
 import (
+	"strings"
 	"testing"
 
+	seiconfig "github.com/sei-protocol/sei-config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,7 +13,13 @@ import (
 	"github.com/sei-protocol/sei-k8s-controller/internal/platform/platformtest"
 )
 
-const testBootstrapImageV1 = "sei:bootstrap-v1"
+const (
+	testBootstrapImageV1   = "sei:bootstrap-v1"
+	testValidatorSecret    = "validator-0-key"
+	testValidatorNodeKey   = "validator-0-nodekey"
+	testCustomSidecarImage = "ghcr.io/sei/sidecar:test"
+	testCustomSidecarPort  = int32(9099)
+)
 
 func bootstrapTestReplayerNode() *seiv1alpha1.SeiNode {
 	return &seiv1alpha1.SeiNode{
@@ -29,20 +37,191 @@ func bootstrapTestReplayerNode() *seiv1alpha1.SeiNode {
 	}
 }
 
-func TestTaskGenerateBootstrapJob(t *testing.T) {
+// --- nodeToBootstrapInputs ---
+
+func TestNodeToBootstrapInputs(t *testing.T) {
+	withValidator := func(secretName, nodeKeyName string) *seiv1alpha1.SeiNode {
+		return &seiv1alpha1.SeiNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "v0", Namespace: "consensus"},
+			Spec: seiv1alpha1.SeiNodeSpec{
+				ChainID: "atlantic-2",
+				Image:   "sei:v1",
+				Validator: &seiv1alpha1.ValidatorSpec{
+					Snapshot: &seiv1alpha1.SnapshotSource{
+						BootstrapImage: testBootstrapImageV1,
+						S3:             &seiv1alpha1.S3SnapshotSource{TargetHeight: 5000},
+					},
+					SigningKey: &seiv1alpha1.SigningKeySource{
+						Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: secretName},
+					},
+					NodeKey: &seiv1alpha1.NodeKeySource{
+						Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: nodeKeyName},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		node     *seiv1alpha1.SeiNode
+		snap     *seiv1alpha1.SnapshotSource
+		validate func(t *testing.T, got BootstrapPodInputs)
+	}{
+		{
+			name: "validator with bootstrap image and identity secrets",
+			node: withValidator(testValidatorSecret, testValidatorNodeKey),
+			snap: withValidator(testValidatorSecret, testValidatorNodeKey).Spec.SnapshotSource(),
+			validate: func(t *testing.T, got BootstrapPodInputs) {
+				if got.Image != testBootstrapImageV1 {
+					t.Errorf("Image = %q, want snapshot BootstrapImage %q", got.Image, testBootstrapImageV1)
+				}
+				if got.Mode != string(seiconfig.ModeValidator) {
+					t.Errorf("Mode = %q, want validator", got.Mode)
+				}
+				if got.HaltHeight != 5000 {
+					t.Errorf("HaltHeight = %d, want 5000", got.HaltHeight)
+				}
+				wantForbidden := map[string]bool{testValidatorSecret: false, testValidatorNodeKey: false}
+				for _, n := range got.ForbiddenSecretNames {
+					wantForbidden[n] = true
+				}
+				if !wantForbidden[testValidatorSecret] || !wantForbidden[testValidatorNodeKey] {
+					t.Errorf("ForbiddenSecretNames = %v, want both signing-key and node-key Secrets", got.ForbiddenSecretNames)
+				}
+			},
+		},
+		{
+			name: "archive node maps to archive mode and has no forbidden secrets",
+			node: &seiv1alpha1.SeiNode{
+				ObjectMeta: metav1.ObjectMeta{Name: "archive-0", Namespace: "default"},
+				Spec: seiv1alpha1.SeiNodeSpec{
+					ChainID: "pacific-1",
+					Image:   "sei:archive",
+					Archive: &seiv1alpha1.ArchiveSpec{},
+				},
+			},
+			snap: &seiv1alpha1.SnapshotSource{S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 42}},
+			validate: func(t *testing.T, got BootstrapPodInputs) {
+				if got.Mode != string(seiconfig.ModeArchive) {
+					t.Errorf("Mode = %q, want archive", got.Mode)
+				}
+				if len(got.ForbiddenSecretNames) != 0 {
+					t.Errorf("ForbiddenSecretNames = %v, want empty for non-validator", got.ForbiddenSecretNames)
+				}
+			},
+		},
+		{
+			name: "Image falls back to Spec.Image when snap.BootstrapImage is empty",
+			node: bootstrapTestReplayerNode(),
+			snap: &seiv1alpha1.SnapshotSource{S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 42}},
+			validate: func(t *testing.T, got BootstrapPodInputs) {
+				if got.Image != "sei:latest" {
+					t.Errorf("Image = %q, want fallback to Spec.Image", got.Image)
+				}
+			},
+		},
+		{
+			name: "full node with custom sidecar image and port",
+			node: &seiv1alpha1.SeiNode{
+				ObjectMeta: metav1.ObjectMeta{Name: "full-0", Namespace: "default"},
+				Spec: seiv1alpha1.SeiNodeSpec{
+					ChainID: "pacific-1",
+					Image:   "sei:full",
+					FullNode: &seiv1alpha1.FullNodeSpec{
+						Snapshot: &seiv1alpha1.SnapshotSource{S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 100}},
+					},
+					Sidecar: &seiv1alpha1.SidecarConfig{Image: testCustomSidecarImage, Port: testCustomSidecarPort},
+				},
+			},
+			snap: &seiv1alpha1.SnapshotSource{S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 100}},
+			validate: func(t *testing.T, got BootstrapPodInputs) {
+				if got.SidecarImage != testCustomSidecarImage {
+					t.Errorf("SidecarImage = %q, want %q", got.SidecarImage, testCustomSidecarImage)
+				}
+				if got.SidecarPort != testCustomSidecarPort {
+					t.Errorf("SidecarPort = %d, want %d", got.SidecarPort, testCustomSidecarPort)
+				}
+				if got.Mode != string(seiconfig.ModeFull) {
+					t.Errorf("Mode = %q, want full", got.Mode)
+				}
+			},
+		},
+		{
+			name: "replayer falls through to default mode (full)",
+			node: bootstrapTestReplayerNode(),
+			snap: bootstrapTestReplayerNode().Spec.SnapshotSource(),
+			validate: func(t *testing.T, got BootstrapPodInputs) {
+				if got.Mode != string(seiconfig.ModeFull) {
+					t.Errorf("Mode = %q, want full (replayer falls through to default)", got.Mode)
+				}
+			},
+		},
+		{
+			name: "default sidecar image when SeiNode.Sidecar is nil",
+			node: &seiv1alpha1.SeiNode{
+				ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: "default"},
+				Spec: seiv1alpha1.SeiNodeSpec{
+					ChainID: "pacific-1",
+					Image:   "sei:full",
+					FullNode: &seiv1alpha1.FullNodeSpec{
+						Snapshot: &seiv1alpha1.SnapshotSource{S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 1}},
+					},
+				},
+			},
+			snap: &seiv1alpha1.SnapshotSource{S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 1}},
+			validate: func(t *testing.T, got BootstrapPodInputs) {
+				if got.SidecarImage != bootstrapDefaultSidecarImage {
+					t.Errorf("SidecarImage = %q, want platform default %q", got.SidecarImage, bootstrapDefaultSidecarImage)
+				}
+				if got.SidecarPort != int32(seiconfig.PortSidecar) {
+					t.Errorf("SidecarPort = %d, want sei-config default %d", got.SidecarPort, seiconfig.PortSidecar)
+				}
+			},
+		},
+		{
+			name: "nil snapshot leaves HaltHeight zero and Image at Spec.Image",
+			node: bootstrapTestReplayerNode(),
+			snap: nil,
+			validate: func(t *testing.T, got BootstrapPodInputs) {
+				if got.HaltHeight != 0 {
+					t.Errorf("HaltHeight = %d, want 0", got.HaltHeight)
+				}
+				if got.Image != "sei:latest" {
+					t.Errorf("Image = %q, want fallback %q", got.Image, "sei:latest")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nodeToBootstrapInputs(tt.node, tt.snap)
+			if got.Name != tt.node.Name || got.Namespace != tt.node.Namespace {
+				t.Errorf("Name/Namespace = %q/%q, want %q/%q", got.Namespace, got.Name, tt.node.Namespace, tt.node.Name)
+			}
+			if got.ChainID != tt.node.Spec.ChainID {
+				t.Errorf("ChainID = %q, want %q", got.ChainID, tt.node.Spec.ChainID)
+			}
+			tt.validate(t, got)
+		})
+	}
+}
+
+// --- GenerateBootstrapJob ---
+
+func TestGenerateBootstrapJob(t *testing.T) {
 	node := bootstrapTestReplayerNode()
 	node.Spec.Replayer.Snapshot.BootstrapImage = testBootstrapImageV1
-	in := nodeToBootstrapInputs(node, node.Spec.SnapshotSource())
-	job, err := GenerateBootstrapJob(in, platformtest.Config())
+	inputs := nodeToBootstrapInputs(node, node.Spec.SnapshotSource())
+	job, err := GenerateBootstrapJob(inputs, platformtest.Config())
 	if err != nil {
 		t.Fatalf("GenerateBootstrapJob error: %v", err)
 	}
 
-	wantName := "test-replayer-bootstrap"
-	if job.Name != wantName {
-		t.Errorf("Job name = %q, want %q", job.Name, wantName)
+	if job.Name != "test-replayer-bootstrap" {
+		t.Errorf("Job name = %q, want test-replayer-bootstrap", job.Name)
 	}
-
 	spec := job.Spec.Template.Spec
 	if spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Errorf("RestartPolicy = %q, want Never", spec.RestartPolicy)
@@ -50,17 +229,63 @@ func TestTaskGenerateBootstrapJob(t *testing.T) {
 	if spec.Containers[0].Image != testBootstrapImageV1 {
 		t.Errorf("main container image = %q, want %q", spec.Containers[0].Image, testBootstrapImageV1)
 	}
-}
-
-func TestTaskGenerateBootstrapJob_NilSnapshot(t *testing.T) {
-	node := bootstrapTestReplayerNode()
-	in := nodeToBootstrapInputs(node, nil)
-	if _, err := GenerateBootstrapJob(in, platformtest.Config()); err == nil {
-		t.Fatal("expected error for nil snapshot (HaltHeight=0), got nil")
+	if spec.InitContainers[0].Image != testBootstrapImageV1 {
+		t.Errorf("seid-init image = %q, want %q (same image as main)", spec.InitContainers[0].Image, testBootstrapImageV1)
 	}
 }
 
-func TestTaskGenerateBootstrapJob_SidecarResources(t *testing.T) {
+func TestGenerateBootstrapJob_Validation(t *testing.T) {
+	base := func() BootstrapPodInputs {
+		return BootstrapPodInputs{
+			Name:        "n",
+			Namespace:   "default",
+			ChainID:     "pacific-1",
+			Image:       "sei:latest",
+			SidecarPort: 7777,
+			Mode:        string(seiconfig.ModeFull),
+			HaltHeight:  100,
+		}
+	}
+	tests := []struct {
+		name      string
+		mutate    func(*BootstrapPodInputs)
+		errSubstr string
+	}{
+		{"empty Name", func(in *BootstrapPodInputs) { in.Name = "" }, "Name and Namespace"},
+		{"empty Namespace", func(in *BootstrapPodInputs) { in.Namespace = "" }, "Name and Namespace"},
+		{"empty ChainID", func(in *BootstrapPodInputs) { in.ChainID = "" }, "ChainID"},
+		{"empty Image", func(in *BootstrapPodInputs) { in.Image = "" }, "Image"},
+		{"zero HaltHeight", func(in *BootstrapPodInputs) { in.HaltHeight = 0 }, "HaltHeight"},
+		{"negative HaltHeight", func(in *BootstrapPodInputs) { in.HaltHeight = -1 }, "HaltHeight"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := base()
+			tt.mutate(&in)
+			_, err := GenerateBootstrapJob(in, platformtest.Config())
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Errorf("error %q does not mention %q", err.Error(), tt.errSubstr)
+			}
+		})
+	}
+}
+
+func TestGenerateBootstrapJob_NilSnapshotProducesZeroHaltHeightError(t *testing.T) {
+	node := bootstrapTestReplayerNode()
+	inputs := nodeToBootstrapInputs(node, nil)
+	if inputs.HaltHeight != 0 {
+		t.Fatalf("expected HaltHeight=0 from nil snapshot, got %d", inputs.HaltHeight)
+	}
+	_, err := GenerateBootstrapJob(inputs, platformtest.Config())
+	if err == nil || !strings.Contains(err.Error(), "HaltHeight") {
+		t.Fatalf("expected HaltHeight error, got %v", err)
+	}
+}
+
+func TestGenerateBootstrapJob_SidecarResources(t *testing.T) {
 	node := bootstrapTestReplayerNode()
 	node.Spec.Replayer.Snapshot.BootstrapImage = testBootstrapImageV1
 	node.Spec.Sidecar = &seiv1alpha1.SidecarConfig{
@@ -71,28 +296,24 @@ func TestTaskGenerateBootstrapJob_SidecarResources(t *testing.T) {
 			},
 		},
 	}
-	in := nodeToBootstrapInputs(node, node.Spec.SnapshotSource())
-	job, err := GenerateBootstrapJob(in, platformtest.Config())
+	inputs := nodeToBootstrapInputs(node, node.Spec.SnapshotSource())
+	job, err := GenerateBootstrapJob(inputs, platformtest.Config())
 	if err != nil {
 		t.Fatalf("GenerateBootstrapJob error: %v", err)
 	}
-	spec := job.Spec.Template.Spec
 
-	sc := spec.InitContainers[1]
-	cpuReq := sc.Resources.Requests[corev1.ResourceCPU]
-	if cpuReq.String() != "500m" {
-		t.Errorf("sidecar CPU request = %q, want %q", cpuReq.String(), "500m")
+	sidecarContainer := job.Spec.Template.Spec.InitContainers[1]
+	cpu := sidecarContainer.Resources.Requests[corev1.ResourceCPU]
+	if cpu.String() != "500m" {
+		t.Errorf("sidecar CPU request = %q, want 500m", cpu.String())
 	}
 }
 
-// TestTaskGenerateBootstrapJob_NeverHasIdentityVolumes is the safety
-// regression guard for the load-bearing invariants on validator identity
-// material. The bootstrap pod must never carry the consensus signing key
-// (slashing risk, LLD §3) AND must never carry the validator's permanent
-// node key (peer-reputation pollution risk — bootstrap pods crash, halt,
-// and restart, and that misbehavior must not attribute to the validator's
-// permanent libp2p identity).
-func TestTaskGenerateBootstrapJob_NeverHasIdentityVolumes(t *testing.T) {
+// TestGenerateBootstrapJob_NeverHasIdentityVolumes is the safety regression
+// guard for the load-bearing invariant on validator identity material. The
+// bootstrap pod must never carry the consensus signing key (slashing risk)
+// nor the validator's permanent node key (peer-reputation pollution risk).
+func TestGenerateBootstrapJob_NeverHasIdentityVolumes(t *testing.T) {
 	node := &seiv1alpha1.SeiNode{
 		ObjectMeta: metav1.ObjectMeta{Name: "validator-0", Namespace: "default"},
 		Spec: seiv1alpha1.SeiNodeSpec{
@@ -104,46 +325,138 @@ func TestTaskGenerateBootstrapJob_NeverHasIdentityVolumes(t *testing.T) {
 					S3:             &seiv1alpha1.S3SnapshotSource{TargetHeight: 100000000},
 				},
 				SigningKey: &seiv1alpha1.SigningKeySource{
-					Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: "validator-0-key"},
+					Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: testValidatorSecret},
 				},
 				NodeKey: &seiv1alpha1.NodeKeySource{
-					Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: "validator-0-nodekey"},
+					Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: testValidatorNodeKey},
 				},
 			},
 		},
 	}
-	in := nodeToBootstrapInputs(node, node.Spec.SnapshotSource())
-	job, err := GenerateBootstrapJob(in, platformtest.Config())
+	inputs := nodeToBootstrapInputs(node, node.Spec.SnapshotSource())
+	job, err := GenerateBootstrapJob(inputs, platformtest.Config())
 	if err != nil {
 		t.Fatalf("GenerateBootstrapJob error: %v", err)
 	}
-	if err := assertNoSigningKeyOnBootstrapPod(node, &job.Spec.Template.Spec); err != nil {
-		t.Fatalf("assertNoSigningKeyOnBootstrapPod: %v", err)
-	}
+
 	forbiddenVolumeNames := map[string]string{
-		"signing-key": "consensus signing material — slashing risk (LLD §3)",
+		"signing-key": "consensus signing material — slashing risk",
 		"node-key":    "validator permanent node ID — peer-reputation pollution risk",
 	}
 	forbiddenSecretNames := map[string]string{
-		"validator-0-key":     "consensus signing Secret",
-		"validator-0-nodekey": "validator node-key Secret",
+		testValidatorSecret:  "consensus signing Secret",
+		testValidatorNodeKey: "validator node-key Secret",
 	}
-	for _, v := range job.Spec.Template.Spec.Volumes {
-		if reason, forbidden := forbiddenVolumeNames[v.Name]; forbidden {
-			t.Fatalf("bootstrap Job pod-spec must NEVER include volume %q (%s); found %+v", v.Name, reason, v)
+	for _, vol := range job.Spec.Template.Spec.Volumes {
+		if reason, forbidden := forbiddenVolumeNames[vol.Name]; forbidden {
+			t.Fatalf("bootstrap Job pod-spec must NEVER include volume %q (%s); found %+v", vol.Name, reason, vol)
 		}
-		if v.Secret != nil {
-			if reason, forbidden := forbiddenSecretNames[v.Secret.SecretName]; forbidden {
+		if vol.Secret != nil {
+			if reason, forbidden := forbiddenSecretNames[vol.Secret.SecretName]; forbidden {
 				t.Fatalf("bootstrap Job pod-spec must NEVER mount Secret %q (%s); found volume %q",
-					v.Secret.SecretName, reason, v.Name)
+					vol.Secret.SecretName, reason, vol.Name)
 			}
 		}
 	}
-	for _, c := range job.Spec.Template.Spec.Containers {
-		for _, m := range c.VolumeMounts {
-			if reason, forbidden := forbiddenVolumeNames[m.Name]; forbidden {
-				t.Fatalf("bootstrap Job container %q must NEVER mount %q (%s)", c.Name, m.Name, reason)
+	for _, container := range job.Spec.Template.Spec.Containers {
+		for _, mount := range container.VolumeMounts {
+			if reason, forbidden := forbiddenVolumeNames[mount.Name]; forbidden {
+				t.Fatalf("bootstrap Job container %q must NEVER mount %q (%s)", container.Name, mount.Name, reason)
 			}
 		}
+	}
+}
+
+// --- rejectForbiddenSecretMounts ---
+
+// TestRejectForbiddenSecretMounts is the negative test that proves the
+// forbidden-Secret guard fires. The natural-path test above only exercises
+// the case where the helper does not produce the volume in the first place;
+// this one hand-builds a leaking PodSpec to catch regressions in the guard.
+func TestRejectForbiddenSecretMounts(t *testing.T) {
+	tests := []struct {
+		name      string
+		volumes   []corev1.Volume
+		forbidden []string
+		wantErr   string
+	}{
+		{
+			name:      "empty forbidden list passes",
+			volumes:   []corev1.Volume{{Name: "data"}},
+			forbidden: nil,
+			wantErr:   "",
+		},
+		{
+			name: "secret not in list passes",
+			volumes: []corev1.Volume{
+				{Name: "config", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "ok"}}},
+			},
+			forbidden: []string{testValidatorSecret},
+			wantErr:   "",
+		},
+		{
+			name: "signing-key secret in list fails closed",
+			volumes: []corev1.Volume{
+				{Name: "data"},
+				{Name: "signing-key", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: testValidatorSecret}}},
+			},
+			forbidden: []string{testValidatorSecret, testValidatorNodeKey},
+			wantErr:   testValidatorSecret,
+		},
+		{
+			name: "node-key secret in list fails closed",
+			volumes: []corev1.Volume{
+				{Name: "node-key", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: testValidatorNodeKey}}},
+			},
+			forbidden: []string{testValidatorSecret, testValidatorNodeKey},
+			wantErr:   testValidatorNodeKey,
+		},
+		{
+			name: "empty-string entries in forbidden list are ignored",
+			volumes: []corev1.Volume{
+				{Name: "config", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: ""}}},
+			},
+			forbidden: []string{""},
+			wantErr:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectForbiddenSecretMounts(&corev1.PodSpec{Volumes: tt.volumes}, tt.forbidden)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error mentioning %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not mention %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// --- GenerateBootstrapService ---
+
+func TestGenerateBootstrapService_TolerantOfZeroFields(t *testing.T) {
+	svc := GenerateBootstrapService(BootstrapPodInputs{
+		Name:        "exporter",
+		Namespace:   "fork",
+		SidecarPort: 7777,
+	})
+	if svc.Spec.ClusterIP != corev1.ClusterIPNone {
+		t.Errorf("ClusterIP = %q, want None", svc.Spec.ClusterIP)
+	}
+	if !svc.Spec.PublishNotReadyAddresses {
+		t.Error("PublishNotReadyAddresses = false, want true")
+	}
+	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 7777 {
+		t.Errorf("ports = %+v, want single sidecar port 7777", svc.Spec.Ports)
+	}
+	if svc.Spec.Selector[bootstrapNodeLabel] != "exporter" {
+		t.Errorf("selector node label = %q, want %q", svc.Spec.Selector[bootstrapNodeLabel], "exporter")
 	}
 }

--- a/internal/task/bootstrap_resources_test.go
+++ b/internal/task/bootstrap_resources_test.go
@@ -1,0 +1,149 @@
+package task
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/platform/platformtest"
+)
+
+const testBootstrapImageV1 = "sei:bootstrap-v1"
+
+func bootstrapTestReplayerNode() *seiv1alpha1.SeiNode {
+	return &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-replayer", Namespace: "default", Generation: 1},
+		Spec: seiv1alpha1.SeiNodeSpec{
+			ChainID: "pacific-1",
+			Image:   "sei:latest",
+			Replayer: &seiv1alpha1.ReplayerSpec{
+				Snapshot: seiv1alpha1.SnapshotSource{
+					S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 100000000},
+				},
+			},
+			Sidecar: &seiv1alpha1.SidecarConfig{Image: "sidecar:latest", Port: 7777},
+		},
+	}
+}
+
+func TestTaskGenerateBootstrapJob(t *testing.T) {
+	node := bootstrapTestReplayerNode()
+	node.Spec.Replayer.Snapshot.BootstrapImage = testBootstrapImageV1
+	in := nodeToBootstrapInputs(node, node.Spec.SnapshotSource())
+	job, err := GenerateBootstrapJob(in, platformtest.Config())
+	if err != nil {
+		t.Fatalf("GenerateBootstrapJob error: %v", err)
+	}
+
+	wantName := "test-replayer-bootstrap"
+	if job.Name != wantName {
+		t.Errorf("Job name = %q, want %q", job.Name, wantName)
+	}
+
+	spec := job.Spec.Template.Spec
+	if spec.RestartPolicy != corev1.RestartPolicyNever {
+		t.Errorf("RestartPolicy = %q, want Never", spec.RestartPolicy)
+	}
+	if spec.Containers[0].Image != testBootstrapImageV1 {
+		t.Errorf("main container image = %q, want %q", spec.Containers[0].Image, testBootstrapImageV1)
+	}
+}
+
+func TestTaskGenerateBootstrapJob_NilSnapshot(t *testing.T) {
+	node := bootstrapTestReplayerNode()
+	in := nodeToBootstrapInputs(node, nil)
+	if _, err := GenerateBootstrapJob(in, platformtest.Config()); err == nil {
+		t.Fatal("expected error for nil snapshot (HaltHeight=0), got nil")
+	}
+}
+
+func TestTaskGenerateBootstrapJob_SidecarResources(t *testing.T) {
+	node := bootstrapTestReplayerNode()
+	node.Spec.Replayer.Snapshot.BootstrapImage = testBootstrapImageV1
+	node.Spec.Sidecar = &seiv1alpha1.SidecarConfig{
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	}
+	in := nodeToBootstrapInputs(node, node.Spec.SnapshotSource())
+	job, err := GenerateBootstrapJob(in, platformtest.Config())
+	if err != nil {
+		t.Fatalf("GenerateBootstrapJob error: %v", err)
+	}
+	spec := job.Spec.Template.Spec
+
+	sc := spec.InitContainers[1]
+	cpuReq := sc.Resources.Requests[corev1.ResourceCPU]
+	if cpuReq.String() != "500m" {
+		t.Errorf("sidecar CPU request = %q, want %q", cpuReq.String(), "500m")
+	}
+}
+
+// TestTaskGenerateBootstrapJob_NeverHasIdentityVolumes is the safety
+// regression guard for the load-bearing invariants on validator identity
+// material. The bootstrap pod must never carry the consensus signing key
+// (slashing risk, LLD §3) AND must never carry the validator's permanent
+// node key (peer-reputation pollution risk — bootstrap pods crash, halt,
+// and restart, and that misbehavior must not attribute to the validator's
+// permanent libp2p identity).
+func TestTaskGenerateBootstrapJob_NeverHasIdentityVolumes(t *testing.T) {
+	node := &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "validator-0", Namespace: "default"},
+		Spec: seiv1alpha1.SeiNodeSpec{
+			ChainID: "atlantic-2",
+			Image:   "ghcr.io/sei-protocol/seid:latest",
+			Validator: &seiv1alpha1.ValidatorSpec{
+				Snapshot: &seiv1alpha1.SnapshotSource{
+					BootstrapImage: testBootstrapImageV1,
+					S3:             &seiv1alpha1.S3SnapshotSource{TargetHeight: 100000000},
+				},
+				SigningKey: &seiv1alpha1.SigningKeySource{
+					Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: "validator-0-key"},
+				},
+				NodeKey: &seiv1alpha1.NodeKeySource{
+					Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: "validator-0-nodekey"},
+				},
+			},
+		},
+	}
+	in := nodeToBootstrapInputs(node, node.Spec.SnapshotSource())
+	job, err := GenerateBootstrapJob(in, platformtest.Config())
+	if err != nil {
+		t.Fatalf("GenerateBootstrapJob error: %v", err)
+	}
+	if err := assertNoSigningKeyOnBootstrapPod(node, &job.Spec.Template.Spec); err != nil {
+		t.Fatalf("assertNoSigningKeyOnBootstrapPod: %v", err)
+	}
+	forbiddenVolumeNames := map[string]string{
+		"signing-key": "consensus signing material — slashing risk (LLD §3)",
+		"node-key":    "validator permanent node ID — peer-reputation pollution risk",
+	}
+	forbiddenSecretNames := map[string]string{
+		"validator-0-key":     "consensus signing Secret",
+		"validator-0-nodekey": "validator node-key Secret",
+	}
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if reason, forbidden := forbiddenVolumeNames[v.Name]; forbidden {
+			t.Fatalf("bootstrap Job pod-spec must NEVER include volume %q (%s); found %+v", v.Name, reason, v)
+		}
+		if v.Secret != nil {
+			if reason, forbidden := forbiddenSecretNames[v.Secret.SecretName]; forbidden {
+				t.Fatalf("bootstrap Job pod-spec must NEVER mount Secret %q (%s); found volume %q",
+					v.Secret.SecretName, reason, v.Name)
+			}
+		}
+	}
+	for _, c := range job.Spec.Template.Spec.Containers {
+		for _, m := range c.VolumeMounts {
+			if reason, forbidden := forbiddenVolumeNames[m.Name]; forbidden {
+				t.Fatalf("bootstrap Job container %q must NEVER mount %q (%s)", c.Name, m.Name, reason)
+			}
+		}
+	}
+}

--- a/internal/task/bootstrap_resources_test.go
+++ b/internal/task/bootstrap_resources_test.go
@@ -19,14 +19,22 @@ const (
 	testValidatorNodeKey   = "validator-0-nodekey"
 	testCustomSidecarImage = "ghcr.io/sei/sidecar:test"
 	testCustomSidecarPort  = int32(9099)
+
+	testNamespaceDefault = "default"
+	testChainPacific     = "pacific-1"
+	testChainAtlantic    = "atlantic-2"
+	testImageLatest      = "sei:latest"
+	testValidatorName    = "validator-0"
+	testExporterName     = "exporter"
+	testDataVolumeName   = "data"
 )
 
 func bootstrapTestReplayerNode() *seiv1alpha1.SeiNode {
 	return &seiv1alpha1.SeiNode{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-replayer", Namespace: "default", Generation: 1},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-replayer", Namespace: testNamespaceDefault, Generation: 1},
 		Spec: seiv1alpha1.SeiNodeSpec{
-			ChainID: "pacific-1",
-			Image:   "sei:latest",
+			ChainID: testChainPacific,
+			Image:   testImageLatest,
 			Replayer: &seiv1alpha1.ReplayerSpec{
 				Snapshot: seiv1alpha1.SnapshotSource{
 					S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 100000000},
@@ -44,7 +52,7 @@ func TestNodeToBootstrapInputs(t *testing.T) {
 		return &seiv1alpha1.SeiNode{
 			ObjectMeta: metav1.ObjectMeta{Name: "v0", Namespace: "consensus"},
 			Spec: seiv1alpha1.SeiNodeSpec{
-				ChainID: "atlantic-2",
+				ChainID: testChainAtlantic,
 				Image:   "sei:v1",
 				Validator: &seiv1alpha1.ValidatorSpec{
 					Snapshot: &seiv1alpha1.SnapshotSource{
@@ -94,9 +102,9 @@ func TestNodeToBootstrapInputs(t *testing.T) {
 		{
 			name: "archive node maps to archive mode and has no forbidden secrets",
 			node: &seiv1alpha1.SeiNode{
-				ObjectMeta: metav1.ObjectMeta{Name: "archive-0", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "archive-0", Namespace: testNamespaceDefault},
 				Spec: seiv1alpha1.SeiNodeSpec{
-					ChainID: "pacific-1",
+					ChainID: testChainPacific,
 					Image:   "sei:archive",
 					Archive: &seiv1alpha1.ArchiveSpec{},
 				},
@@ -116,7 +124,7 @@ func TestNodeToBootstrapInputs(t *testing.T) {
 			node: bootstrapTestReplayerNode(),
 			snap: &seiv1alpha1.SnapshotSource{S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 42}},
 			validate: func(t *testing.T, got BootstrapPodInputs) {
-				if got.Image != "sei:latest" {
+				if got.Image != testImageLatest {
 					t.Errorf("Image = %q, want fallback to Spec.Image", got.Image)
 				}
 			},
@@ -124,9 +132,9 @@ func TestNodeToBootstrapInputs(t *testing.T) {
 		{
 			name: "full node with custom sidecar image and port",
 			node: &seiv1alpha1.SeiNode{
-				ObjectMeta: metav1.ObjectMeta{Name: "full-0", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "full-0", Namespace: testNamespaceDefault},
 				Spec: seiv1alpha1.SeiNodeSpec{
-					ChainID: "pacific-1",
+					ChainID: testChainPacific,
 					Image:   "sei:full",
 					FullNode: &seiv1alpha1.FullNodeSpec{
 						Snapshot: &seiv1alpha1.SnapshotSource{S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 100}},
@@ -160,9 +168,9 @@ func TestNodeToBootstrapInputs(t *testing.T) {
 		{
 			name: "default sidecar image when SeiNode.Sidecar is nil",
 			node: &seiv1alpha1.SeiNode{
-				ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: testNamespaceDefault},
 				Spec: seiv1alpha1.SeiNodeSpec{
-					ChainID: "pacific-1",
+					ChainID: testChainPacific,
 					Image:   "sei:full",
 					FullNode: &seiv1alpha1.FullNodeSpec{
 						Snapshot: &seiv1alpha1.SnapshotSource{S3: &seiv1alpha1.S3SnapshotSource{TargetHeight: 1}},
@@ -174,7 +182,7 @@ func TestNodeToBootstrapInputs(t *testing.T) {
 				if got.SidecarImage != bootstrapDefaultSidecarImage {
 					t.Errorf("SidecarImage = %q, want platform default %q", got.SidecarImage, bootstrapDefaultSidecarImage)
 				}
-				if got.SidecarPort != int32(seiconfig.PortSidecar) {
+				if got.SidecarPort != seiconfig.PortSidecar {
 					t.Errorf("SidecarPort = %d, want sei-config default %d", got.SidecarPort, seiconfig.PortSidecar)
 				}
 			},
@@ -187,8 +195,8 @@ func TestNodeToBootstrapInputs(t *testing.T) {
 				if got.HaltHeight != 0 {
 					t.Errorf("HaltHeight = %d, want 0", got.HaltHeight)
 				}
-				if got.Image != "sei:latest" {
-					t.Errorf("Image = %q, want fallback %q", got.Image, "sei:latest")
+				if got.Image != testImageLatest {
+					t.Errorf("Image = %q, want fallback %q", got.Image, testImageLatest)
 				}
 			},
 		},
@@ -238,9 +246,9 @@ func TestGenerateBootstrapJob_Validation(t *testing.T) {
 	base := func() BootstrapPodInputs {
 		return BootstrapPodInputs{
 			Name:        "n",
-			Namespace:   "default",
-			ChainID:     "pacific-1",
-			Image:       "sei:latest",
+			Namespace:   testNamespaceDefault,
+			ChainID:     testChainPacific,
+			Image:       testImageLatest,
 			SidecarPort: 7777,
 			Mode:        string(seiconfig.ModeFull),
 			HaltHeight:  100,
@@ -315,9 +323,9 @@ func TestGenerateBootstrapJob_SidecarResources(t *testing.T) {
 // nor the validator's permanent node key (peer-reputation pollution risk).
 func TestGenerateBootstrapJob_NeverHasIdentityVolumes(t *testing.T) {
 	node := &seiv1alpha1.SeiNode{
-		ObjectMeta: metav1.ObjectMeta{Name: "validator-0", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: testValidatorName, Namespace: testNamespaceDefault},
 		Spec: seiv1alpha1.SeiNodeSpec{
-			ChainID: "atlantic-2",
+			ChainID: testChainAtlantic,
 			Image:   "ghcr.io/sei-protocol/seid:latest",
 			Validator: &seiv1alpha1.ValidatorSpec{
 				Snapshot: &seiv1alpha1.SnapshotSource{
@@ -382,7 +390,7 @@ func TestRejectForbiddenSecretMounts(t *testing.T) {
 	}{
 		{
 			name:      "empty forbidden list passes",
-			volumes:   []corev1.Volume{{Name: "data"}},
+			volumes:   []corev1.Volume{{Name: testDataVolumeName}},
 			forbidden: nil,
 			wantErr:   "",
 		},
@@ -397,7 +405,7 @@ func TestRejectForbiddenSecretMounts(t *testing.T) {
 		{
 			name: "signing-key secret in list fails closed",
 			volumes: []corev1.Volume{
-				{Name: "data"},
+				{Name: testDataVolumeName},
 				{Name: "signing-key", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: testValidatorSecret}}},
 			},
 			forbidden: []string{testValidatorSecret, testValidatorNodeKey},
@@ -443,7 +451,7 @@ func TestRejectForbiddenSecretMounts(t *testing.T) {
 
 func TestGenerateBootstrapService_TolerantOfZeroFields(t *testing.T) {
 	svc := GenerateBootstrapService(BootstrapPodInputs{
-		Name:        "exporter",
+		Name:        testExporterName,
 		Namespace:   "fork",
 		SidecarPort: 7777,
 	})
@@ -456,7 +464,7 @@ func TestGenerateBootstrapService_TolerantOfZeroFields(t *testing.T) {
 	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 7777 {
 		t.Errorf("ports = %+v, want single sidecar port 7777", svc.Spec.Ports)
 	}
-	if svc.Spec.Selector[bootstrapNodeLabel] != "exporter" {
-		t.Errorf("selector node label = %q, want %q", svc.Spec.Selector[bootstrapNodeLabel], "exporter")
+	if svc.Spec.Selector[bootstrapNodeLabel] != testExporterName {
+		t.Errorf("selector node label = %q, want %q", svc.Spec.Selector[bootstrapNodeLabel], testExporterName)
 	}
 }

--- a/internal/task/bootstrap_service.go
+++ b/internal/task/bootstrap_service.go
@@ -43,7 +43,8 @@ func (e *deployBootstrapServiceExecution) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	svc := GenerateBootstrapService(node)
+	inputs := nodeToBootstrapInputs(node, node.Spec.SnapshotSource())
+	svc := GenerateBootstrapService(inputs)
 	if err := ctrl.SetControllerReference(node, svc, e.cfg.Scheme); err != nil {
 		return fmt.Errorf("setting owner reference on bootstrap service: %w", err)
 	}

--- a/internal/task/bootstrap_task_test.go
+++ b/internal/task/bootstrap_task_test.go
@@ -47,6 +47,11 @@ func testNode() *seiv1alpha1.SeiNode {
 	}
 }
 
+func nodeBootstrapService(t *testing.T, node *seiv1alpha1.SeiNode) *corev1.Service {
+	t.Helper()
+	return GenerateBootstrapService(nodeToBootstrapInputs(node, node.Spec.SnapshotSource()))
+}
+
 func testCfg(t *testing.T, objs ...client.Object) ExecutionConfig {
 	t.Helper()
 	s := testScheme(t)
@@ -90,7 +95,7 @@ func TestDeployBootstrapService_Execute_CreatesService(t *testing.T) {
 
 func TestDeployBootstrapService_Execute_Idempotent(t *testing.T) {
 	node := testNode()
-	svc := GenerateBootstrapService(node)
+	svc := nodeBootstrapService(t, node)
 	cfg := testCfg(t, svc)
 
 	params := DeployBootstrapServiceParams{ServiceName: node.Name, Namespace: node.Namespace}
@@ -111,7 +116,7 @@ func TestDeployBootstrapService_Execute_Idempotent(t *testing.T) {
 
 func TestDeployBootstrapService_Status_DetectsExisting(t *testing.T) {
 	node := testNode()
-	svc := GenerateBootstrapService(node)
+	svc := nodeBootstrapService(t, node)
 	cfg := testCfg(t, svc)
 
 	params := DeployBootstrapServiceParams{ServiceName: node.Name, Namespace: node.Namespace}
@@ -131,7 +136,7 @@ func TestDeployBootstrapService_Status_DetectsExisting(t *testing.T) {
 func TestDeployBootstrapJob_Execute_CreatesJob(t *testing.T) {
 	node := testNode()
 	cfg := testCfg(t)
-	params := DeployBootstrapJobParams{JobName: BootstrapJobName(node), Namespace: node.Namespace}
+	params := DeployBootstrapJobParams{JobName: BootstrapJobName(node.Name), Namespace: node.Namespace}
 	raw, _ := json.Marshal(params)
 	exec, err := deserializeBootstrapJob("id-2", raw, cfg)
 	if err != nil {
@@ -147,7 +152,7 @@ func TestDeployBootstrapJob_Execute_CreatesJob(t *testing.T) {
 	}
 
 	job := &batchv1.Job{}
-	if err := cfg.KubeClient.Get(ctx, types.NamespacedName{Name: BootstrapJobName(node), Namespace: node.Namespace}, job); err != nil {
+	if err := cfg.KubeClient.Get(ctx, types.NamespacedName{Name: BootstrapJobName(node.Name), Namespace: node.Namespace}, job); err != nil {
 		t.Fatalf("job not found: %v", err)
 	}
 }
@@ -164,7 +169,7 @@ func TestDeployBootstrapJob_Execute_NilSnapshot(t *testing.T) {
 		Platform:   platformtest.Config(),
 	}
 
-	params := DeployBootstrapJobParams{JobName: BootstrapJobName(node), Namespace: node.Namespace}
+	params := DeployBootstrapJobParams{JobName: BootstrapJobName(node.Name), Namespace: node.Namespace}
 	raw, _ := json.Marshal(params)
 	exec, err := deserializeBootstrapJob("id-2", raw, cfg)
 	if err != nil {
@@ -181,12 +186,12 @@ func TestDeployBootstrapJob_Execute_NilSnapshot(t *testing.T) {
 func TestAwaitBootstrapComplete_JobRunning(t *testing.T) {
 	node := testNode()
 	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: BootstrapJobName(node), Namespace: node.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: BootstrapJobName(node.Name), Namespace: node.Namespace},
 		Status:     batchv1.JobStatus{Active: 1},
 	}
 	cfg := testCfg(t, job)
 
-	params := AwaitBootstrapCompleteParams{JobName: BootstrapJobName(node), Namespace: node.Namespace}
+	params := AwaitBootstrapCompleteParams{JobName: BootstrapJobName(node.Name), Namespace: node.Namespace}
 	raw, _ := json.Marshal(params)
 	exec, err := deserializeBootstrapAwait("id-3", raw, cfg)
 	if err != nil {
@@ -205,7 +210,7 @@ func TestAwaitBootstrapComplete_JobRunning(t *testing.T) {
 func TestAwaitBootstrapComplete_JobComplete(t *testing.T) {
 	node := testNode()
 	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: BootstrapJobName(node), Namespace: node.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: BootstrapJobName(node.Name), Namespace: node.Namespace},
 		Status: batchv1.JobStatus{
 			Conditions: []batchv1.JobCondition{
 				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
@@ -214,7 +219,7 @@ func TestAwaitBootstrapComplete_JobComplete(t *testing.T) {
 	}
 	cfg := testCfg(t, job)
 
-	params := AwaitBootstrapCompleteParams{JobName: BootstrapJobName(node), Namespace: node.Namespace}
+	params := AwaitBootstrapCompleteParams{JobName: BootstrapJobName(node.Name), Namespace: node.Namespace}
 	raw, _ := json.Marshal(params)
 	exec, err := deserializeBootstrapAwait("id-3", raw, cfg)
 	if err != nil {
@@ -229,7 +234,7 @@ func TestAwaitBootstrapComplete_JobComplete(t *testing.T) {
 func TestAwaitBootstrapComplete_JobFailed(t *testing.T) {
 	node := testNode()
 	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: BootstrapJobName(node), Namespace: node.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: BootstrapJobName(node.Name), Namespace: node.Namespace},
 		Status: batchv1.JobStatus{
 			Conditions: []batchv1.JobCondition{
 				{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Message: "OOM killed"},
@@ -238,7 +243,7 @@ func TestAwaitBootstrapComplete_JobFailed(t *testing.T) {
 	}
 	cfg := testCfg(t, job)
 
-	params := AwaitBootstrapCompleteParams{JobName: BootstrapJobName(node), Namespace: node.Namespace}
+	params := AwaitBootstrapCompleteParams{JobName: BootstrapJobName(node.Name), Namespace: node.Namespace}
 	raw, _ := json.Marshal(params)
 	exec, err := deserializeBootstrapAwait("id-3", raw, cfg)
 	if err != nil {
@@ -273,7 +278,7 @@ func TestAwaitBootstrapComplete_JobNotFound(t *testing.T) {
 func TestTeardownBootstrap_Execute_DeletesResources(t *testing.T) {
 	node := testNode()
 	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: BootstrapJobName(node), Namespace: node.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: BootstrapJobName(node.Name), Namespace: node.Namespace},
 	}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: node.Name, Namespace: node.Namespace},
@@ -281,7 +286,7 @@ func TestTeardownBootstrap_Execute_DeletesResources(t *testing.T) {
 	cfg := testCfg(t, job, svc)
 
 	params := TeardownBootstrapParams{
-		JobName:     BootstrapJobName(node),
+		JobName:     BootstrapJobName(node.Name),
 		ServiceName: node.Name,
 		Namespace:   node.Namespace,
 	}
@@ -297,7 +302,7 @@ func TestTeardownBootstrap_Execute_DeletesResources(t *testing.T) {
 	}
 
 	gotJob := &batchv1.Job{}
-	if err := cfg.KubeClient.Get(ctx, types.NamespacedName{Name: BootstrapJobName(node), Namespace: node.Namespace}, gotJob); !apierrors.IsNotFound(err) {
+	if err := cfg.KubeClient.Get(ctx, types.NamespacedName{Name: BootstrapJobName(node.Name), Namespace: node.Namespace}, gotJob); !apierrors.IsNotFound(err) {
 		t.Fatalf("expected job to be deleted, got err=%v", err)
 	}
 	gotSvc := &corev1.Service{}
@@ -347,12 +352,12 @@ func TestTeardownBootstrap_Status_CompleteWhenGone(t *testing.T) {
 func TestTeardownBootstrap_Status_RunningWhilePresent(t *testing.T) {
 	node := testNode()
 	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: BootstrapJobName(node), Namespace: node.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: BootstrapJobName(node.Name), Namespace: node.Namespace},
 	}
 	cfg := testCfg(t, job)
 
 	params := TeardownBootstrapParams{
-		JobName:     BootstrapJobName(node),
+		JobName:     BootstrapJobName(node.Name),
 		ServiceName: node.Name,
 		Namespace:   node.Namespace,
 	}


### PR DESCRIPTION
## Summary

Pure refactor that prepares for the SND-driven fork-genesis plan (PR 2). No behavior change on the per-SeiNode bootstrap path.

- Introduces `task.BootstrapPodInputs` — value-typed pod-shape contract for the bootstrap Job and its sibling headless Service.
- `GenerateBootstrapJob`, `GenerateBootstrapService`, `BootstrapJobName`, `BootstrapLabels`, `buildBootstrapPodSpec`, and `bootstrapSeidInitContainer` no longer take a `*SeiNode`.
- `nodeToBootstrapInputs(node, snap)` adapter lives next to `assertNoSigningKeyOnBootstrapPod` in a new `bootstrap_node_adapter.go`. Both stay SeiNode-shaped because they read SeiNode-only fields. The SND fork-genesis path (next PR) will build `BootstrapPodInputs` directly without a SeiNode in scope.
- Job-side invariants (`Name`, `Namespace`, `ChainID`, `SeidImage`, `BootstrapImage`, `HaltHeight`) are now enforced inside `GenerateBootstrapJob` so any future direct caller fails fast.
- Four `TestTaskGenerateBootstrapJob_*` tests moved from `internal/controller/node/` into `internal/task/` where they have access to the unexported adapter — including the load-bearing `_NeverHasIdentityVolumes` regression guard.

Per the fork-genesis LLD ([Rev 3](docs/design-fork-genesis-export-job-lld.md), §A4), this is **PR A** of a 4-PR sequence.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages green)
- [x] `goimports -l` clean on touched directories
- [x] Cross-reviewed by kubernetes-specialist before tagging humans

🤖 Generated with [Claude Code](https://claude.com/claude-code)