### PR TITLE
fix(noderesource): DataPVCName honors spec.dataVolume.import.pvcName

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -40,6 +40,9 @@ type PlatformConfig = platform.Config
 
 // DataPVCName returns the PVC name for a node's data volume.
 func DataPVCName(node *seiv1alpha1.SeiNode) string {
+	if dv := node.Spec.DataVolume; dv != nil && dv.Import != nil && dv.Import.PVCName != "" {
+		return dv.Import.PVCName
+	}
 	return fmt.Sprintf("data-%s", node.Name)
 }
 

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -202,6 +202,24 @@ func TestNodeDataPVCClaimName_Snapshot(t *testing.T) {
 	g.Expect(DataPVCName(node)).To(Equal("data-snap-0"))
 }
 
+func TestNodeDataPVCClaimName_HonorsImport(t *testing.T) {
+	g := NewWithT(t)
+	node := newGenesisNode("mynet-0", "default")
+	node.Spec.DataVolume = &seiv1alpha1.DataVolumeSpec{
+		Import: &seiv1alpha1.DataVolumeImport{
+			PVCName: "preprovisioned-archive-0",
+		},
+	}
+	g.Expect(DataPVCName(node)).To(Equal("preprovisioned-archive-0"))
+}
+
+func TestNodeDataPVCClaimName_FallsBackWhenImportEmpty(t *testing.T) {
+	g := NewWithT(t)
+	node := newGenesisNode("mynet-0", "default")
+	node.Spec.DataVolume = &seiv1alpha1.DataVolumeSpec{}
+	g.Expect(DataPVCName(node)).To(Equal("data-mynet-0"))
+}
+
 // --- Main container ---
 
 func TestBuildNodeMainContainer_ImageAndEnv(t *testing.T) {


### PR DESCRIPTION
## Summary

The bring-your-own-volume path was half-wired. The validator correctly recognizes `spec.dataVolume.import` (setting `ImportPVCReady: True`), and the deletion path correctly skips delete for imported PVCs (`controller.go:222-227`), but the StatefulSet pod template's volume reference still hardcoded the controller-default name `data-<seinode-name>`.

Net effect: pod stuck `Pending` forever with `FailedScheduling`, because the PVC the user imported is named however the user named it (e.g., `pacific-1-archive-0`), not `data-<seinode-name>`.

## Reproduction (live, today)

Hit on prod with `pacific-1/archive-0-0`:

```
SeiNode condition:
  ImportPVCReady   True   PVCValidated
  message: PVC "pacific-1-archive-0" passes all import requirements

pod/archive-0-0-0:
  Status: Pending
  Event:  FailedScheduling
  Reason: persistentvolumeclaim "data-archive-0-0" not found
```

The PVC `pacific-1-archive-0` exists, is `Bound` to its 40 TiB gp3 volume, sized correctly. The controller validates it. But it builds a StatefulSet referencing `data-archive-0-0` (the auto-generated name) which never gets created — when import is set, `ensure_pvc.go:56` short-circuits before creating the default PVC.

## Fix

One branch in `DataPVCName`:

```go
func DataPVCName(node *seiv1alpha1.SeiNode) string {
    if dv := node.Spec.DataVolume; dv != nil && dv.Import != nil && dv.Import.PVCName != "" {
        return dv.Import.PVCName
    }
    return fmt.Sprintf("data-%s", node.Name)
}
```

Three call sites use `DataPVCName`:

1. `noderesource.go:240` (`buildNodePodSpec`'s volume claim) — **the bug**, now honors import ✓
2. `noderesource.go:187` (`GenerateDataPVC`) — never reached when import is set (`ensure_pvc.go:55-57` short-circuits)
3. `controller.go:230` (`deleteNodeDataPVC` lookup) — never reached when import is set (line 222-227 returns early)

So changing `DataPVCName` to be import-aware is safe at all call sites.

## Test plan

- [x] `TestNodeDataPVCClaimName_HonorsImport` — explicitly verifies imported name returned
- [x] `TestNodeDataPVCClaimName_FallsBackWhenImportEmpty` — verifies the fallback behavior preserved
- [x] Existing `TestNodeDataPVCClaimName_Genesis`, `_Snapshot` still pass
- [x] `GOWORK=off go test ./...` — full suite green
- [x] After merge + image build + platform bump: `archive-0-0` pod transitions Pending → Running with the imported PVC mounted