### PR TITLE
Revert "feat(noderesource): set SELinuxChangePolicy=MountOption on SeiNode pods (#202)"

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -273,10 +273,6 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) corev1.PodSpe
 			},
 		},
 		Volumes: volumes,
-		SecurityContext: &corev1.PodSecurityContext{
-			// Avoids recursive setxattr walk on the data PVC at pod start.
-			SELinuxChangePolicy: ptr.To(corev1.SELinuxChangePolicyMountOption),
-		},
 	}
 
 	spec.ShareProcessNamespace = ptr.To(true)

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -188,21 +188,6 @@ func TestBuildNodePodSpec_SharedPIDNamespace(t *testing.T) {
 	g.Expect(*sts.Spec.Template.Spec.ShareProcessNamespace).To(BeTrue())
 }
 
-// SELinuxChangePolicy=MountOption avoids the per-pod-recreation recursive
-// xattr walk over the data PVC. On a multi-TB archive PVC, that walk takes
-// ~20 minutes; with MountOption the kernel applies the SELinux context as
-// a per-mount overlay in milliseconds.
-func TestBuildNodePodSpec_SELinuxChangePolicyMountOption(t *testing.T) {
-	g := NewWithT(t)
-	node := newSnapshotNode("snap-0", "default")
-
-	spec := buildNodePodSpec(node, platformtest.Config())
-
-	g.Expect(spec.SecurityContext).NotTo(BeNil())
-	g.Expect(spec.SecurityContext.SELinuxChangePolicy).NotTo(BeNil())
-	g.Expect(*spec.SecurityContext.SELinuxChangePolicy).To(Equal(corev1.SELinuxChangePolicyMountOption))
-}
-
 // --- PVC ---
 
 func TestNodeDataPVCClaimName_Genesis(t *testing.T) {


### PR DESCRIPTION
This reverts commit 0ba241ee1090b86faf794ce23db99142696ba21f.

## Why

Harbor's K8s API server rejects the field value:

```
StatefulSet.apps "rel-..." is invalid:
  spec.template.spec.securityContext.seLinuxChangePolicy:
  Unsupported value: "MountOption": supported values: "Recursive"
```

The original PR's documented prerequisite was K8s 1.33+ with `SELinuxMount` feature gate enabled, validated only on pacific-1 (K8s 1.34). Harbor runs an earlier version where the field exists but only `"Recursive"` is allowed. Every SeiNode StatefulSet apply on harbor fails this validation, no pods come up, every chain hangs at "wait Ready" until orchestrator timeout.

Reproduced today against harbor: validator + RPC fleet SNDs both stuck on `apply-statefulset` retry loop with the same error message on every attempt.

## What this preserves vs. reverts

- **Preserves**: #204 (`DefaultSidecarImage` bump to seictl built against sei-config v0.0.14). My change at `internal/platform/platform.go:8` is untouched.
- **Reverts**: only the `seLinuxChangePolicy: MountOption` field added to `buildNodePodSpec` and the corresponding test in `noderesource_test.go`.

## Net behavior change

Removes the field from rendered SeiNode pod specs. K8s falls back to default behavior (Recursive relabel walk). Loses the ~20-minute archive-node optimization on pacific-1 — but that optimization isn't yet active there (production controller hasn't been bumped past `786b091e`), so reverting doesn't regress anything currently running.

## Follow-up

Tracking re-introduction conditionally (opt-in via Config field, version detection, or feature-gate check) in a separate issue.

## Test plan

- [x] `go test ./...` green on the revert branch
- [x] CI builds new controller image
- [x] Bump platform's controller pin to the new image; verify SeiNode StatefulSets apply on harbor without the validation error
- [ ] Trigger nightly release-test; confirm chain bring-up reaches Ready