### PR TITLE
refactor(task): invoke Validate() in executor before submit

### DIFF
--- a/internal/planner/executor_test.go
+++ b/internal/planner/executor_test.go
@@ -286,7 +286,11 @@ func TestExecuteGroupPlan_CompletesSuccessfully(t *testing.T) {
 	for i := range nodes {
 		nodes[i] = sidecar.GenesisNodeParam{Name: fmt.Sprintf("node-%d", i)}
 	}
-	assembleParams, _ := json.Marshal(sidecar.AssembleAndUploadGenesisTask{Nodes: nodes})
+	assembleParams, _ := json.Marshal(sidecar.AssembleAndUploadGenesisTask{
+		AccountBalance: "1000usei",
+		Namespace:      "default",
+		Nodes:          nodes,
+	})
 
 	group.Status.Plan = &seiv1alpha1.TaskPlan{
 		ID:    planID,

--- a/internal/task/sidecar.go
+++ b/internal/task/sidecar.go
@@ -48,6 +48,14 @@ func (e *sidecarExecution[T]) Execute(ctx context.Context) error {
 		return fmt.Errorf("invalid task UUID %q: %w", e.id, parseErr)
 	}
 
+	// Validate before submit so malformed params surface as a terminal task
+	// failure with a structured error, not a sidecar HTTP 400.
+	if err := e.params.Validate(); err != nil {
+		e.status = ExecutionFailed
+		e.err = fmt.Errorf("validating %s: %w", e.params.TaskType(), err)
+		return e.err
+	}
+
 	// Override Id at the TaskRequest layer rather than on the wrapper's
 	// embedded TaskMeta — keeps the executor decoupled from wrapper internals.
 	req := e.params.ToTaskRequest()

--- a/internal/task/sidecar.go
+++ b/internal/task/sidecar.go
@@ -56,8 +56,6 @@ func (e *sidecarExecution[T]) Execute(ctx context.Context) error {
 		return e.err
 	}
 
-	// Override Id at the TaskRequest layer rather than on the wrapper's
-	// embedded TaskMeta — keeps the executor decoupled from wrapper internals.
 	req := e.params.ToTaskRequest()
 	req.Id = &taskID
 


### PR DESCRIPTION
## Summary

Adds `e.params.Validate()` to `sidecarExecution[T].Execute()` before the `ToTaskRequest()`/`SubmitTask` path. Catches malformed task params at executor-time as a structured terminal failure instead of as an opaque sidecar HTTP 400.

Closes the platform-engineer's deferred opportunity flagged in the cross-review of #192 ("Validate() is now defined on every wrapper but invoked nowhere in the executor path").

## What it actually catches

For most task types `Validate()` returns nil (empty struct or trivial validation), so this is a no-op in practice. The two strict paths are:

- **`sidecar.AssembleAndUploadGenesisTask.Validate()`** — required-field + bech32 checks. **Already invoked at planner-time** at `group.go:45`, so this catch is defense-in-depth.
- **`configApplyTask.Validate()`** — delegates to seictl `ConfigApplyTask.Validate()`, which calls `seiconfig.ValidateIntent`. The planner doesn't currently call this; the executor now does.

## Drive-by cleanups

- **Drop a stale comment** in `sidecar.go` about overriding Id "rather than on the wrapper's embedded TaskMeta" — TaskMeta no longer exists (removed in seictl#153, consumed in #195). The comment was rot from #192.
- **Fix `TestExecuteGroupPlan_CompletesSuccessfully` fixture** — it built an `AssembleAndUploadGenesisTask` with only `Nodes` (missing required `AccountBalance` and `Namespace`). It passed before only because `Validate()` wasn't invoked; now we populate the required fields, which is the correct test intent for a happy-path submission test.

## Verification

- [x] `GOWORK=off go build ./...` clean
- [x] `GOWORK=off go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)