### PR TITLE
chore: drop dead exporter-role filters; add detectGenesisCeremonyNeeded test

### DIFF
--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -126,7 +126,7 @@ func (r *SeiNodeDeploymentReconciler) detectDeploymentNeeded(group *seiv1alpha1.
 }
 
 // populateIncumbentNodes lists child SeiNodes and records their names
-// on the group status. Exporter nodes are excluded.
+// on the group status.
 func (r *SeiNodeDeploymentReconciler) populateIncumbentNodes(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
 	nodes, err := r.listChildSeiNodes(ctx, group)
 	if err != nil {
@@ -134,9 +134,6 @@ func (r *SeiNodeDeploymentReconciler) populateIncumbentNodes(ctx context.Context
 	}
 	names := make([]string, 0, len(nodes))
 	for i := range nodes {
-		if nodes[i].Labels["sei.io/role"] == "exporter" {
-			continue
-		}
 		names = append(names, nodes[i].Name)
 	}
 	group.Status.IncumbentNodes = names

--- a/internal/controller/nodedeployment/nodes_test.go
+++ b/internal/controller/nodedeployment/nodes_test.go
@@ -293,3 +293,58 @@ func TestGenerateSeiNode_DeepCopiesTemplate(t *testing.T) {
 	g.Expect(group.Spec.Template.Spec.Overrides).NotTo(HaveKey("modified"),
 		"modification to generated SeiNode should not mutate the group template")
 }
+
+func TestDetectGenesisCeremonyNeeded(t *testing.T) {
+	cases := []struct {
+		name        string
+		mutate      func(*seiv1alpha1.SeiNodeDeployment)
+		wantPresent bool
+		wantStatus  metav1.ConditionStatus
+	}{
+		{
+			name:        "no genesis spec clears condition",
+			mutate:      func(g *seiv1alpha1.SeiNodeDeployment) { g.Spec.Genesis = nil },
+			wantPresent: false,
+		},
+		{
+			name: "ceremony complete clears condition",
+			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
+				setCondition(g, seiv1alpha1.ConditionGenesisCeremonyComplete, metav1.ConditionTrue, "Done", "")
+				setCondition(g, seiv1alpha1.ConditionGenesisCeremonyNeeded, metav1.ConditionTrue, "Stale", "")
+			},
+			wantPresent: false,
+		},
+		{
+			name: "plan in progress leaves condition untouched",
+			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
+				setCondition(g, seiv1alpha1.ConditionPlanInProgress, metav1.ConditionTrue, "Running", "")
+			},
+			wantPresent: false,
+		},
+		{
+			name:        "genesis configured sets condition true",
+			mutate:      func(g *seiv1alpha1.SeiNodeDeployment) {},
+			wantPresent: true,
+			wantStatus:  metav1.ConditionTrue,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			group := newTestGroup("archive-rpc", "sei")
+			group.Spec.Genesis = &seiv1alpha1.GenesisCeremonyConfig{ChainID: "pacific-1"}
+			tc.mutate(group)
+
+			r := &SeiNodeDeploymentReconciler{Recorder: record.NewFakeRecorder(10)}
+			r.detectGenesisCeremonyNeeded(group)
+
+			cond := apimeta.FindStatusCondition(group.Status.Conditions, seiv1alpha1.ConditionGenesisCeremonyNeeded)
+			if !tc.wantPresent {
+				g.Expect(cond).To(BeNil())
+				return
+			}
+			g.Expect(cond).NotTo(BeNil())
+			g.Expect(cond.Status).To(Equal(tc.wantStatus))
+		})
+	}
+}

--- a/internal/controller/nodedeployment/per_pod_services.go
+++ b/internal/controller/nodedeployment/per_pod_services.go
@@ -12,8 +12,7 @@ import (
 )
 
 // populatePerPodServices builds the PerPodServices status from child SeiNodes,
-// sorted by ordinal. Excludes exporter-role children. Returns nil when empty
-// so omitempty drops the field.
+// sorted by ordinal. Returns nil when empty so omitempty drops the field.
 func populatePerPodServices(log logr.Logger, nodes []seiv1alpha1.SeiNode) []seiv1alpha1.PerPodServiceStatus {
 	type entry struct {
 		status  seiv1alpha1.PerPodServiceStatus
@@ -22,9 +21,6 @@ func populatePerPodServices(log logr.Logger, nodes []seiv1alpha1.SeiNode) []seiv
 	entries := make([]entry, 0, len(nodes))
 	for i := range nodes {
 		node := &nodes[i]
-		if node.Labels["sei.io/role"] == "exporter" {
-			continue
-		}
 		ordStr, ok := node.Labels[groupOrdinalLabel]
 		if !ok {
 			log.V(1).Info("per-pod service: skipping node missing ordinal label", "node", node.Name)

--- a/internal/controller/nodedeployment/per_pod_services_test.go
+++ b/internal/controller/nodedeployment/per_pod_services_test.go
@@ -1,7 +1,6 @@
 package nodedeployment
 
 import (
-	"maps"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -12,17 +11,15 @@ import (
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
 
-func nodeWithOrdinal(name, ordinal string, extraLabels map[string]string) seiv1alpha1.SeiNode {
-	labels := map[string]string{
-		groupLabel:        "pacific-1-wave",
-		groupOrdinalLabel: ordinal,
-	}
-	maps.Copy(labels, extraLabels)
+func nodeWithOrdinal(name, ordinal string) seiv1alpha1.SeiNode {
 	return seiv1alpha1.SeiNode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "pacific-1",
-			Labels:    labels,
+			Labels: map[string]string{
+				groupLabel:        "pacific-1-wave",
+				groupOrdinalLabel: ordinal,
+			},
 		},
 	}
 }
@@ -37,9 +34,9 @@ func TestPopulatePerPodServices_AllHealthySorted(t *testing.T) {
 	g := NewWithT(t)
 	// Out-of-order on purpose; helper must sort by ordinal.
 	nodes := []seiv1alpha1.SeiNode{
-		nodeWithOrdinal("pacific-1-wave-2", "2", nil),
-		nodeWithOrdinal("pacific-1-wave-0", "0", nil),
-		nodeWithOrdinal("pacific-1-wave-1", "1", nil),
+		nodeWithOrdinal("pacific-1-wave-2", "2"),
+		nodeWithOrdinal("pacific-1-wave-0", "0"),
+		nodeWithOrdinal("pacific-1-wave-1", "1"),
 	}
 
 	got := populatePerPodServices(logr.Discard(), nodes)
@@ -60,9 +57,9 @@ func TestPopulatePerPodServices_OrdinalGapAfterScaleDown(t *testing.T) {
 	// Post-scale-down: ordinals 0, 2, 5 — non-contiguous but each entry
 	// must still appear in sorted order.
 	nodes := []seiv1alpha1.SeiNode{
-		nodeWithOrdinal("pacific-1-wave-5", "5", nil),
-		nodeWithOrdinal("pacific-1-wave-0", "0", nil),
-		nodeWithOrdinal("pacific-1-wave-2", "2", nil),
+		nodeWithOrdinal("pacific-1-wave-5", "5"),
+		nodeWithOrdinal("pacific-1-wave-0", "0"),
+		nodeWithOrdinal("pacific-1-wave-2", "2"),
 	}
 
 	got := populatePerPodServices(logr.Discard(), nodes)
@@ -71,21 +68,6 @@ func TestPopulatePerPodServices_OrdinalGapAfterScaleDown(t *testing.T) {
 	g.Expect(got[0].Name).To(Equal("pacific-1-wave-0"))
 	g.Expect(got[1].Name).To(Equal("pacific-1-wave-2"))
 	g.Expect(got[2].Name).To(Equal("pacific-1-wave-5"))
-}
-
-func TestPopulatePerPodServices_ExporterExcluded(t *testing.T) {
-	g := NewWithT(t)
-	nodes := []seiv1alpha1.SeiNode{
-		nodeWithOrdinal("pacific-1-wave-0", "0", nil),
-		nodeWithOrdinal("pacific-1-wave-1", "1", map[string]string{"sei.io/role": "exporter"}),
-		nodeWithOrdinal("pacific-1-wave-2", "2", nil),
-	}
-
-	got := populatePerPodServices(logr.Discard(), nodes)
-
-	g.Expect(got).To(HaveLen(2))
-	g.Expect(got[0].Name).To(Equal("pacific-1-wave-0"))
-	g.Expect(got[1].Name).To(Equal("pacific-1-wave-2"))
 }
 
 func TestPopulatePerPodServices_MissingOrdinalLabelSkipped(t *testing.T) {
@@ -98,7 +80,7 @@ func TestPopulatePerPodServices_MissingOrdinalLabelSkipped(t *testing.T) {
 		},
 	}
 	nodes := []seiv1alpha1.SeiNode{
-		nodeWithOrdinal("pacific-1-wave-0", "0", nil),
+		nodeWithOrdinal("pacific-1-wave-0", "0"),
 		noOrdinal,
 	}
 
@@ -110,9 +92,9 @@ func TestPopulatePerPodServices_MissingOrdinalLabelSkipped(t *testing.T) {
 
 func TestPopulatePerPodServices_UnparseableOrdinalSkipped(t *testing.T) {
 	g := NewWithT(t)
-	bad := nodeWithOrdinal("pacific-1-wave-junk", "not-a-number", nil)
+	bad := nodeWithOrdinal("pacific-1-wave-junk", "not-a-number")
 	nodes := []seiv1alpha1.SeiNode{
-		nodeWithOrdinal("pacific-1-wave-0", "0", nil),
+		nodeWithOrdinal("pacific-1-wave-0", "0"),
 		bad,
 	}
 

--- a/internal/controller/nodedeployment/per_pod_services_test.go
+++ b/internal/controller/nodedeployment/per_pod_services_test.go
@@ -11,13 +11,15 @@ import (
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
 
+const testGroupLabelValue = "pacific-1-wave"
+
 func nodeWithOrdinal(name, ordinal string) seiv1alpha1.SeiNode {
 	return seiv1alpha1.SeiNode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "pacific-1",
 			Labels: map[string]string{
-				groupLabel:        "pacific-1-wave",
+				groupLabel:        testGroupLabelValue,
 				groupOrdinalLabel: ordinal,
 			},
 		},


### PR DESCRIPTION
## Summary

Two follow-ups from cross-review of #189 (drop reverted fork-genesis surface):

### 1. Drop dead exporter-role plumbing

With `Genesis.Fork` and `TaskTypeCreateExporter` removed in #189, no controller code path can produce a `SeiNode` labeled `sei.io/role: exporter` anymore. The two filter sites that skipped such children were permanently unreachable.

- `internal/controller/nodedeployment/nodes.go:128-144` — removed exporter-role skip in `populateIncumbentNodes`
- `internal/controller/nodedeployment/per_pod_services.go:14-26` — removed exporter-role skip in `populatePerPodServices`
- `internal/controller/nodedeployment/per_pod_services_test.go:76-89` — removed `TestPopulatePerPodServices_ExporterExcluded`; simplified `nodeWithOrdinal` helper (dropped `extraLabels` param now that no caller passed non-nil) — fixes a `unparam` lint hit

### 2. Add `detectGenesisCeremonyNeeded` table test

The function was only exercised indirectly via `TestBuildGroupAssemblyPlan`. Added a focused table test covering all four branches:
- no `Genesis` spec → condition cleared
- `GenesisCeremonyComplete` true → condition cleared
- `PlanInProgress` true → condition untouched
- otherwise → condition set true

Guards against silent reintroduction of fork-branch logic in this function.

## Verification

- [x] `GOWORK=off go build ./...` clean
- [x] `GOWORK=off go test ./...` — all packages pass
- [x] `make lint` — zero new issues from this change (pre-existing goconst/modernize debt unchanged; tracked separately in #163)

## Net

`+71 / -41` across 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)