### PR TITLE
chore(platform): bump DefaultSidecarImage to seictl built against sei-config v0.0.14

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -5,7 +5,7 @@ import "fmt"
 const (
 	// DefaultSidecarImage is the seictl sidecar image used when not overridden
 	// by the SeiNode spec. Shared between the node controller and bootstrap task.
-	DefaultSidecarImage = "ghcr.io/sei-protocol/seictl@sha256:d3ecb1a0d0f76366e468a7f771932690562238a3c45475b3353af422327eda65"
+	DefaultSidecarImage = "ghcr.io/sei-protocol/seictl@sha256:a2af4e1b8ed4c12661a3c98cce050bae3f292cc7560abc2ba98fd7dfc80d9be5"
 
 	// DataDir is the mount path for the sei data volume inside node pods.
 	DataDir = "/sei"


### PR DESCRIPTION
## Summary

The current `DefaultSidecarImage` (`d3ecb1a0d0f76366`) is built against `sei-config v0.0.13`. Its `BuildRegistry()` doesn't include the `EVM.EnabledLegacySeiApis` field added in `sei-config v0.0.14`, so any SND with `spec.template.spec.overrides["evm.enabled_legacy_sei_apis"]` hits `"unknown override key"` in the sidecar's `ApplyOverrides` (at `sei-config/io.go:79-80`) and the `configure-genesis` task fails.

Bumping to `a2af4e1b8ed4` — built today from `seictl v0.0.49` (commit `fb39223e5682`) against `sei-config v0.0.14`.

## Empirical verification

Extracted both binaries and inspected vendored sei-config + registered field:

```
Old (d3ecb1a0d0f76366):
  /go/pkg/mod/github.com/sei-protocol/sei-config@v0.0.13
  enabled_legacy_sei_apis: 0 occurrences

New (a2af4e1b8ed4):
  /go/pkg/mod/github.com/sei-protocol/sei-config@v0.0.14
  enabled_legacy_sei_apis: 3 occurrences (field name + toml tag + registry key path)
```

## Why this matters

Unblocks the harbor `nightly` release-test orchestrator's `seictl nd apply --override evm.enabled_legacy_sei_apis=sei_getLogs,sei_getBlockByNumber,sei_getBlockByHash` line. Without this bump, the orchestrator-side seictl can write the override into the SND's overrides map (it knows the field at v0.0.14), but the in-pod sidecar can't apply it (it doesn't know the field at v0.0.13). Bumping the default sidecar aligns both ends of the override pipeline at sei-config v0.0.14.

After this lands, the override will succeed end-to-end and the qa harness's ~16 `sei_*` tests will start running. From there: parity assertions can validate `sei_getLogs` matches `eth_getLogs` shape where they should agree, and the synthetic-tx coverage stays load-bearing.

## Tests

- `go build ./...` — green
- `go test ./...` — green (no test exercises the constant directly; the binary path is unchanged)

## Test plan

- [x] CI builds new controller image
- [x] Manifest update bumps the controller image in harbor / production clusters
- [x] Confirm new controller pods spawn SeiNodes with the new sidecar image
- [x] Re-add `--override evm.enabled_legacy_sei_apis=...` to the harbor nightly orchestrator (separate platform PR)
- [x] Trigger a manual release-test run; confirm sei_*-using tests no longer return `-32601 not enabled on this node`