### PR TITLE
chore(planner): default seid logging.level to error

### DIFF
--- a/internal/planner/common_overrides_test.go
+++ b/internal/planner/common_overrides_test.go
@@ -23,6 +23,9 @@ func TestCommonOverrides_WithExternalAddress(t *testing.T) {
 	if got := overrides[seiconfig.KeyP2PExternalAddress]; got != "p2p.atlantic-2.seinetwork.io:26656" {
 		t.Errorf("p2p.external_address = %q, want %q", got, "p2p.atlantic-2.seinetwork.io:26656")
 	}
+	if got := overrides["logging.level"]; got != "error" {
+		t.Errorf("logging.level = %q, want %q", got, "error")
+	}
 }
 
 func TestCommonOverrides_EmptyExternalAddress(t *testing.T) {
@@ -30,8 +33,11 @@ func TestCommonOverrides_EmptyExternalAddress(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
 	}
 	overrides := commonOverrides(node)
-	if overrides != nil {
-		t.Errorf("expected nil overrides, got %v", overrides)
+	if got := overrides["logging.level"]; got != "error" {
+		t.Errorf("logging.level = %q, want %q", got, "error")
+	}
+	if _, ok := overrides[seiconfig.KeyP2PExternalAddress]; ok {
+		t.Errorf("expected no p2p.external_address, got %q", overrides[seiconfig.KeyP2PExternalAddress])
 	}
 }
 

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -634,15 +634,17 @@ func configureStateSyncParams(snap *seiv1alpha1.SnapshotSource) *task.ConfigureS
 	return p
 }
 
-// commonOverrides returns controller overrides derived from node status
-// that apply to all node modes (e.g., external P2P address from the LB).
+// commonOverrides returns controller overrides that apply to all node modes.
+// sei-config defaults logging.level to "info"; we baseline it to "error" here.
+// spec.Overrides still wins via mergeOverrides for per-node verbosity.
 func commonOverrides(node *seiv1alpha1.SeiNode) map[string]string {
-	if node.Status.ExternalAddress == "" {
-		return nil
+	out := map[string]string{
+		"logging.level": "error",
 	}
-	return map[string]string{
-		seiconfig.KeyP2PExternalAddress: node.Status.ExternalAddress,
+	if node.Status.ExternalAddress != "" {
+		out[seiconfig.KeyP2PExternalAddress] = node.Status.ExternalAddress
 	}
+	return out
 }
 
 // buildRunningPlan returns a steady-state drift plan, or nil if no drift.


### PR DESCRIPTION
## Summary

Adds `logging.level: error` as a controller-baked default override in `commonOverrides` so all SeiNode modes start quiet. sei-config currently defaults `logging.level` to `info` (`sei-config/defaults.go:208`); without this change, every fleet node ships INFO-level seid logs which are noisy and dominated by routine consensus messages.

## Coverage

`commonOverrides` is the shared base layer for every node mode — confirmed call sites:

- `internal/planner/archive.go:34`
- `internal/planner/bootstrap.go:163`
- `internal/planner/full.go:39`
- `internal/planner/replay.go:43`
- `internal/planner/validator.go:69`

All five flow through the same `mergeOverrides(commonOverrides(node), …, node.Spec.Overrides)` chain, so per-node `spec.Overrides[\"logging.level\"]` still wins for nodes that need debug/info — typically a single node during incident response.

## Behavior change

Before: seid runs at sei-config default INFO unless the user sets `spec.Overrides[\"logging.level\"]`.
After: seid runs at ERROR unless the user sets `spec.Overrides[\"logging.level\"]`.

No CRD change. No restart needed for new nodes; existing nodes pick up the override on the next config-apply task (next reconcile that touches config).

## Out of scope

- Runtime log-level toggling without a config-apply (would require a sidecar admin-gRPC client targeting seid's `127.0.0.1:9095`; researched separately, deferred).
- sei-config field metadata says `logging.level` is hot-reloadable, but seilog has no signal handler — runtime reload happens via seid's admin gRPC, not file re-read. New nodes will pick this up on first start.

## Test plan

- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go test ./...` — all packages green
- [x] Updated `common_overrides_test.go` to assert `logging.level=error` in both LB-set and no-LB cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)