### PR TITLE
chore: bump controller image to 374f615 (fork-genesis revert)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:0b1de8e3b2773253c1a46fce8f95fff1c11fd5ba
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:374f615451b6baea1ea7802242331f78cd3dbfc9
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Bumps the controller image from `0b1de8e` → `374f615`.

Pulls in:
- **#185** — revert fork-genesis pipeline (#169, #170, #173, #174, #179, #183) after research surfaced chain-won't-start blockers in the cosmos-sdk export/init round-trip (F1 bonded-pool retention, F2 sei-cosmos streaming exit-code).
- **#177** — expose composed endpoint URLs at `.status.endpoints`.
- **#181** — bump sei-config to v0.0.13.

ECR image was published by the post-merge ECR workflow on `374f615`.

## Test plan

- [x] Argo sync shows controller pod rolling to `374f615` tag
- [x] No spurious reconcile errors on existing SeiNode/SeiNodeDeployment resources after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)