### PR TITLE
chore: bump controller image to 0b1de8e (DataPVCName honors import)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8a3084788d45178ebe436050672c138e9402da65
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:0b1de8e3b2773253c1a46fce8f95fff1c11fd5ba
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Picks up the fix from #176 so `dataVolume.import.pvcName` is actually referenced by the StatefulSet's volume mount, instead of the auto-generated `data-<seinode-name>` default that never gets created.

## Live impact

Once this lands, prod's `pacific-1/archive-0-0` pod (currently stuck Pending with `FailedScheduling: persistentvolumeclaim "data-archive-0-0" not found`) will:

1. Flux pulls the new manifest
2. Controller pods roll to the new image
3. Existing `archive-0-0` SeiNode reconciles → patches StatefulSet to reference `pacific-1-archive-0` PVC
4. Pod schedules, EBS-CSI attaches, xfs mount, seid starts

## Test plan

- [x] After Flux reconcile: `kubectl -n sei-k8s-controller-system get pod -l control-plane=controller-manager -o jsonpath='{.items[0].spec.containers[0].image}'` shows new SHA
- [x] After ~5min: `archive-0-0-0` pod transitions Pending → Running
- [x] seid logs show consensus engagement