### PR TITLE
chore: bump controller image to 879015a (drop TaskMeta from client)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:238f7b1df94f295c8b6c77a2e624ecf38e684b84
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:879015a5180654c1b71b2d539cebe50bf20caac7
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Pulls in #195 — bumps seictl to v0.0.46, which dropped the unused `TaskMeta` + `applyMeta` from `client.*Task` wrappers. Side benefit: `PlannedTask.Params.Raw` bytes shed the `"ID":null` suffix that came from json-marshaling the empty embed.

`238f7b1 → 879015a`

## Test plan

- [x] One-line edit to `config/manager/manager.yaml`
- [x] Image SHA matches PR #195 merge commit (`879015a5180654c1b71b2d539cebe50bf20caac7`)
- [x] ECR build job for the merge commit completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)