### PR TITLE
chore: bump controller image to 238f7b1 (drop taskParamser interface)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:c1d5fbaa83598fb752bda77bf18d77ba85d7f867
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:238f7b1df94f295c8b6c77a2e624ecf38e684b84
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Pulls in #192 — drops the controller's local `taskParamser` interface and 14 `*Params` shells; the executor now uses `client.TaskBuilder` (the seictl interface) directly. ConfigApply uses an unexported `configApplyTask` that anonymously embeds `seiconfig.ConfigIntent` for storage-shape stability. Bumps seictl to v0.0.45.

`c1d5fba → 238f7b1`

## Test plan

- [x] One-line edit to `config/manager/manager.yaml`
- [x] Image SHA matches PR #192 merge commit (`238f7b1df94f295c8b6c77a2e624ecf38e684b84`)
- [x] ECR build job for the merge commit completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)