### PR TITLE
chore: bump controller image to c1d5fba (drop fork-genesis surface)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:d5eff517e2da11aa1323ee4695f13e927b67ef1a
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:c1d5fbaa83598fb752bda77bf18d77ba85d7f867
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Pulls in #189 — drops the reverted fork-genesis pipeline (CRD `Genesis.Fork` field, `ForkConfig` type, `ConditionForkGenesisCeremonyNeeded`, 4 controller-internal export tasks, planner dispatch) and bumps seictl to `v0.0.44` (which removes the seictl-side `AssembleGenesisForkTask`).

`d5eff51 → c1d5fba`

## Test plan

- [x] One-line edit to `config/manager/manager.yaml`
- [x] Image SHA matches PR #189 merge commit (`c1d5fbaa83598fb752bda77bf18d77ba85d7f867`)
- [x] ECR build job for the merge commit completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)