### PR TITLE
fix(export): pass --streaming to seid export to avoid OOM on multi-GB chains

### DIFF
--- a/internal/task/export_resources.go
+++ b/internal/task/export_resources.go
@@ -300,8 +300,12 @@ until (exec 3<>/dev/tcp/localhost/${SIDECAR_PORT} \
     sleep 5
 done
 
-# Run the export. Stderr stays on the container's stderr stream.
-seid export --home /sei --height "${EXPORT_HEIGHT}" > /sei/tmp/exported-state.json
+# Run the export. --streaming writes directly to the file in chunks so the
+# seid process doesn't buffer multi-GB exports in memory (sei-chain has
+# historical OOM scars on the non-streaming path). Stderr stays on the
+# container's stderr stream.
+seid export --home /sei --height "${EXPORT_HEIGHT}" \
+    --streaming --streaming-file /sei/tmp/exported-state.json
 
 # POST upload-file task. Body is the envelope {"type","params"} the sidecar's
 # /v0/tasks handler decodes; capture task id from the response.

--- a/internal/task/export_resources_test.go
+++ b/internal/task/export_resources_test.go
@@ -138,6 +138,11 @@ func TestExportTriggerScript_PinsContract(t *testing.T) {
 		"/v0/healthz",  // health gate
 		// Wall-clock timeout on the healthz wait so /dev/tcp failure can't hang.
 		"SECONDS",
+		// --streaming avoids OOM on multi-GB exports; --streaming-file routes
+		// the JSON directly to disk instead of through stdout's in-memory
+		// buffer (sei-chain has prior genesis-export-oom history).
+		"--streaming",
+		"--streaming-file /sei/tmp/exported-state.json",
 	}
 	for _, want := range wantSubstrings {
 		if !strings.Contains(exportTriggerScript, want) {


### PR DESCRIPTION
## Summary

Small follow-up to #179. The `--streaming` flag fix was on the branch when #179 merged but didn't land in the squash-merge — re-applying as a focused PR.

`internal/task/export_resources.go::exportTriggerScript` now runs:

```bash
seid export --home /sei --height "${EXPORT_HEIGHT}" \
    --streaming --streaming-file /sei/tmp/exported-state.json
```

Drops the stdout redirect (streaming writes the file directly).

`TestExportTriggerScript_PinsContract` grows two assertions for `--streaming` and `--streaming-file <path>` so a regression that drops them fails at PR-review time.

## Why

sei-chain has historical OOM scars on the non-streaming export path (commits `42a2964c4` "Genesis Export Streaming" and `d14e2c5e2` "Merge genesis-export-oom"). Pacific-1's exported state is estimated multi-GB (full EVM storage trie + wasm contract state); without `--streaming`, seid buffers the entire JSON in memory before stdout writes it to file — likely OOMs the seid process before the file is complete.

Tracked at #182.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all green; new contract-test assertions pass)
- [x] `golangci-lint run --new-from-rev=origin/main` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
