### PR TITLE
chore: bump controller image to d5eff51 (default logging.level=error)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:374f615451b6baea1ea7802242331f78cd3dbfc9
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:d5eff517e2da11aa1323ee4695f13e927b67ef1a
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Bumps the controller image from `374f615` → `d5eff51`.

Pulls in:
- **#187** — `commonOverrides` baselines seid `logging.level` to `error` for all five node modes (archive, bootstrap, full, replay, validator). Per-node `spec.Overrides` still wins.

ECR image was published by the post-merge ECR workflow on `d5eff51`.

## Test plan

- [x] Argo sync rolls controller pod to `d5eff51`
- [x] New SeiNode reconciles emit `logging.level: error` in their config-apply override map
- [x] Existing nodes pick up the override on next config-apply (next reconcile that touches config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)