### PR TITLE
chore: bump controller image to e99c04c (replace-pod for chain-upgrade rollouts)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:069a866160705cd957b2e37bf3f0170f7bfe1aca
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:e99c04cda4de178838ca7340a0cbe29f4a096d8e
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

- Pulls in #216 — NodeUpdate plans now include a `replace-pod` task that proactively deletes pods at the old StatefulSet revision.
- StatefulSets generated by this controller now use `OnDelete` update strategy (pod lifecycle is the SeiNode controller's responsibility, not the StatefulSet controller's).
- Unblocks the chain-upgrade rollout pattern where `seid` is intentionally unready (halted at upgrade height) and native `RollingUpdate` refuses to disturb the unready pod.

Closes #211 once this lands and rolls out.

## Rollback semantics

`OnDelete` is set in the StatefulSet spec (`internal/noderesource/`), so reverting the controller container alone won't flip the strategy back — existing StatefulSets stay on `OnDelete`. To fully revert, also delete and recreate the affected SeiNode resources, or hand-patch the StatefulSet spec.

## Test plan

- [x] Confirm Flux reconciles the new image on dev / harbor / prod
- [x] Watch the next NodeUpdate plan (image bump on a Running node) — expect plan steps `apply-statefulset` → `apply-service` → `replace-pod` → `observe-image` → `mark-ready`
- [x] Verify pod at old controller-revision-hash is deleted by `replace-pod` and StatefulSet recreates it at the new revision
- [x] Confirm steady-state behavior: no plan built when `spec.image == status.currentImage`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk manifest-only change, but it will roll out a new controller binary; any behavior change depends entirely on the new image contents.
> 
> **Overview**
> Updates the controller-manager Deployment (`config/manager/manager.yaml`) to use a new `sei-k8s-controller` image tag (`069a866…` → `e99c04c…`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4d1e52e4f3d25ce30a069342339868feeaca6b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->