### PR TITLE
docs(lld): fork-genesis Rev 4 — sidecar upload-file task, drop seictl CLI

### DIFF
--- a/docs/design-fork-genesis-export-job-lld.md
+++ b/docs/design-fork-genesis-export-job-lld.md
@@ -1,9 +1,10 @@
 # Design: Fork-Genesis Export — push the lifecycle into plan generation
 
-**Status:** Revision 4 (post-PR-A merge; pivots PR 1 from CLI to sidecar task)
+**Status:** Revision 4.1 (post-coral cross-review)
 **Date:** 2026-05-05
 **Tracks:** sei-k8s-controller fork-genesis architectural fix
 **Related:** `internal/task/fork_export.go`, `internal/task/bootstrap_resources.go`, `seictl/sidecar/tasks/export_state.go`, `internal/planner/group.go`
+**Prior revisions:** sei-k8s-controller#169 (Rev 1, OneShot/PhaseBootstrapComplete), #170 (Rev 3, single-container export Job + `seictl upload` CLI), #173 (PR A, `BootstrapPodInputs` refactor — merged).
 
 ## Problem
 
@@ -15,20 +16,13 @@ exec: "seid": executable file not found in $PATH
 
 Root cause: `seictl/sidecar/tasks/export_state.go:85` does `exec.CommandContext(ctx, "seid", args...)` from inside the sei-sidecar container, which is distroless and ships only `seictl`. The `seid` binary lives in a separate container in the same pod. Pod containers share network and named volumes — not filesystems. The exec lookup is structurally impossible.
 
-## How this design evolved (Rev 1 → Rev 4)
-
-- **Rev 1 (merged at #169)** added `Spec.OneShot bool` + `PhaseBootstrapComplete` to opt the exporter SeiNode out of the StatefulSet phase.
-- **Rev 2** dropped `Spec.OneShot` after user feedback ("adding fields into the spec is a really bad smell"). Exporter no longer wrapped as a SeiNode — SND-level plan owns Jobs and PVC directly. Branch on `Spec.Genesis.Fork != nil` (already in spec). Proposed a fused `await-export-finished-and-upload` task with a sidecar in the export Job.
-- **Rev 3 (merged at #170)** dropped the sidecar from the export Job. Export Job became single-container with a `seictl-copy` initContainer; seid container chained `seid export > file && seictl upload`. `BootstrapPodInputs` refactor (PR A) landed standalone.
-- **Rev 4 (this revision)** drops the `seictl upload` CLI subcommand and the `seictl-copy` initContainer. The export Job re-introduces a native `sei-sidecar` container; the seid container triggers a `upload-file` sidecar HTTP task and polls for completion. Reasoning: a generic file-upload CLI is outside seictl's scope. seictl's CLI is for sei-chain-specific operations (config, genesis, patch, await, report); generic ops belong as sidecar HTTP tasks alongside the existing `snapshot-upload` family. The cost is a longer seid-container shell script that POSTs and polls via bash `/dev/tcp` — same primitive the existing `bootstrapWaitCommand` already uses for healthchecks. PR A merged unchanged; only PR 1 and PR 2 are reshaped.
-
 ## Goals
 
 1. Export-state phase succeeds end-to-end with no cross-container exec.
 2. No new SeiNode CRD spec fields, no new lifecycle phases — branch on existing semantic information.
 3. Reuse the bootstrap-Job pod-spec primitives (the seid-init + sei-sidecar + seid container shape) without forcing a single fused builder for both bootstrap and export.
 4. Failure modes debuggable via `kubectl get jobs` + `kubectl logs` on the SND. Two log streams per export Job (seid + sei-sidecar) — same as bootstrap Jobs.
-5. Status surface on the SND tells operators whether export succeeded, where the artifact lives, and which Job to read logs from.
+5. Status surface on the SND tells operators which Job ran the export.
 6. Keep seictl's CLI surface focused on sei-chain-specific verbs. Generic file/S3 operations live in the sidecar's HTTP task registry.
 
 ## Non-goals
@@ -41,7 +35,7 @@ Root cause: `seictl/sidecar/tasks/export_state.go:85` does `exec.CommandContext(
 
 ### A1. Exporter is not a SeiNode — SND owns Jobs and PVC directly
 
-The current `create-exporter` task creates a SeiNode CRD object that goes through the standard init plan (bootstrap Job → StatefulSet → Running). Rev 3 deletes that pattern. The SND-level fork-genesis sub-plan creates the PVC, the bootstrap Job, the export Job, and the headless Service directly — owner-referenced to the SND.
+The `create-exporter` task creates a SeiNode CRD object that goes through the standard init plan (bootstrap Job → StatefulSet → Running). This design deletes that pattern. The SND-level fork-genesis sub-plan creates the PVC, the bootstrap Job, the export Job, and the headless Service directly — owner-referenced to the SND.
 
 Why: the exporter's "lifecycle" only exists from the controller's point of view. The user never queries `kubectl get seinode <exporter>`. Modeling it as a SeiNode forces invariants (`Phase`, `Conditions`, `ResolvePlan` drift detection, NodeUpdate plans) that we then have to gate. Modeling it as Jobs avoids that ceremony entirely.
 
@@ -51,25 +45,24 @@ Why: the exporter's "lifecycle" only exists from the controller's point of view.
 ensure-exporter-pvc       PVC <group>-exporter-data, owner-ref'd to SND. Size + storageClassName
                           copied from `Spec.Template.Spec.DataVolume`. RWO.
 
-apply-bootstrap-job       Job <group>-exporter-bootstrap. Uses `GenerateBootstrapJob(BootstrapPodInputs)`
-                          — the helper merged in PR A. seid-init + sei-sidecar + seid containers
-                          (bootstrap shape). seid runs `seid start --halt-height N`.
+apply-bootstrap-job       Job <group>-exporter-bootstrap. Uses `GenerateBootstrapJob(BootstrapPodInputs)`.
+                          seid-init + sei-sidecar + seid containers (bootstrap shape). seid runs
+                          `seid start --halt-height N`.
 
 await-bootstrap-job       Polls Job.status.succeeded == 1.
 
 apply-export-job          Job <group>-exporter-export. Uses new `GenerateExportJob(ExportJobInputs)`.
-                          Same three-container shape as the bootstrap Job. The sei-sidecar
-                          container has the `upload-file` HTTP task registered. The seid main
-                          container runs `seid export > /sei/tmp/exported-state.json`, then
-                          POSTs `upload-file` to the sidecar over localhost, polls until terminal,
-                          and exits with a code derived from the task's `Retryable` flag.
+                          Same three-container shape as the bootstrap Job. The sei-sidecar has the
+                          `upload-file` HTTP task registered. The seid main container runs
+                          `seid export > /sei/tmp/exported-state.json`, POSTs `upload-file` to
+                          the sidecar over localhost, polls until terminal, exits 0 on success
+                          and 1 on any failure.
 
-await-export-job          Same task type/code shape as await-bootstrap-job, parameterized by
-                          JobName. Reads pod.Status.ContainerStatuses[seid].State.Terminated.ExitCode
-                          on failure to set Reason.
+await-export-job          Polls the same Job-status surface as await-bootstrap-job. On Failed,
+                          stamps Reason=UploadFailed.
 
-teardown-exporter         Deletes PVC + both Jobs explicitly. K8s cascade-GC from SND deletion is
-                          the abandonment-path safety net.
+teardown-exporter         Deletes PVC + both Jobs + Service explicitly. K8s cascade-GC from SND
+                          deletion is the abandonment-path safety net.
 
 assemble-genesis-fork     Unchanged. Reads <sourceChainId>/exported-state.json from S3.
 
@@ -86,30 +79,28 @@ Validator-side init plans untouched.
 
 ### A4. `BootstrapPodInputs` (merged in PR A — recorded for context)
 
-PR A merged at sei-k8s-controller#173 with the following struct shape:
+PR A merged at #173 with this shape:
 
 ```go
 type BootstrapPodInputs struct {
     Name                 string
     Namespace            string
     ChainID              string
-    Image                string  // single seid image (init + main)
+    Image                string
     SidecarImage         string
     SidecarPort          int32
     SidecarResources     *corev1.ResourceRequirements
     Mode                 string  // "full" | "archive" | "validator"
     HaltHeight           int64
-    ForbiddenSecretNames []string  // signing-key + node-key Secrets — fail closed if mounted
+    ForbiddenSecretNames []string
 }
 ```
 
-`GenerateBootstrapJob(BootstrapPodInputs, platform.Config) (*batchv1.Job, error)` enforces validator-identity invariants internally via `rejectForbiddenSecretMounts`. The per-SeiNode `nodeToBootstrapInputs(node, snap)` adapter populates `ForbiddenSecretNames` with the validator's signing-key and node-key Secret names.
-
-The SND fork-genesis path constructs `BootstrapPodInputs` directly with `ForbiddenSecretNames: nil` — there is no validator in scope and the builder still fails closed if any future change inadvertently adds one.
+`GenerateBootstrapJob(BootstrapPodInputs, platform.Config) (*batchv1.Job, error)` enforces the validator-identity invariant internally via `rejectForbiddenSecretMounts`. The per-SeiNode `nodeToBootstrapInputs(node, snap)` adapter populates `ForbiddenSecretNames` with the validator's signing-key and node-key Secret names. The SND fork-genesis path constructs `BootstrapPodInputs` directly with `ForbiddenSecretNames: nil` — there is no validator in scope and the builder still fails closed if any future change inadvertently adds one.
 
 ### A5. `GenerateExportJob` builder
 
-The export Job's pod shape is structurally identical to the bootstrap Job's: `seid-init` + `sei-sidecar` (native sidecar) + `seid` (main). What differs is the seid container's command and the sidecar tasks the seid container triggers. Don't fuse the builders — sibling helper:
+The export Job's pod shape is structurally identical to the bootstrap Job's: `seid-init` + `sei-sidecar` (native sidecar with `restartPolicy: Always`) + `seid` (main). What differs is the seid container's command and which sidecar tasks the seid container triggers. The two builders stay separate; PR 2 extracts a shared `buildSidecarContainer(image, port, env, resources)` helper used by both.
 
 ```go
 type ExportJobInputs struct {
@@ -120,7 +111,7 @@ type ExportJobInputs struct {
     SidecarImage      string  // resolved from platform.Config (same as bootstrap path)
     SidecarPort       int32   // resolved from platform.Config
     SidecarResources  *corev1.ResourceRequirements
-    Mode              string  // for nodepool selection — "full" suffices for export
+    Mode              string  // "full" — drives nodepool selection and resource preset
     PVCClaimName      string  // = the bootstrap-stage PVC, mounted RW
     ExportHeight      int64
     GenesisBucket     string  // from platform.Config
@@ -131,81 +122,69 @@ type ExportJobInputs struct {
 func GenerateExportJob(ExportJobInputs, platform.Config) (*batchv1.Job, error)
 ```
 
-Pod shape:
+Pod-spec assembly mirrors `buildBootstrapPodSpec`:
 
-```yaml
-spec:
-  restartPolicy: Never
-  hostname: <Name>-0
-  subdomain: <Name>             # so sidecar URL is <Name>-0.<Name>.<ns>.svc...
-  shareProcessNamespace: true
-  initContainers:
-    - name: seid-init
-      image: <SeidImage>
-      command: ["/bin/sh", "-c", "seid init <ChainID> --home /sei --overwrite || true; mkdir -p /sei/tmp"]
-      volumeMounts:
-        - { name: data, mountPath: /sei }
-    - name: sei-sidecar           # native sidecar — restartPolicy: Always
-      image: <SidecarImage>
-      restartPolicy: Always
-      command: ["seictl", "serve"]
-      env:
-        - { name: SEI_CHAIN_ID,       value: <ChainID> }
-        - { name: SEI_SIDECAR_PORT,   value: "<SidecarPort>" }
-        - { name: SEI_HOME,           value: /sei }
-        - { name: SEI_GENESIS_BUCKET, value: <GenesisBucket> }
-        - { name: SEI_GENESIS_REGION, value: <GenesisRegion> }
-        # SEI_SNAPSHOT_BUCKET / SEI_SNAPSHOT_REGION inherited if needed
-      volumeMounts:
-        - { name: data, mountPath: /sei }
-  containers:
-    - name: seid
-      image: <SeidImage>
-      command: ["/bin/bash", "-c"]
-      args: ["<seid-export-and-trigger-script — see below>"]
-      env:
-        - { name: TMPDIR,         value: /sei/tmp }
-        - { name: EXPORT_HEIGHT,  value: "<ExportHeight>" }
-        - { name: GENESIS_BUCKET, value: <GenesisBucket> }
-        - { name: GENESIS_REGION, value: <GenesisRegion> }
-        - { name: GENESIS_KEY,    value: <GenesisKey> }
-        - { name: SIDECAR_PORT,   value: "<SidecarPort>" }
-      volumeMounts:
-        - { name: data, mountPath: /sei }
-  volumes:
-    - name: data
-      persistentVolumeClaim: { claimName: <PVCClaimName> }
-```
+- `ServiceAccountName: platformCfg.ServiceAccount` — required for IRSA so the sidecar's `transfermanager` can authenticate to S3.
+- `RestartPolicy: Never`. K8s 1.29+ permits a per-container `restartPolicy: Always` on the sei-sidecar (native-sidecar GA — KEP-753); the kubelet sends SIGTERM to the sidecar when the seid main container exits, and the Job's `Status.Succeeded` is determined by the seid container's exit code.
+- `TerminationGracePeriodSeconds: 600`. Longer than bootstrap's 120s so a cascade-GC mid-upload (operator deletes the SND) gives the sidecar's `transfermanager` time to finalize before SIGKILL.
+- `BackoffLimit: 0`, `TTLSecondsAfterFinished: 3600`. The TTL must outlast `await-export-job`'s polling window so the controller can list the Pod by Job-selector and read the seid container's `Terminated.ExitCode`.
+- Same Karpenter `do-not-disrupt` annotation, tolerations, and `karpenter.sh/nodepool` affinity as the bootstrap Job (resolved from `platformCfg.NodepoolForMode(Mode)`).
+- `bootstrapResourcesForMode(Mode, platformCfg)` on the seid container — unbounded `seid export` on a multi-TiB chain will OOM-kill without requests.
 
-`backoffLimit: 0`, `restartPolicy: Never`. No `seictl-copy` init container, no `emptyDir` volume — the export Job's footprint matches the bootstrap Job's exactly.
+Sidecar env (`SEI_CHAIN_ID`, `SEI_HOME`, `SEI_GENESIS_BUCKET`, `SEI_GENESIS_REGION`, `SEI_SIDECAR_PORT`). `SEI_SNAPSHOT_BUCKET` / `SEI_SNAPSHOT_REGION` are deliberately omitted — the export Job's sidecar only needs the genesis bucket.
 
-The seid container's args is a bash script that runs the export and triggers the upload via the sidecar. Sketch (full implementation lives in `internal/task/export_resources.go`):
+The seid container's args is a bash script defined as a `const` in `internal/task/export_resources.go` so unit tests pin the exact text:
 
 ```bash
 set -euo pipefail
 
-# 1. Wait for the sidecar to come up (mirrors bootstrapWaitCommand healthz poll).
+# Wait for the sidecar to come up. Bound by 5 min so we don't hang forever.
+SECONDS=0
 until (exec 3<>/dev/tcp/localhost/${SIDECAR_PORT} \
        && printf 'GET /v0/healthz HTTP/1.0\r\nHost: localhost\r\n\r\n' >&3 \
        && head -1 <&3 | grep -q ' 200 ') 2>/dev/null; do
+    if [ "$SECONDS" -ge 300 ]; then
+        echo "sidecar healthz never reached 200 after ${SECONDS}s" >&2
+        exit 1
+    fi
     sleep 5
 done
 
-# 2. Run the export. Stderr stays on the container's stderr stream.
+# Run the export. Stderr stays on the container's stderr stream.
 seid export --home /sei --height "${EXPORT_HEIGHT}" > /sei/tmp/exported-state.json
 
-# 3. POST upload-file task to sidecar; capture task id from response.
+# POST upload-file task; capture task id.
 BODY=$(printf '{"file":"/sei/tmp/exported-state.json","bucket":"%s","key":"%s","region":"%s"}' \
        "${GENESIS_BUCKET}" "${GENESIS_KEY}" "${GENESIS_REGION}")
-TASK_ID=$(post_task localhost ${SIDECAR_PORT} /v0/tasks/upload-file "${BODY}")
+RESP=$(post_task localhost ${SIDECAR_PORT} /v0/tasks/upload-file "${BODY}")
+TASK_ID=$(echo "$RESP" | grep -oE '"id":"[^"]+"' | head -1 | cut -d'"' -f4)
 
-# 4. Poll task status; map terminal Retryable=true → exit 11, else exit 10. Success → exit 0.
-exit "$(poll_task_until_done localhost ${SIDECAR_PORT} "${TASK_ID}")"
+# Poll task status. On terminal failure, echo the TaskResult.Error to stderr
+# so kubectl logs surfaces the classified message, then exit 1.
+while true; do
+    RESP=$(get_task localhost ${SIDECAR_PORT} "${TASK_ID}")
+    STATUS=$(echo "$RESP" | grep -oE '"status":"[^"]+"' | head -1 | cut -d'"' -f4)
+    case "$STATUS" in
+        complete) exit 0 ;;
+        failed)
+            echo "$RESP" | grep -oE '"error":"[^"]+"' | head -1 | cut -d'"' -f4 >&2
+            exit 1 ;;
+        *) sleep 5 ;;
+    esac
+done
 ```
 
-`post_task` and `poll_task_until_done` are bash functions defined inline; they speak HTTP/1.0 over `/dev/tcp` and parse JSON with `grep`/`cut` (no `jq` in the seid distroless image). Same mechanic as `bootstrapWaitCommand`. Implementation captured as a module-level constant in `export_resources.go` so unit tests can pin the exact script.
+`post_task` and `get_task` are bash functions (also in the const) that speak HTTP/1.0 over `/dev/tcp` — same primitive `bootstrapWaitCommand` already uses. JSON parsing is `grep`/`cut` because the seid distroless image has no `jq`. The shape matches the existing `engine.TaskResult` envelope (`status`, `error`) — no wire-format change needed in PR 1.
 
-The shared helpers between bootstrap and export Jobs (nodepool selection, tolerations, Karpenter `do-not-disrupt` annotation, common pod labels, PodSpec assembly) live as standalone functions both builders call.
+#### Differences from the bootstrap Job
+
+Same three-container shape. The deltas, all in §A5:
+
+- Sidecar env: no `SEI_SNAPSHOT_*`.
+- Seid container command: `seid export → POST upload-file → poll → exit`, vs. bootstrap's `wait healthz → seid start --halt-height`.
+- `TerminationGracePeriodSeconds: 600` vs. bootstrap's 120 — covers in-flight uploads on cascade-GC.
+- No `ForbiddenSecretNames` to enforce — no validator in scope, builder still fails closed if any future change adds a Secret volume named like a signing key.
+- Halt-height (bootstrap) → export-height (export). Same shape, different verb on seid.
 
 ### A6. Sidecar `upload-file` HTTP task (PR 1)
 
@@ -220,60 +199,43 @@ New sidecar HTTP task at `POST /v0/tasks/upload-file`. Body:
 }
 ```
 
-Returns the standard sidecar task envelope: `{ "id": "<task-id>" }`. The task runs asynchronously inside the sidecar process; clients poll `GET /v0/tasks/<task-id>` for state. On terminal failure the response carries a populated `engine.TaskError` with `Retryable: bool`.
+Returns the standard sidecar task envelope: `{ "id": "<task-id>" }`. The task runs asynchronously inside the sidecar process; clients poll `GET /v0/tasks/<task-id>` for state. On failure the response carries the standard `engine.TaskResult` with `status: "failed"` and `error: "<formatted TaskError>"` — the seid container's bash echoes that string to stderr before exiting 1, and the operator reads the classified message ("S3 throttled" / "access denied" / etc.) via `kubectl logs`.
 
-Implementation reuses `seis3.UploaderFactory` and `seis3.ClassifyS3Error` — same helpers the existing `snapshot-upload` task uses. Streams the file through `transfermanager.UploadObjectInput` so multi-GB exports don't sit in memory.
+Implementation reuses `seis3.UploaderFactory` and `seis3.ClassifyS3Error` — same helpers the existing `snapshot-upload` task uses. Streams the file through `transfermanager.UploadObjectInput` so multi-GB exports don't sit in memory. **No `engine.TaskResult` schema change.** Earlier drafts of this design proposed a `Retryable bool` on the wire to drive a 10/11 exit-code split; we collapsed that to exit 0/1 because nothing downstream consumed the bit (the controller doesn't auto-retry; operators read the classified message from `kubectl logs` directly).
 
-The seid container in the export Job consumes this task as described in §A5. Exit codes the seid container sets, derived from the polled task state:
+#### Why a sidecar task and not a `seictl upload` CLI
 
-```
-exit 0  — task complete (Status: complete)
-exit 10 — task failed with Retryable=false (operator must fix)
-exit 11 — task failed with Retryable=true (re-run might succeed)
-exit 1  — anything else (script-level error: file not found, sidecar unreachable, etc.)
-```
-
-`await-export-job` on the controller side reads `pod.Status.ContainerStatuses[<seid>].State.Terminated.ExitCode` and stamps `ForkExportComplete=False, Reason=UploadFailed (terminal|retryable)` on the SND.
-
-The seictl HTTP `export-state` task that ran `exec seid` from inside the sidecar (the original bug) is deleted in PR 3.
+A `seictl upload --file ... --bucket ...` CLI was the previous shape. We rejected it because seictl's CLI surface is for sei-chain-specific operations (config, genesis, patch, await, report); a generic file-uploader bloats the surface. The sidecar already runs in every Job pod, already has `seis3` helpers, and `upload-file` is a natural neighbor of the existing `snapshot-upload` task. Tradeoff: the bash POST/poll script in §A5 is ~30 lines (modeled on `bootstrapWaitCommand`). A future debug-pod use case where a human wants to upload a one-off file would benefit from the CLI shape — accepted as a follow-up trigger if anyone hits it.
 
 ### A7. SND status surface
 
 New conditions on `SeiNodeDeployment.Status.Conditions`:
 
 - `ForkBootstrapComplete` — set after `await-bootstrap-job` succeeds. Reasons: `HaltHeightReached`, `SnapshotRestoreFailed`, `BootstrapJobFailed`.
-- `ForkExportComplete` — set after `await-export-job` succeeds. Reasons: `Uploaded`, `ExportFailed`, `UploadFailed`, `Unknown`.
+- `ForkExportComplete` — set after `await-export-job` succeeds. Reasons: `Uploaded`, `ExportFailed`, `UploadFailed`.
 - `ForkGenesisReady` — set after `assemble-genesis-fork` lands the final `<chainId>/genesis.json`.
 
-New fields on `SeiNodeDeployment.Status.Fork`:
+One new field on `SeiNodeDeployment.Status.Fork`:
 
-- `ExportArtifactURL` — `s3://<genesis-bucket>/<sourceChainId>/exported-state.json` once uploaded.
-- `ExportedHeight` — the height that was exported, stamped after success.
-- `ExportJobRef` — namespaced name of the export Job, so operators can `kubectl logs job/<ref>` directly from `kubectl describe seinodedeployment`.
+- `ExportJobRef` — namespaced name of the export Job, so operators can `kubectl logs job/<ref>` directly from `kubectl describe seinodedeployment`. Populated when `apply-export-job` creates the Job; remains after `teardown-exporter` deletes it (historical breadcrumb).
 
-### A8. Karpenter scheduling
+`Status.Fork.ExportJobRef` populated AND `ForkExportComplete` not yet `True` is the in-progress signal. We don't add a transitional "Uploading" condition.
 
-Both Jobs mirror existing bootstrap Job's annotations:
-- `karpenter.sh/do-not-disrupt: true` on the pod template
-- Same nodeSelector/tolerations/topologySpreadConstraints copied from the SND template (both Jobs run in the same AZ to share the same RWO PVC)
+`ExportArtifactURL` (deterministic from `s3://${GENESIS_BUCKET}/${SourceChainID}/exported-state.json`) and `ExportedHeight` (= `Spec.Genesis.Fork.SourceHeight`) are intentionally not status fields — both are derivable from spec; stamping them on status is duplication.
 
-Both Jobs use `restartPolicy: Never` and `backoffLimit: 0` (one-shot, fail-terminal).
+### A8. Karpenter and PVC scheduling
 
-### A9. Single-AZ PVC across two Jobs
-
-The PVC is RWO and bound to a single AZ once the bootstrap Job's pod attaches it. The export Job's pod must land in the same AZ. Karpenter respects `topology.kubernetes.io/zone` on the bound PV; the second Job's pod will schedule into the same AZ or fail to schedule (which surfaces cleanly as a `Pending` pod with a `Multi-Attach`/`affinity` event). No silent corruption.
-
-Documenting this as expected operational behavior. Chaining the two Jobs into one isn't viable: the bootstrap Job needs the sidecar running concurrently with seid (HTTP healthz gate before seid starts), and that's a sidecar-container pattern, not an init-container pattern. Init containers run sequentially.
+Both Jobs reuse the bootstrap Job's scheduling annotations (`karpenter.sh/do-not-disrupt`, tolerations, nodepool affinity). The PVC is RWO and bound to a single AZ once the bootstrap Job's pod attaches it; Karpenter respects `topology.kubernetes.io/zone` on the bound PV, so the export Job's pod schedules into the same AZ or fails to schedule (a `Pending` pod with a `Multi-Attach`/`affinity` event — surfaces cleanly, no silent corruption). We don't additionally set explicit nodeAffinity on the export Job.
 
 ## Plan-shape diff
 
-| Before (current main) | After (Rev 4) |
+| Before (current main) | After |
 |---|---|
 | `create-exporter` (creates SeiNode) | `ensure-exporter-pvc` |
 | (SeiNode init plan: PVC + bootstrap Job + StatefulSet) | `apply-bootstrap-job` |
 | `await-exporter-running` (polls SeiNode phase) | `await-bootstrap-job` (polls Job) |
 | `submit-export-state` (broken: sidecar exec seid) | `apply-export-job` |
-| — | `await-export-job` (same shape as await-bootstrap-job) |
+| — | `await-export-job` |
 | `teardown-exporter` (deletes SeiNode) | `teardown-exporter` (deletes PVC + Jobs + Service) |
 | `assemble-genesis-fork` | unchanged |
 
@@ -281,34 +243,35 @@ Documenting this as expected operational behavior. Chaining the two Jobs into on
 
 ### PR A — `BootstrapPodInputs` refactor
 
-Merged at sei-k8s-controller#173.
+Merged at #173.
 
 ### PR 1 — Sidecar `upload-file` HTTP task (seictl, ~120 LoC + tests)
 
 - New file `seictl/sidecar/tasks/upload_file.go`:
   - `UploadFileTask` implementing the sidecar `engine.Task` interface.
-  - Params struct: `{ File, Bucket, Key, Region string }`.
+  - Params struct: `{ File, Bucket, Key, Region string }`. Param validation (any empty → 400) before submission.
   - Reuses `seis3.UploaderFactory` (default + injectable for tests) and `seis3.ClassifyS3Error`.
-  - Returns the standard `engine.TaskError` shape; the sidecar's HTTP layer handles the wire envelope.
-- Register the task type in `seictl/sidecar/serve.go` (or wherever the task registry lives).
-- Tests modeled on `snapshot_upload_test.go`: mock `seis3.Uploader`, table-driven over success / `AccessDenied` (terminal) / `SlowDown` (retryable) / file-not-found (non-S3 error). 100% coverage of the task's branches.
-- No CLI surface — the task is reachable only through `POST /v0/tasks/upload-file`.
+  - Returns `engine.TaskError` from the run path; the sidecar's HTTP layer formats it into `TaskResult.Error` per the existing wire contract.
+- Register the task type in `seictl/sidecar/serve.go`.
+- Tests modeled on `snapshot_upload_test.go`: mock `seis3.Uploader`, table-driven over success / `AccessDenied` / `SlowDown` / file-not-found. 100% coverage of the task's branches. One additional contract test pins the JSON request shape against PR 2's bash script (the bash POSTs `{"file":"...","bucket":"...","key":"...","region":"..."}` and the test asserts those keys are exactly what `UploadFileTask`'s param decoder accepts).
 
 ### PR 2 — Fork-genesis SND-driven plan (controller, ~280 LoC net new + ~350 LoC deleted)
 
 Files added:
 - `internal/task/fork_exporter.go` — replaces `fork_export.go`. Task types and executions for `ensure-exporter-pvc`, `apply-bootstrap-job` (SND), `await-bootstrap-job` (SND, parameterized by JobName), `apply-export-job`, `await-export-job` (SND), `teardown-exporter` (SND). Helpers: `ExporterPVCName(group)`, `ExporterBootstrapJobName(group)`, `ExporterExportJobName(group)`, `ExporterServiceName(group)`.
-- `internal/task/export_resources.go` — `GenerateExportJob(ExportJobInputs, platform.Config)`. The seid container's bash script (the trigger-and-poll body) lives as a `const` here so unit tests can pin it.
+- `internal/task/export_resources.go` — `GenerateExportJob(ExportJobInputs, platform.Config)`. The seid container's bash script lives as a `const` here so unit tests can pin the exact text.
 
 Files modified:
+- `internal/task/bootstrap_resources.go`: extract `buildSidecarContainer(image, port, env, resources)` shared with the export builder. Leave `seid-init` inline in each builder (two lines each — duplication isn't worth a helper).
 - `internal/planner/group.go` (or wherever the fork sub-plan is generated): emit the new task list above.
 - `internal/task/registry.go`: register new task types; remove `TaskTypeCreateExporter`, `TaskTypeAwaitExporterRunning`, `TaskTypeSubmitExportState`.
-- `internal/task/bootstrap_resources.go`: optionally factor `buildSeidInitContainer` / `buildSidecarContainer` out so `GenerateBootstrapJob` and `GenerateExportJob` can both call them — only if the duplication is more than ~30 LoC. Keep both builders distinct at the top level.
 - `go.mod`: bump seictl to PR 1's release.
-- `api/v1alpha1/seinodedeployment_types.go` (or wherever `Status.Fork` lives): add `ExportArtifactURL`, `ExportedHeight`, `ExportJobRef` fields.
+- `api/v1alpha1/seinodedeployment_types.go`: add `ExportJobRef` field on `Status.Fork`; add the three new conditions.
 
 Files deleted:
 - `internal/task/fork_export.go` (entire file — the four old task types).
+
+`apply-export-job` Execute is idempotent at the Job-apply layer (server-side apply, fieldOwner). The sidecar's `upload-file` task is fire-and-forget non-idempotent — but since `apply-export-job` produces exactly one Job and the seid container POSTs exactly once per Pod lifecycle (and `restartPolicy: Never` + `backoffLimit: 0` prevent Pod restart), there's no path that produces duplicate uploads.
 
 ### PR 3 — seictl: delete `export-state` HTTP task
 
@@ -327,19 +290,19 @@ Unit tests (PR A — already merged):
 
 Unit tests (PR 1):
 - `UploadFileTask` happy path with mock `seis3.Uploader`.
-- `Retryable=true` path: `SlowDown` and simulated network error.
-- `Retryable=false` path: `AccessDenied`, `NoSuchBucket`.
-- File-not-found: returns non-classified error, sidecar surfaces it as terminal.
+- Failure paths: `AccessDenied`, `NoSuchBucket`, `SlowDown`, simulated network error, file-not-found. Each asserts the `TaskError.Error()` rendering contains the classified message.
 - Param validation: missing `File`/`Bucket`/`Key`/`Region` → 400.
+- Contract test: the JSON keys PR 2's bash POSTs exactly match `UploadFileTask`'s param decoder.
 
 Unit tests (PR 2):
 - `GenerateExportJob(ExportJobInputs{...})` produces correct pod spec — table-driven; pin the seid bash script as a string assertion.
 - `apply-bootstrap-job` and `apply-export-job` Execute is idempotent.
-- `await-bootstrap-job` and `await-export-job` Status table cases: not-yet-succeeded → Running; succeeded → Complete; failed (with various exit codes from the seid container) → Failed with stamped Reason.
+- `await-bootstrap-job` and `await-export-job` Status table cases: not-yet-succeeded → Running; succeeded → Complete; failed (with various exit codes) → Failed with stamped Reason.
 - Planner: `buildForkPlan` for an SND with `Genesis.Fork` set emits the new task list; without it, no fork-export tasks appear.
+- Planner: `Status.Fork.ExportJobRef` is stamped when `apply-export-job` creates the Job and is preserved across `teardown-exporter`.
 
 Integration smoke (post-PR-2 merge, on harbor):
-- Reconstitute the `eng-bdchatham` cell from git history. Apply. Watch the new flow run from `ensure-exporter-pvc` through `assemble-genesis-fork`. Verify `kubectl describe seinodedeployment` shows `ForkExportComplete=True` and `Status.Fork.ExportArtifactURL` populated.
+- Reconstitute the `eng-bdchatham` cell from git history. Apply. Watch the new flow run from `ensure-exporter-pvc` through `assemble-genesis-fork`. Verify `kubectl describe seinodedeployment` shows `ForkExportComplete=True` and `Status.Fork.ExportJobRef` populated.
 - Confirm both seid and sei-sidecar logs are reachable for the export Job.
 
 ## Execution plan
@@ -348,24 +311,22 @@ Integration smoke (post-PR-2 merge, on harbor):
 |---|---|---|---|---|
 | **A** | sei-k8s-controller | `BootstrapPodInputs` refactor | k8s-spec | merged at #173 |
 | **1** | seictl | Sidecar `upload-file` HTTP task | k8s-spec | pending |
-| **2** | sei-k8s-controller | New SND-driven fork-genesis plan tasks. Uses `BootstrapPodInputs` directly. Adds `GenerateExportJob`. Bumps seictl module. Adds `Status.Fork.*`. Deletes `fork_export.go` + four old task types. | k8s-spec + platform-eng | pending |
+| **2** | sei-k8s-controller | New SND-driven fork-genesis plan tasks. Uses `BootstrapPodInputs` directly. Adds `GenerateExportJob` + extracts `buildSidecarContainer`. Bumps seictl module. Adds `Status.Fork.ExportJobRef` + three conditions. Deletes `fork_export.go` + four old task types. | k8s-spec + platform-eng | pending |
 | **3** | seictl | Delete `export-state` HTTP task | k8s-spec | pending |
 
 Each PR gets coral cross-review before user-tagging. PR 1 and PR 2 can land in parallel, but PR 2 must bump to a seictl release that includes PR 1.
 
-## Open questions
-
-1. **Job `activeDeadlineSeconds`**: 6h (matches the previous `exportStateTimeout`)? Per-Job differentiation (bootstrap shorter, export longer)?
-2. **Sidecar task retry surface**: PR 1 ships single-attempt. If observed transient failures warrant it, expose a `MaxAttempts int` field in the task params in a follow-up.
-3. **`Status.Fork.ExportJobRef` cleanup timing**: stays referenced on the SND status after `teardown-exporter` deletes the Job — operators can still see "what Job ran the export," even though `kubectl logs` against it now 404s. Acceptable historical breadcrumb, or zero out on teardown?
-4. **Inline bash vs external trigger script**: the seid container's POST/poll body is ~30 lines of bash. Keep it inline as a `const` in `export_resources.go`, or ship a tiny `seictl/scripts/trigger-task.sh` that the seictl image already carries and the seid container shells out to via the shared `data` PVC? Inline is simpler; external is more debuggable. Default to inline; revisit if the script grows.
+Decisions captured here that would otherwise be open questions:
+- `activeDeadlineSeconds`: 6h on both bootstrap and export Jobs (matches the previous `exportStateTimeout`). Per-Job differentiation is a follow-up if a real failure motivates it.
+- Sidecar task retry: single-attempt. Auto-retry would be a planner-level `MaxRetries` decision, not a runtime classification.
+- `ExportJobRef` after teardown: kept as a historical breadcrumb. `kubectl logs` against a deleted Job 404s but the operator still knows which Job ran.
+- Inline bash vs. external `trigger-task.sh`: inline `const` in `export_resources.go` (mirrors `bootstrapWaitCommand`). External script would create a cross-image version-skew failure mode the design doesn't address.
 
 ## References
 
-- Rev 1 (now superseded): merged at PR sei-k8s-controller#169.
-- Rev 2 (force-pushed): the SND-driven sub-plan with sidecar-in-export-Job and a fused await-and-upload task.
-- Rev 3 (merged at PR #170): single-container export Job with `seictl-copy` init + `seictl upload` CLI.
-- Bootstrap-Job builder (post-PR-A): `internal/task/bootstrap_resources.go`. `BootstrapPodInputs`, `GenerateBootstrapJob`, `GenerateBootstrapService`, `rejectForbiddenSecretMounts`.
+- PR sei-k8s-controller#169 (Rev 1, superseded), #170 (Rev 3, force-pushed and superseded by Rev 4 force-push), #173 (PR A merged).
+- Bootstrap-Job builder (post-PR-A): `internal/task/bootstrap_resources.go` — `BootstrapPodInputs`, `GenerateBootstrapJob`, `GenerateBootstrapService`, `rejectForbiddenSecretMounts`, `bootstrapWaitCommand` (the `/dev/tcp` healthcheck primitive PR 2's seid script extends).
 - Existing snapshot-upload sidecar task (PR 1's reference implementation): `seictl/sidecar/tasks/snapshot_upload.go` + `_test.go`.
-- Existing fork-export tasks (to be deleted): `internal/task/fork_export.go`.
-- `bootstrapWaitCommand` (the bash + `/dev/tcp` healthcheck pattern PR 2's seid container script extends): `internal/task/bootstrap_resources.go`.
+- Existing fork-export tasks (deleted in PR 2): `internal/task/fork_export.go`.
+- `engine.TaskResult` wire envelope: `seictl/sidecar/engine/types.go`.
+- K8s native sidecar GA (KEP-753): permits per-container `restartPolicy: Always` on an initContainer alongside Pod-level `restartPolicy: Never`.

--- a/docs/design-fork-genesis-export-job-lld.md
+++ b/docs/design-fork-genesis-export-job-lld.md
@@ -1,6 +1,6 @@
 # Design: Fork-Genesis Export — push the lifecycle into plan generation
 
-**Status:** Revision 3 (force-pushed to Rev 2 PR after a simplification round)
+**Status:** Revision 4 (post-PR-A merge; pivots PR 1 from CLI to sidecar task)
 **Date:** 2026-05-05
 **Tracks:** sei-k8s-controller fork-genesis architectural fix
 **Related:** `internal/task/fork_export.go`, `internal/task/bootstrap_resources.go`, `seictl/sidecar/tasks/export_state.go`, `internal/planner/group.go`
@@ -15,19 +15,21 @@ exec: "seid": executable file not found in $PATH
 
 Root cause: `seictl/sidecar/tasks/export_state.go:85` does `exec.CommandContext(ctx, "seid", args...)` from inside the sei-sidecar container, which is distroless and ships only `seictl`. The `seid` binary lives in a separate container in the same pod. Pod containers share network and named volumes — not filesystems. The exec lookup is structurally impossible.
 
-## How this design evolved (Rev 1 → Rev 3)
+## How this design evolved (Rev 1 → Rev 4)
 
 - **Rev 1 (merged at #169)** added `Spec.OneShot bool` + `PhaseBootstrapComplete` to opt the exporter SeiNode out of the StatefulSet phase.
 - **Rev 2** dropped `Spec.OneShot` after user feedback ("adding fields into the spec is a really bad smell"). Exporter no longer wrapped as a SeiNode — SND-level plan owns Jobs and PVC directly. Branch on `Spec.Genesis.Fork != nil` (already in spec). Proposed a fused `await-export-finished-and-upload` task with a sidecar in the export Job.
-- **Rev 3 (this revision)** drops the sidecar from the export Job entirely. Export Job is single-container; uses an init container to copy the `seictl` static binary, and chains `seid export > file && seictl upload` in the main container. `await-export-job` becomes a standard `Job.status.succeeded` poll, identical in shape to `await-bootstrap-job`. `BootstrapPodInputs` refactor lands as its own prep PR, and a sibling `ExportJobInputs` struct stays distinct rather than fusing the two builders.
+- **Rev 3 (merged at #170)** dropped the sidecar from the export Job. Export Job became single-container with a `seictl-copy` initContainer; seid container chained `seid export > file && seictl upload`. `BootstrapPodInputs` refactor (PR A) landed standalone.
+- **Rev 4 (this revision)** drops the `seictl upload` CLI subcommand and the `seictl-copy` initContainer. The export Job re-introduces a native `sei-sidecar` container; the seid container triggers a `upload-file` sidecar HTTP task and polls for completion. Reasoning: a generic file-upload CLI is outside seictl's scope. seictl's CLI is for sei-chain-specific operations (config, genesis, patch, await, report); generic ops belong as sidecar HTTP tasks alongside the existing `snapshot-upload` family. The cost is a longer seid-container shell script that POSTs and polls via bash `/dev/tcp` — same primitive the existing `bootstrapWaitCommand` already uses for healthchecks. PR A merged unchanged; only PR 1 and PR 2 are reshaped.
 
 ## Goals
 
 1. Export-state phase succeeds end-to-end with no cross-container exec.
 2. No new SeiNode CRD spec fields, no new lifecycle phases — branch on existing semantic information.
-3. Reuse the bootstrap-Job pod-spec primitives (the seid + sei-sidecar container shape) without forcing a single fused builder for both bootstrap and export.
-4. Failure modes debuggable via `kubectl get jobs` + `kubectl logs` on the SND. Single-container export Job means one log stream.
+3. Reuse the bootstrap-Job pod-spec primitives (the seid-init + sei-sidecar + seid container shape) without forcing a single fused builder for both bootstrap and export.
+4. Failure modes debuggable via `kubectl get jobs` + `kubectl logs` on the SND. Two log streams per export Job (seid + sei-sidecar) — same as bootstrap Jobs.
 5. Status surface on the SND tells operators whether export succeeded, where the artifact lives, and which Job to read logs from.
+6. Keep seictl's CLI surface focused on sei-chain-specific verbs. Generic file/S3 operations live in the sidecar's HTTP task registry.
 
 ## Non-goals
 
@@ -50,21 +52,20 @@ ensure-exporter-pvc       PVC <group>-exporter-data, owner-ref'd to SND. Size + 
                           copied from `Spec.Template.Spec.DataVolume`. RWO.
 
 apply-bootstrap-job       Job <group>-exporter-bootstrap. Uses `GenerateBootstrapJob(BootstrapPodInputs)`
-                          — the helper refactored in PR A. seid + sei-sidecar containers
-                          (existing shape). seid runs `seid start --halt-height N`.
+                          — the helper merged in PR A. seid-init + sei-sidecar + seid containers
+                          (bootstrap shape). seid runs `seid start --halt-height N`.
 
 await-bootstrap-job       Polls Job.status.succeeded == 1.
 
-apply-export-job          Job <group>-exporter-export. Uses new `GenerateExportJob(ExportJobInputs)`
-                          — single seid container, init container copies seictl binary into a
-                          shared emptyDir. Main container chains:
-                            seid export --home /sei --height N > /sei/tmp/exported-state.json
-                              && seictl upload --file /sei/tmp/exported-state.json \
-                                              --bucket <genesis> --key <chain>/exported-state.json
-                                              --region <region>
+apply-export-job          Job <group>-exporter-export. Uses new `GenerateExportJob(ExportJobInputs)`.
+                          Same three-container shape as the bootstrap Job. The sei-sidecar
+                          container has the `upload-file` HTTP task registered. The seid main
+                          container runs `seid export > /sei/tmp/exported-state.json`, then
+                          POSTs `upload-file` to the sidecar over localhost, polls until terminal,
+                          and exits with a code derived from the task's `Retryable` flag.
 
 await-export-job          Same task type/code shape as await-bootstrap-job, parameterized by
-                          JobName. Reads pod.Status.ContainerStatuses[0].State.Terminated.ExitCode
+                          JobName. Reads pod.Status.ContainerStatuses[seid].State.Terminated.ExitCode
                           on failure to set Reason.
 
 teardown-exporter         Deletes PVC + both Jobs explicitly. K8s cascade-GC from SND deletion is
@@ -83,55 +84,51 @@ Validator-side init plans untouched.
 
 `ctrl.SetControllerReference(group, job, scheme)` for each of: PVC, bootstrap Job, export Job, headless Service.
 
-### A4. Refactor `GenerateBootstrapJob` to take `BootstrapPodInputs` as its own PR (PR A)
+### A4. `BootstrapPodInputs` (merged in PR A — recorded for context)
 
-Today: `GenerateBootstrapJob(node *SeiNode, snap *SnapshotSource, platformCfg) (*batchv1.Job, error)` — pulls fields off the SeiNode.
-
-PR A introduces:
+PR A merged at sei-k8s-controller#173 with the following struct shape:
 
 ```go
 type BootstrapPodInputs struct {
-    Name             string  // Job/Service name
-    Namespace        string
-    ChainID          string
-    SeidImage        string  // for the seid-init container
-    BootstrapImage   string  // for the main "seid" container (snap.BootstrapImage with fallback to SeidImage)
-    SidecarImage     string  // resolved (with default)
-    SidecarPort      int32   // resolved (with default)
-    SidecarResources *corev1.ResourceRequirements
-    Mode             string  // "full" | "archive" | "validator"
-    HaltHeight       int64
-    PVCClaimName     string  // explicit, not derived from Name — the export Job needs to
-                             // mount the bootstrap-provisioned PVC by name
+    Name                 string
+    Namespace            string
+    ChainID              string
+    Image                string  // single seid image (init + main)
+    SidecarImage         string
+    SidecarPort          int32
+    SidecarResources     *corev1.ResourceRequirements
+    Mode                 string  // "full" | "archive" | "validator"
+    HaltHeight           int64
+    ForbiddenSecretNames []string  // signing-key + node-key Secrets — fail closed if mounted
 }
 ```
 
-`GenerateBootstrapJob(in BootstrapPodInputs) (*batchv1.Job, error)`. Existing per-SeiNode caller (`bootstrap_job.go::Execute`) adds a small `nodeToInputs(node, snap)` adapter and calls the new signature.
+`GenerateBootstrapJob(BootstrapPodInputs, platform.Config) (*batchv1.Job, error)` enforces validator-identity invariants internally via `rejectForbiddenSecretMounts`. The per-SeiNode `nodeToBootstrapInputs(node, snap)` adapter populates `ForbiddenSecretNames` with the validator's signing-key and node-key Secret names.
 
-`assertNoSigningKeyOnBootstrapPod` stays at the per-SeiNode adapter boundary — it reads `node.Spec.Validator.SigningKey.Secret.SecretName`, which doesn't exist in `BootstrapPodInputs`. The SND fork-genesis path doesn't have a SeiNode and physically cannot leak signing material, so the assertion is irrelevant on that path.
+The SND fork-genesis path constructs `BootstrapPodInputs` directly with `ForbiddenSecretNames: nil` — there is no validator in scope and the builder still fails closed if any future change inadvertently adds one.
 
-### A5. Separate `GenerateExportJob` builder, distinct from `GenerateBootstrapJob`
+### A5. `GenerateExportJob` builder
 
-The export Job is structurally different from bootstrap (no sidecar, different command shape). Don't fuse the builders. Sibling helper:
+The export Job's pod shape is structurally identical to the bootstrap Job's: `seid-init` + `sei-sidecar` (native sidecar) + `seid` (main). What differs is the seid container's command and the sidecar tasks the seid container triggers. Don't fuse the builders — sibling helper:
 
 ```go
 type ExportJobInputs struct {
-    Name             string  // <group>-exporter-export
-    Namespace        string
-    SeidImage        string  // = fork.SourceImage
-    SeictlImage      string  // pinned by digest, used by the init container
-    PVCClaimName     string  // = the bootstrap PVC, mounted read-write
-    ExportHeight     int64
-    ChainID          string  // = fork.SourceChainID, used in the seid export command
-    GenesisBucket    string  // from platformCfg
-    GenesisRegion    string  // from platformCfg
-    GenesisKey       string  // = "<sourceChainId>/exported-state.json"
-    Mode             string  // for nodepool selection (likely "full")
-    OwnerRef         metav1.OwnerReference  // SND
-    EmptyDirSizeLimit *resource.Quantity     // for the seictl-binary copy volume — small (~50Mi)
+    Name              string  // <group>-exporter-export
+    Namespace         string
+    ChainID           string  // = fork.SourceChainID
+    SeidImage         string  // = fork.SourceImage
+    SidecarImage      string  // resolved from platform.Config (same as bootstrap path)
+    SidecarPort       int32   // resolved from platform.Config
+    SidecarResources  *corev1.ResourceRequirements
+    Mode              string  // for nodepool selection — "full" suffices for export
+    PVCClaimName      string  // = the bootstrap-stage PVC, mounted RW
+    ExportHeight      int64
+    GenesisBucket     string  // from platform.Config
+    GenesisRegion     string  // from platform.Config
+    GenesisKey        string  // = "<sourceChainId>/exported-state.json"
 }
 
-func GenerateExportJob(in ExportJobInputs) (*batchv1.Job, error)
+func GenerateExportJob(ExportJobInputs, platform.Config) (*batchv1.Job, error)
 ```
 
 Pod shape:
@@ -139,54 +136,106 @@ Pod shape:
 ```yaml
 spec:
   restartPolicy: Never
+  hostname: <Name>-0
+  subdomain: <Name>             # so sidecar URL is <Name>-0.<Name>.<ns>.svc...
+  shareProcessNamespace: true
   initContainers:
-    - name: seictl-copy
-      image: <seictl-image-by-digest>
-      imagePullPolicy: IfNotPresent
-      command: ["sh", "-c", "cp /usr/local/bin/seictl /seictl/seictl && chmod +x /seictl/seictl"]
-      volumeMounts:
-        - { name: seictl-bin, mountPath: /seictl }
-  containers:
-    - name: seid
-      image: <seid-image>
-      command: ["/bin/bash", "-c"]
-      args: ["seid export --home /sei --height $EXPORT_HEIGHT > /sei/tmp/exported-state.json && /seictl/seictl upload --file /sei/tmp/exported-state.json --bucket $GENESIS_BUCKET --key $GENESIS_KEY --region $GENESIS_REGION"]
-      env:
-        - { name: EXPORT_HEIGHT, value: "<height>" }
-        - { name: GENESIS_BUCKET, value: "..." }
-        - { name: GENESIS_KEY, value: "..." }
-        - { name: GENESIS_REGION, value: "..." }
-        - (Pod Identity creds inherited via webhook-injected env)
+    - name: seid-init
+      image: <SeidImage>
+      command: ["/bin/sh", "-c", "seid init <ChainID> --home /sei --overwrite || true; mkdir -p /sei/tmp"]
       volumeMounts:
         - { name: data, mountPath: /sei }
-        - { name: seictl-bin, mountPath: /seictl }
+    - name: sei-sidecar           # native sidecar — restartPolicy: Always
+      image: <SidecarImage>
+      restartPolicy: Always
+      command: ["seictl", "serve"]
+      env:
+        - { name: SEI_CHAIN_ID,       value: <ChainID> }
+        - { name: SEI_SIDECAR_PORT,   value: "<SidecarPort>" }
+        - { name: SEI_HOME,           value: /sei }
+        - { name: SEI_GENESIS_BUCKET, value: <GenesisBucket> }
+        - { name: SEI_GENESIS_REGION, value: <GenesisRegion> }
+        # SEI_SNAPSHOT_BUCKET / SEI_SNAPSHOT_REGION inherited if needed
+      volumeMounts:
+        - { name: data, mountPath: /sei }
+  containers:
+    - name: seid
+      image: <SeidImage>
+      command: ["/bin/bash", "-c"]
+      args: ["<seid-export-and-trigger-script — see below>"]
+      env:
+        - { name: TMPDIR,         value: /sei/tmp }
+        - { name: EXPORT_HEIGHT,  value: "<ExportHeight>" }
+        - { name: GENESIS_BUCKET, value: <GenesisBucket> }
+        - { name: GENESIS_REGION, value: <GenesisRegion> }
+        - { name: GENESIS_KEY,    value: <GenesisKey> }
+        - { name: SIDECAR_PORT,   value: "<SidecarPort>" }
+      volumeMounts:
+        - { name: data, mountPath: /sei }
   volumes:
     - name: data
-      persistentVolumeClaim: { claimName: <bootstrap PVC name> }
-    - name: seictl-bin
-      emptyDir:
-        medium: ""        # disk, not tmpfs
-        sizeLimit: 50Mi
+      persistentVolumeClaim: { claimName: <PVCClaimName> }
 ```
 
-`backoffLimit: 0`, no `terminationGracePeriodSeconds` tuning needed. Stderr stays on the container's stderr stream by default — only stdout is redirected to file. A seid panic remains visible in `kubectl logs`.
+`backoffLimit: 0`, `restartPolicy: Never`. No `seictl-copy` init container, no `emptyDir` volume — the export Job's footprint matches the bootstrap Job's exactly.
 
-The shared helpers between bootstrap and export Jobs (nodepool selection, tolerations, Karpenter `do-not-disrupt` annotation, common pod labels) live as standalone functions both builders call.
+The seid container's args is a bash script that runs the export and triggers the upload via the sidecar. Sketch (full implementation lives in `internal/task/export_resources.go`):
 
-### A6. `seictl upload` CLI subcommand (PR 1)
+```bash
+set -euo pipefail
 
-New top-level CLI subcommand in seictl. Reuses `seis3.UploaderFactory` and `seis3.ClassifyS3Error` from the existing snapshot-upload path. Distinct exit codes for downstream classification:
+# 1. Wait for the sidecar to come up (mirrors bootstrapWaitCommand healthz poll).
+until (exec 3<>/dev/tcp/localhost/${SIDECAR_PORT} \
+       && printf 'GET /v0/healthz HTTP/1.0\r\nHost: localhost\r\n\r\n' >&3 \
+       && head -1 <&3 | grep -q ' 200 ') 2>/dev/null; do
+    sleep 5
+done
+
+# 2. Run the export. Stderr stays on the container's stderr stream.
+seid export --home /sei --height "${EXPORT_HEIGHT}" > /sei/tmp/exported-state.json
+
+# 3. POST upload-file task to sidecar; capture task id from response.
+BODY=$(printf '{"file":"/sei/tmp/exported-state.json","bucket":"%s","key":"%s","region":"%s"}' \
+       "${GENESIS_BUCKET}" "${GENESIS_KEY}" "${GENESIS_REGION}")
+TASK_ID=$(post_task localhost ${SIDECAR_PORT} /v0/tasks/upload-file "${BODY}")
+
+# 4. Poll task status; map terminal Retryable=true → exit 11, else exit 10. Success → exit 0.
+exit "$(poll_task_until_done localhost ${SIDECAR_PORT} "${TASK_ID}")"
+```
+
+`post_task` and `poll_task_until_done` are bash functions defined inline; they speak HTTP/1.0 over `/dev/tcp` and parse JSON with `grep`/`cut` (no `jq` in the seid distroless image). Same mechanic as `bootstrapWaitCommand`. Implementation captured as a module-level constant in `export_resources.go` so unit tests can pin the exact script.
+
+The shared helpers between bootstrap and export Jobs (nodepool selection, tolerations, Karpenter `do-not-disrupt` annotation, common pod labels, PodSpec assembly) live as standalone functions both builders call.
+
+### A6. Sidecar `upload-file` HTTP task (PR 1)
+
+New sidecar HTTP task at `POST /v0/tasks/upload-file`. Body:
+
+```json
+{
+  "file":   "/sei/tmp/exported-state.json",
+  "bucket": "<bucket>",
+  "key":    "<key>",
+  "region": "<region>"
+}
+```
+
+Returns the standard sidecar task envelope: `{ "id": "<task-id>" }`. The task runs asynchronously inside the sidecar process; clients poll `GET /v0/tasks/<task-id>` for state. On terminal failure the response carries a populated `engine.TaskError` with `Retryable: bool`.
+
+Implementation reuses `seis3.UploaderFactory` and `seis3.ClassifyS3Error` — same helpers the existing `snapshot-upload` task uses. Streams the file through `transfermanager.UploadObjectInput` so multi-GB exports don't sit in memory.
+
+The seid container in the export Job consumes this task as described in §A5. Exit codes the seid container sets, derived from the polled task state:
 
 ```
-exit 0  — success
-exit 10 — terminal S3 error (4xx, NoSuchBucket, AccessDenied, etc.) — operator must fix
-exit 11 — retryable S3 error (5xx, throttling, transient network) — re-run might succeed
-exit 1  — other (file not found, args invalid, etc.)
+exit 0  — task complete (Status: complete)
+exit 10 — task failed with Retryable=false (operator must fix)
+exit 11 — task failed with Retryable=true (re-run might succeed)
+exit 1  — anything else (script-level error: file not found, sidecar unreachable, etc.)
 ```
 
-`await-export-job` on the controller side reads `pod.Status.ContainerStatuses[0].State.Terminated.ExitCode` and stamps `ForkExportComplete=False, Reason=UploadFailed (terminal|retryable)` on the SND.
+`await-export-job` on the controller side reads `pod.Status.ContainerStatuses[<seid>].State.Terminated.ExitCode` and stamps `ForkExportComplete=False, Reason=UploadFailed (terminal|retryable)` on the SND.
 
-The seictl HTTP `upload-file` task that earlier revisions proposed is **not built**. Just the CLI.
+The seictl HTTP `export-state` task that ran `exec seid` from inside the sidecar (the original bug) is deleted in PR 3.
 
 ### A7. SND status surface
 
@@ -216,13 +265,9 @@ The PVC is RWO and bound to a single AZ once the bootstrap Job's pod attaches it
 
 Documenting this as expected operational behavior. Chaining the two Jobs into one isn't viable: the bootstrap Job needs the sidecar running concurrently with seid (HTTP healthz gate before seid starts), and that's a sidecar-container pattern, not an init-container pattern. Init containers run sequentially.
 
-### A10. Init container `seictl` binary distribution (PR 2)
-
-The export Job's init container uses the seictl image (pinned by digest) with `imagePullPolicy: IfNotPresent` to copy the static binary into a shared `emptyDir`. emptyDir sized at `50Mi` (binary is ~25 MB), `medium: ""` (disk, not tmpfs — multi-GB exported-state shouldn't share tmpfs). The seictl image's pin digest comes from `platform.Config` (or hardcoded near the existing `DefaultSidecarImage` constant — same image, different consumer).
-
 ## Plan-shape diff
 
-| Before (current main) | After (Rev 3) |
+| Before (current main) | After (Rev 4) |
 |---|---|
 | `create-exporter` (creates SeiNode) | `ensure-exporter-pvc` |
 | (SeiNode init plan: PVC + bootstrap Job + StatefulSet) | `apply-bootstrap-job` |
@@ -234,43 +279,36 @@ The export Job's init container uses the seictl image (pinned by digest) with `i
 
 ## Implementation outline
 
-### PR A — `BootstrapPodInputs` refactor (standalone, ~150 LoC)
+### PR A — `BootstrapPodInputs` refactor
 
-- `internal/task/bootstrap_resources.go`:
-  - Define `BootstrapPodInputs` struct (~30 LoC).
-  - Modify all 11 helper functions to take `BootstrapPodInputs` instead of `*SeiNode` (~50 LoC of mechanical s/`node.X`/`in.X`/).
-- `internal/task/bootstrap_job.go`:
-  - Add `nodeToBootstrapInputs(node, snap, platformCfg)` adapter (~25 LoC).
-  - `Execute` calls the adapter, then `GenerateBootstrapJob(inputs)`.
-  - `assertNoSigningKeyOnBootstrapPod(node, podSpec)` runs after the builder returns — unchanged signature.
-- `internal/task/bootstrap_task_test.go`: tests keep `*SeiNode` fixtures; the call site routes through the adapter. Should require ~10 LoC of plumbing changes.
+Merged at sei-k8s-controller#173.
 
-No fork-genesis changes. No behavior change. Standalone.
+### PR 1 — Sidecar `upload-file` HTTP task (seictl, ~120 LoC + tests)
 
-### PR 1 — `seictl upload` CLI subcommand (seictl, ~80 LoC)
+- New file `seictl/sidecar/tasks/upload_file.go`:
+  - `UploadFileTask` implementing the sidecar `engine.Task` interface.
+  - Params struct: `{ File, Bucket, Key, Region string }`.
+  - Reuses `seis3.UploaderFactory` (default + injectable for tests) and `seis3.ClassifyS3Error`.
+  - Returns the standard `engine.TaskError` shape; the sidecar's HTTP layer handles the wire envelope.
+- Register the task type in `seictl/sidecar/serve.go` (or wherever the task registry lives).
+- Tests modeled on `snapshot_upload_test.go`: mock `seis3.Uploader`, table-driven over success / `AccessDenied` (terminal) / `SlowDown` (retryable) / file-not-found (non-S3 error). 100% coverage of the task's branches.
+- No CLI surface — the task is reachable only through `POST /v0/tasks/upload-file`.
 
-- New file `seictl/upload.go` (or wherever CLI subcommands live):
-  - `upload --file PATH --bucket BUCKET --key KEY --region REGION [--content-type TYPE]`
-  - Uses `seis3.UploaderFactory` + `seis3.ClassifyS3Error`.
-  - Distinct exit codes per A6.
-- New CLI test exercising each exit-code path.
-- The HTTP `upload-file` sidecar task is **not** added.
-
-### PR 2 — Fork-genesis SND-driven plan (controller, ~250 LoC net new + ~350 LoC deleted)
+### PR 2 — Fork-genesis SND-driven plan (controller, ~280 LoC net new + ~350 LoC deleted)
 
 Files added:
 - `internal/task/fork_exporter.go` — replaces `fork_export.go`. Task types and executions for `ensure-exporter-pvc`, `apply-bootstrap-job` (SND), `await-bootstrap-job` (SND, parameterized by JobName), `apply-export-job`, `await-export-job` (SND), `teardown-exporter` (SND). Helpers: `ExporterPVCName(group)`, `ExporterBootstrapJobName(group)`, `ExporterExportJobName(group)`, `ExporterServiceName(group)`.
-- `GenerateExportJob(in ExportJobInputs)` lives in this file (sibling to `GenerateBootstrapJob`).
+- `internal/task/export_resources.go` — `GenerateExportJob(ExportJobInputs, platform.Config)`. The seid container's bash script (the trigger-and-poll body) lives as a `const` here so unit tests can pin it.
 
 Files modified:
 - `internal/planner/group.go` (or wherever the fork sub-plan is generated): emit the new task list above.
 - `internal/task/registry.go`: register new task types; remove `TaskTypeCreateExporter`, `TaskTypeAwaitExporterRunning`, `TaskTypeSubmitExportState`.
+- `internal/task/bootstrap_resources.go`: optionally factor `buildSeidInitContainer` / `buildSidecarContainer` out so `GenerateBootstrapJob` and `GenerateExportJob` can both call them — only if the duplication is more than ~30 LoC. Keep both builders distinct at the top level.
 - `go.mod`: bump seictl to PR 1's release.
 - `api/v1alpha1/seinodedeployment_types.go` (or wherever `Status.Fork` lives): add `ExportArtifactURL`, `ExportedHeight`, `ExportJobRef` fields.
 
 Files deleted:
 - `internal/task/fork_export.go` (entire file — the four old task types).
-- `seictl/sidecar/tasks/export_state.go` references that become dangling — actual deletion lands in PR 3.
 
 ### PR 3 — seictl: delete `export-state` HTTP task
 
@@ -282,47 +320,52 @@ Wait until PR 2 is in a deployed controller image before merging — once PR 3 s
 
 ## Test plan
 
-Unit tests (PR A):
-- `nodeToBootstrapInputs` produces the expected struct from a representative SeiNode (table-driven over Mode).
-- Existing `bootstrap_task_test.go` cases still pass after the adapter routing.
+Unit tests (PR A — already merged):
+- `nodeToBootstrapInputs` table-driven over Mode and snapshot states.
+- `GenerateBootstrapJob` validation table.
+- `rejectForbiddenSecretMounts` negative test.
 
 Unit tests (PR 1):
-- `seictl upload` happy path.
-- Exit-code 10 on `AccessDenied`.
-- Exit-code 11 on simulated 5xx.
-- Exit-code 1 on file-not-found.
+- `UploadFileTask` happy path with mock `seis3.Uploader`.
+- `Retryable=true` path: `SlowDown` and simulated network error.
+- `Retryable=false` path: `AccessDenied`, `NoSuchBucket`.
+- File-not-found: returns non-classified error, sidecar surfaces it as terminal.
+- Param validation: missing `File`/`Bucket`/`Key`/`Region` → 400.
 
 Unit tests (PR 2):
-- `GenerateExportJob(ExportJobInputs{...})` produces correct pod spec — table-driven.
+- `GenerateExportJob(ExportJobInputs{...})` produces correct pod spec — table-driven; pin the seid bash script as a string assertion.
 - `apply-bootstrap-job` and `apply-export-job` Execute is idempotent.
-- `await-bootstrap-job` and `await-export-job` Status table cases: not-yet-succeeded → Running; succeeded → Complete; failed (with various exit codes) → Failed with stamped Reason.
+- `await-bootstrap-job` and `await-export-job` Status table cases: not-yet-succeeded → Running; succeeded → Complete; failed (with various exit codes from the seid container) → Failed with stamped Reason.
 - Planner: `buildForkPlan` for an SND with `Genesis.Fork` set emits the new task list; without it, no fork-export tasks appear.
 
 Integration smoke (post-PR-2 merge, on harbor):
 - Reconstitute the `eng-bdchatham` cell from git history. Apply. Watch the new flow run from `ensure-exporter-pvc` through `assemble-genesis-fork`. Verify `kubectl describe seinodedeployment` shows `ForkExportComplete=True` and `Status.Fork.ExportArtifactURL` populated.
+- Confirm both seid and sei-sidecar logs are reachable for the export Job.
 
 ## Execution plan
 
-| PR | Repo | Scope | Reviewers |
-|---|---|---|---|
-| **A** | sei-k8s-controller | `BootstrapPodInputs` refactor in isolation, no fork-genesis changes | k8s-spec |
-| **1** | seictl | `seictl upload` CLI subcommand additively | k8s-spec |
-| **2** | sei-k8s-controller | New SND-driven fork-genesis plan tasks. Uses `BootstrapPodInputs` directly. Adds `GenerateExportJob`. Bumps seictl module. Adds `Status.Fork.*`. Deletes `fork_export.go` + four old task types. | k8s-spec + platform-eng |
-| **3** | seictl | Delete `export-state` HTTP task | k8s-spec |
+| PR | Repo | Scope | Reviewers | Status |
+|---|---|---|---|---|
+| **A** | sei-k8s-controller | `BootstrapPodInputs` refactor | k8s-spec | merged at #173 |
+| **1** | seictl | Sidecar `upload-file` HTTP task | k8s-spec | pending |
+| **2** | sei-k8s-controller | New SND-driven fork-genesis plan tasks. Uses `BootstrapPodInputs` directly. Adds `GenerateExportJob`. Bumps seictl module. Adds `Status.Fork.*`. Deletes `fork_export.go` + four old task types. | k8s-spec + platform-eng | pending |
+| **3** | seictl | Delete `export-state` HTTP task | k8s-spec | pending |
 
-Each PR gets coral cross-review before user-tagging. PR A and PR 1 can land in parallel; PR 2 depends on both.
+Each PR gets coral cross-review before user-tagging. PR 1 and PR 2 can land in parallel, but PR 2 must bump to a seictl release that includes PR 1.
 
 ## Open questions
 
 1. **Job `activeDeadlineSeconds`**: 6h (matches the previous `exportStateTimeout`)? Per-Job differentiation (bootstrap shorter, export longer)?
-2. **`seictl upload` retry surface**: PR 1 ships single-attempt. If observed transient failures warrant it, expose an in-CLI `--retry-count` flag in a follow-up.
+2. **Sidecar task retry surface**: PR 1 ships single-attempt. If observed transient failures warrant it, expose a `MaxAttempts int` field in the task params in a follow-up.
 3. **`Status.Fork.ExportJobRef` cleanup timing**: stays referenced on the SND status after `teardown-exporter` deletes the Job — operators can still see "what Job ran the export," even though `kubectl logs` against it now 404s. Acceptable historical breadcrumb, or zero out on teardown?
+4. **Inline bash vs external trigger script**: the seid container's POST/poll body is ~30 lines of bash. Keep it inline as a `const` in `export_resources.go`, or ship a tiny `seictl/scripts/trigger-task.sh` that the seictl image already carries and the seid container shells out to via the shared `data` PVC? Inline is simpler; external is more debuggable. Default to inline; revisit if the script grows.
 
 ## References
 
 - Rev 1 (now superseded): merged at PR sei-k8s-controller#169.
-- Rev 2 (force-pushed to sei-k8s-controller#170 by this revision): the SND-driven sub-plan with sidecar-in-export-Job and a fused await-and-upload task.
-- Bootstrap-Job builder: `internal/task/bootstrap_resources.go:45-80` (`GenerateBootstrapJob`).
-- Bootstrap-Service builder: `internal/task/bootstrap_resources.go:91-109` (`GenerateBootstrapService`).
+- Rev 2 (force-pushed): the SND-driven sub-plan with sidecar-in-export-Job and a fused await-and-upload task.
+- Rev 3 (merged at PR #170): single-container export Job with `seictl-copy` init + `seictl upload` CLI.
+- Bootstrap-Job builder (post-PR-A): `internal/task/bootstrap_resources.go`. `BootstrapPodInputs`, `GenerateBootstrapJob`, `GenerateBootstrapService`, `rejectForbiddenSecretMounts`.
+- Existing snapshot-upload sidecar task (PR 1's reference implementation): `seictl/sidecar/tasks/snapshot_upload.go` + `_test.go`.
 - Existing fork-export tasks (to be deleted): `internal/task/fork_export.go`.
-- Coral round on Rev 3: kubernetes-specialist + platform-engineer aligned. Refinements folded into A4–A10 above.
+- `bootstrapWaitCommand` (the bash + `/dev/tcp` healthcheck pattern PR 2's seid container script extends): `internal/task/bootstrap_resources.go`.


### PR DESCRIPTION
## Summary

Rev 4 pivots PR 1 from a top-level `seictl upload` CLI subcommand to a sidecar HTTP task. PR A (BootstrapPodInputs refactor) is already merged at #173 and is unaffected.

**Why the pivot:** A generic file-uploader CLI is outside seictl's scope. seictl's CLI is for sei-chain-specific operations (config, genesis, patch, await, report). Generic ops (S3, files, network) belong as sidecar HTTP tasks alongside the existing `snapshot-upload` family.

## What changes vs Rev 3

- §A5 export Job pod shape — drops the `seictl-copy` initContainer + `seictl-bin` emptyDir; re-introduces a native `sei-sidecar` container.
- §A6 — replaces "seictl upload CLI subcommand" with sidecar `POST /v0/tasks/upload-file` task.
- §A10 deleted (no init-container binary distribution needed).
- `ExportJobInputs` swaps `SeictlImage` + `EmptyDirSizeLimit` for `SidecarImage` + `SidecarPort` + `SidecarResources`, matching `BootstrapPodInputs`.
- PR 1 implementation outline rewritten as a sidecar task built on the `snapshot-upload` pattern.
- PR 2 implementation outline rewritten — `GenerateExportJob` produces a three-container pod (same shape as bootstrap), seid container runs a bash script that POSTs to the sidecar and polls.

The trigger script (seid container's bash) uses the same `/dev/tcp` primitive `bootstrapWaitCommand` already uses for healthchecks. No new tooling in any image.

## Open questions captured in the doc

1. `activeDeadlineSeconds` per Job — 6h matching old `exportStateTimeout`, or differentiated?
2. Sidecar task retry surface — single-attempt now, `MaxAttempts` field later if needed?
3. `Status.Fork.ExportJobRef` cleanup timing — historical breadcrumb or zero on teardown?
4. Inline bash vs external trigger script in the seid container — default to inline; revisit if the script grows.

## Test plan

- [x] Read the Rev 3 → Rev 4 diff in this PR
- [x] Confirm the sidecar `upload-file` task shape (params + return envelope) is right
- [x] Confirm the seid-container bash trigger pattern is acceptable, vs alternatives (synchronous POST, lifecycle.preStop, two-Job sequencing)
- [x] Approve so PR 1 implementation can begin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
