### PR TITLE
chore(deps): bump sei-config to v0.0.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.38.2
-	github.com/sei-protocol/sei-config v0.0.12
+	github.com/sei-protocol/sei-config v0.0.13
 	github.com/sei-protocol/seictl v0.0.37
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -1591,8 +1591,8 @@ github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7 h1:k
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7/go.mod h1:R1/EoOY+MKvwH0k5ivTtG9mLYOQvm0Ni/Trjxrep3t4=
 github.com/sei-protocol/sei-config v0.0.11 h1:bq+YGCREipBlsvPLm/qY2l8qFBVJyjx/EHSYNEBzTzk=
 github.com/sei-protocol/sei-config v0.0.11/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
-github.com/sei-protocol/sei-config v0.0.12 h1:pv0IIM8c4sKPoNOvUEIx0OAp+X+coDlBibHUPbBZGxI=
-github.com/sei-protocol/sei-config v0.0.12/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/sei-config v0.0.13 h1:F3J6ZyQo/rBQVgmleOAWVugGD7x1l5VTgsNK9JmtWmk=
+github.com/sei-protocol/sei-config v0.0.13/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/sei-protocol/seictl v0.0.30 h1:Y230GU92OFlMsNUe5yUZcbvBTQaQqO+nhVgb8I4d3zY=


### PR DESCRIPTION
## Summary

Picks up sei-config v0.0.13, which adds the new `[receipt-store]` config section and archive zero-pruning defaults (sei-protocol/sei-config#11).

## What this enables

When the controller's sidecar emits app.toml for archive `SeiNode` resources, it now writes:

```toml
[receipt-store]
backend = "pebbledb"
db-directory = ""
async-write-buffer = 100
keep-recent = 0
prune-interval-seconds = 0
tx-index-backend = "pebbledb"
```

The retention semantics are documented in sei-config#11 — `min-retain-blocks=0` is the load-bearing knob on post-#3237 sei-chain; the receipt-store keys are emitted to self-document intent.

Note: this PR alone does not change runtime behavior — the controller's sidecar image pin (`internal/platform/platform.go`) still points at a pre-#3237 seictl/seid build. A subsequent sidecar bump is needed to pick up post-#3237 sei-chain semantics where `min-retain-blocks` becomes the only load-bearing knob.

## Test plan

- [x] Hand-edited go.mod / go.sum to v0.0.13 (avoiding `go mod tidy` cleanup of workspace-induced indirect deps; keeps the diff to 3 lines)
- [x] `GOWORK=off go build ./...` clean
- [x] `GOWORK=off go test ./...` clean across node, nodedeployment, noderesource, planner, task

🤖 Generated with [Claude Code](https://claude.com/claude-code)