### PR TITLE
chore(deps): bump seictl to v0.0.47

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.38.2
 	github.com/sei-protocol/sei-config v0.0.13
-	github.com/sei-protocol/seictl v0.0.46
+	github.com/sei-protocol/seictl v0.0.47
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.65.0

--- a/go.sum
+++ b/go.sum
@@ -1605,6 +1605,8 @@ github.com/sei-protocol/seictl v0.0.45 h1:KGMheRzRdbPj/tJJ4PDXyzjExBdY6o6CvJfroZ
 github.com/sei-protocol/seictl v0.0.45/go.mod h1:gB4lhqGKGYLiDgMwN4TOGLD4Mo3k8UxlcjdXZ9Osp88=
 github.com/sei-protocol/seictl v0.0.46 h1:oRclug/a5M2tL/5rQyJA3Vyn/sGgFNfAWjmdEilefas=
 github.com/sei-protocol/seictl v0.0.46/go.mod h1:gB4lhqGKGYLiDgMwN4TOGLD4Mo3k8UxlcjdXZ9Osp88=
+github.com/sei-protocol/seictl v0.0.47 h1:crV++ft3/i3VVZ5ITyh5rZmQyQCos7t9g7FMGz4gb5s=
+github.com/sei-protocol/seictl v0.0.47/go.mod h1:9XV8yQC3/NxHw4WZodyyrkE3lhZ7QyZ8p838hYYXERU=
 github.com/sei-protocol/seilog v0.0.3 h1:Zi7oWXdX5jv92dY8n482xH032LtNebC89Y+qYZlBn0Y=
 github.com/sei-protocol/seilog v0.0.3/go.mod h1:CKg58wraWnB3gRxWQ0v1rIVr0gmDHjkfP1bM2giKFFU=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=


### PR DESCRIPTION
## Summary

Picks up seictl#156 — adds json tags to `client.PeerSource`.

`v0.0.46 → v0.0.47`

## Effect on this repo

`PlannedTask.Params.Raw` bytes for `discover-peers` tasks shift from PascalCase (`Type`/`Region`/`Tags`/`Addresses`/`Endpoints`) back to camelCase (`type`/`region`/`tags`/...) and drop omitempty-eligible fields. Restores the shape operators saw pre-#192.

## No code changes

Controller never references `PeerSource` fields by struct-tag-sensitive json paths. Tests unmarshal into typed structs which work case-insensitively.

## Mid-rollover safety

Pre-existing PascalCase `Params.Raw` bytes deserialize cleanly into the now-tagged struct via Go's case-insensitive json unmarshal — when no exact tag match is found, `encoding/json` falls back to case-insensitive comparison against the tag.

## Verification

- [x] `GOWORK=off go get github.com/sei-protocol/seictl@v0.0.47` — clean 3-line diff
- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)