### PR TITLE
chore(deps): bump seictl to v0.0.46

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.38.2
 	github.com/sei-protocol/sei-config v0.0.13
-	github.com/sei-protocol/seictl v0.0.45
+	github.com/sei-protocol/seictl v0.0.46
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.65.0

--- a/go.sum
+++ b/go.sum
@@ -1603,6 +1603,8 @@ github.com/sei-protocol/seictl v0.0.44 h1:lGkuf5PWTVuNIGHaSyP7vvEU/cc/QaFf2XiKZY
 github.com/sei-protocol/seictl v0.0.44/go.mod h1:gB4lhqGKGYLiDgMwN4TOGLD4Mo3k8UxlcjdXZ9Osp88=
 github.com/sei-protocol/seictl v0.0.45 h1:KGMheRzRdbPj/tJJ4PDXyzjExBdY6o6CvJfroZtrcFA=
 github.com/sei-protocol/seictl v0.0.45/go.mod h1:gB4lhqGKGYLiDgMwN4TOGLD4Mo3k8UxlcjdXZ9Osp88=
+github.com/sei-protocol/seictl v0.0.46 h1:oRclug/a5M2tL/5rQyJA3Vyn/sGgFNfAWjmdEilefas=
+github.com/sei-protocol/seictl v0.0.46/go.mod h1:gB4lhqGKGYLiDgMwN4TOGLD4Mo3k8UxlcjdXZ9Osp88=
 github.com/sei-protocol/seilog v0.0.3 h1:Zi7oWXdX5jv92dY8n482xH032LtNebC89Y+qYZlBn0Y=
 github.com/sei-protocol/seilog v0.0.3/go.mod h1:CKg58wraWnB3gRxWQ0v1rIVr0gmDHjkfP1bM2giKFFU=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=


### PR DESCRIPTION
## Summary

Picks up seictl#153 — drops the unused `TaskMeta` + `applyMeta` from `client.*Task` wrappers.

`v0.0.45 → v0.0.46`

## Side benefit

`PlannedTask.Params.Raw` bytes shed the `"ID":null` suffix that came from json-marshaling the empty `TaskMeta` embed. Cosmetic-only — operators reading `kubectl get snd -o yaml` see slightly cleaner persisted task bytes.

## No controller code changes

`TaskMeta` had **zero references** in this repo. Since #192's executor refactor, the controller sets `TaskRequest.Id` directly post-`ToTaskRequest()`, never touching `TaskMeta.ID`. The seictl deletion ripples through cleanly via the `go.mod` bump.

## Mid-rollover safety

Pre-existing CRD `Params.Raw` bytes contain `"ID":null` (from prior versions of this controller persisting `client.*Task` with the empty embed). Post-upgrade controllers reading those bytes deserialize them into TaskMeta-less structs — Go's `json.Unmarshal` silently drops unknown keys. Safe.

## Verification

- [x] `GOWORK=off go get github.com/sei-protocol/seictl@v0.0.46` — clean 3-line diff (no `go mod tidy` workspace-induced churn)
- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./...` — all packages pass (node, nodedeployment, noderesource, planner, task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)