### PR TITLE
feat(noderesource): set SELinuxChangePolicy=MountOption on SeiNode pods

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -274,11 +274,7 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) corev1.PodSpe
 		},
 		Volumes: volumes,
 		SecurityContext: &corev1.PodSecurityContext{
-			// Apply SELinux labels via mount option (constant time) instead of
-			// the default recursive xattr walk, which takes ~20 minutes on the
-			// 40 TiB archive PVC and stalls every pod recreation. Requires K8s
-			// 1.33+ (SELinuxMount GA) and a CSI driver that supports it; EBS
-			// CSI v1.30+ does.
+			// Avoids recursive setxattr walk on the data PVC at pod start.
 			SELinuxChangePolicy: ptr.To(corev1.SELinuxChangePolicyMountOption),
 		},
 	}

--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -273,6 +273,14 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) corev1.PodSpe
 			},
 		},
 		Volumes: volumes,
+		SecurityContext: &corev1.PodSecurityContext{
+			// Apply SELinux labels via mount option (constant time) instead of
+			// the default recursive xattr walk, which takes ~20 minutes on the
+			// 40 TiB archive PVC and stalls every pod recreation. Requires K8s
+			// 1.33+ (SELinuxMount GA) and a CSI driver that supports it; EBS
+			// CSI v1.30+ does.
+			SELinuxChangePolicy: ptr.To(corev1.SELinuxChangePolicyMountOption),
+		},
 	}
 
 	spec.ShareProcessNamespace = ptr.To(true)

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -188,6 +188,21 @@ func TestBuildNodePodSpec_SharedPIDNamespace(t *testing.T) {
 	g.Expect(*sts.Spec.Template.Spec.ShareProcessNamespace).To(BeTrue())
 }
 
+// SELinuxChangePolicy=MountOption avoids the per-pod-recreation recursive
+// xattr walk over the data PVC. On a multi-TB archive PVC, that walk takes
+// ~20 minutes; with MountOption the kernel applies the SELinux context as
+// a per-mount overlay in milliseconds.
+func TestBuildNodePodSpec_SELinuxChangePolicyMountOption(t *testing.T) {
+	g := NewWithT(t)
+	node := newSnapshotNode("snap-0", "default")
+
+	spec := buildNodePodSpec(node, platformtest.Config())
+
+	g.Expect(spec.SecurityContext).NotTo(BeNil())
+	g.Expect(spec.SecurityContext.SELinuxChangePolicy).NotTo(BeNil())
+	g.Expect(*spec.SecurityContext.SELinuxChangePolicy).To(Equal(corev1.SELinuxChangePolicyMountOption))
+}
+
 // --- PVC ---
 
 func TestNodeDataPVCClaimName_Genesis(t *testing.T) {


### PR DESCRIPTION
## Summary

Set `pod.spec.securityContext.SELinuxChangePolicy = MountOption` on every pod the SeiNode controller builds.

Without this, on SELinux-enforcing nodes (Bottlerocket on EKS), the kubelet does a recursive `setxattr` walk over the entire data PVC on pod start to apply the per-pod MCS label. On the pacific-1 archive's 40 TiB / 8.2M-file xfs volume that walk took ~20 minutes — pod stuck in `Init:0/2 PodInitializing`, with `CreateContainerError "name reservation"` symptoms downstream.

With `MountOption`, the kernel applies the SELinux context as a per-mount overlay in milliseconds. Feature is GA in K8s 1.33+ (`SELinuxMount` feature gate).

## Test plan

- [x] `go test ./internal/noderesource/...` passes
- [ ] CI lint + test green
- [ ] Verified on next archive pod recreate (boot time should drop from ~22 min to <1 min for the volume-relabel phase)
