### PR TITLE
fix(planner): correct retry wall-clock formula + lock table contract

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -456,8 +456,9 @@ func buildPlannedTask(planID, taskType string, planIndex int, params any) (seiv1
 }
 
 // taskMaxRetries is the executor's retry budget per task type. Default 0
-// makes the first ExecutionFailed terminal. Wall-clock per N retries:
-// 5s + 10s + 20s + 30s*(N-3) for N>=3.
+// makes the first ExecutionFailed terminal. Wall-clock per N retries
+// (RetryCount is incremented before retryBackoff is called):
+// 10s for N=1; 10s + 20s + 30s*(N-2) for N>=2.
 func taskMaxRetries(taskType string) int {
 	switch taskType {
 	case TaskConfigureGenesis:

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -1,0 +1,18 @@
+package planner
+
+import "testing"
+
+func TestTaskMaxRetries(t *testing.T) {
+	cases := map[string]int{
+		TaskConfigureGenesis: genesisConfigureMaxRetries,
+		TaskAssembleGenesis:  groupAssemblyMaxRetries,
+		TaskDiscoverPeers:    discoverPeersMaxRetries,
+		"unknown-task-type":  0,
+		"":                   0,
+	}
+	for taskType, want := range cases {
+		if got := taskMaxRetries(taskType); got != want {
+			t.Errorf("taskMaxRetries(%q) = %d, want %d", taskType, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #209. Coral platform-engineer review caught two items post-merge.

## 1. Wall-clock formula in `taskMaxRetries` godoc was wrong

The executor at `internal/planner/executor.go:189-196` increments `t.RetryCount` **before** calling `retryBackoff`, so the smallest argument ever passed is 1, not 0:

```go
if t.MaxRetries > 0 && t.RetryCount < t.MaxRetries {
    t.RetryCount++  // increments to 1+ first
    ...
    return ctrl.Result{RequeueAfter: retryBackoff(t.RetryCount)}
}
```

`retryBackoff(1) = 10s`, `retryBackoff(2) = 20s`, `retryBackoff(N≥3)` caps at 30s. Real wall-clock for N retries:

```
N=1: 10s
N≥2: 10s + 20s + 30s*(N-2)
```

The prior comment claimed `5s + 10s + 20s + 30s*(N-3) for N>=3` — under-counts by one term and starts at the wrong value. Operators sizing budgets from the godoc would compute the wrong wall-clock — e.g. `discoverPeersMaxRetries=20` was documented as ~9 min but the real value is ~9.5 min.

Bigger drift on the larger budgets: `genesisConfigureMaxRetries=180` is documented in `bootstrap.go:151-153` as ~30 min but actual wall-clock is ~89.5 min. Fixing `bootstrap.go`'s comment is out of scope here (separate pre-existing bug, file as follow-up if it bites).

## 2. Lock the lookup table directly

The existing `TestArchivePlanner_WithPeers` (`archive_test.go:79-83`) catches the `MaxRetries != discoverPeersMaxRetries` regression but doesn't pin the lookup itself — a refactor that swaps `discoverPeersMaxRetries` for `genesisConfigureMaxRetries` in the switch would compile fine and the assertion would still find a non-zero value. Adding a direct table test:

```go
func TestTaskMaxRetries(t *testing.T) {
    cases := map[string]int{
        TaskConfigureGenesis: genesisConfigureMaxRetries,
        TaskAssembleGenesis:  groupAssemblyMaxRetries,
        TaskDiscoverPeers:    discoverPeersMaxRetries,
        "unknown-task-type":  0,
        "":                   0,
    }
    ...
}
```

Locks the contract. Adding a new retry-aware task type adds one switch entry + one map entry — no per-call-site test changes needed.

## Test plan

- [x] `go test ./...` green
- [x] CI builds new controller image (no behavior change in the binary, just a comment + a test)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: no runtime behavior changes, only a comment correction and a small unit test asserting the retry-budget mapping for task types.
> 
> **Overview**
> Corrects the `taskMaxRetries` godoc to reflect the executor’s actual retry/backoff sequence (since `RetryCount` is incremented before `retryBackoff` is called).
> 
> Adds `TestTaskMaxRetries` to directly assert the task-type→max-retries mapping (including unknown/empty task types returning `0`), helping prevent accidental regressions during refactors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252dc118af2c00959bb190ca5105b6a4d8215f93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->