### PR TITLE
feat(controller): share HTTP transport across sidecar calls (closes #225)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -167,13 +167,19 @@ func main() {
 	objectStore := platform.NewS3ObjectStore()
 	kc := mgr.GetClient()
 
-	buildSidecarClient := func(node *seiv1alpha1.SeiNode) (task.SidecarClient, error) {
-		url := planner.SidecarURLForNode(node)
-		if !noderesource.SidecarTLSEnabled(node) {
-			return sidecar.NewSidecarClient(url)
+	// One transport per process: keepalive pool and SA-token cache
+	// shared across reconciles.
+	sharedTLSDoer := &http.Client{Transport: sidecartransport.New(sidecartransport.Config{})}
+
+	newSidecarClient := func(node *seiv1alpha1.SeiNode) (*sidecar.SidecarClient, error) {
+		url := noderesource.SidecarURLForNode(node)
+		if noderesource.SidecarTLSEnabled(node) {
+			return sidecar.NewSidecarClient(url, sidecar.WithHTTPDoer(sharedTLSDoer))
 		}
-		rt := sidecartransport.New(sidecartransport.Config{})
-		return sidecar.NewSidecarClient(url, sidecar.WithHTTPDoer(&http.Client{Transport: rt}))
+		return sidecar.NewSidecarClient(url)
+	}
+	buildSidecarClient := func(node *seiv1alpha1.SeiNode) (task.SidecarClient, error) {
+		return newSidecarClient(node)
 	}
 
 	//nolint:staticcheck // TODO: migrate to GetEventRecorder (new events API)
@@ -190,12 +196,13 @@ func main() {
 					BuildSidecarClient: func() (task.SidecarClient, error) {
 						return buildSidecarClient(node)
 					},
-					KubeClient:  kc,
-					APIReader:   mgr.GetAPIReader(),
-					Scheme:      mgr.GetScheme(),
-					Resource:    node,
-					Platform:    platformCfg,
-					ObjectStore: objectStore,
+					NewSidecarClient: newSidecarClient,
+					KubeClient:       kc,
+					APIReader:        mgr.GetAPIReader(),
+					Scheme:           mgr.GetScheme(),
+					Resource:         node,
+					Platform:         platformCfg,
+					ObjectStore:      objectStore,
 				}
 			},
 		},
@@ -234,12 +241,13 @@ func main() {
 						}
 						return buildSidecarClient(assemblerNode)
 					},
-					KubeClient:  kc,
-					APIReader:   mgr.GetAPIReader(),
-					Scheme:      mgr.GetScheme(),
-					Resource:    group,
-					Platform:    platformCfg,
-					ObjectStore: objectStore,
+					NewSidecarClient: newSidecarClient,
+					KubeClient:       kc,
+					APIReader:        mgr.GetAPIReader(),
+					Scheme:           mgr.GetScheme(),
+					Resource:         group,
+					Platform:         platformCfg,
+					ObjectStore:      objectStore,
 				}
 			},
 		},

--- a/internal/task/deployment_await.go
+++ b/internal/task/deployment_await.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/google/uuid"
 	sidecar "github.com/sei-protocol/seictl/sidecar/client"
@@ -12,8 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
-	"github.com/sei-protocol/sei-k8s-controller/internal/noderesource"
-	"github.com/sei-protocol/sei-k8s-controller/internal/sidecartransport"
 )
 
 // awaitNodesAtHeightExecution submits await-condition(height=H) to each
@@ -112,7 +109,7 @@ func (e *awaitNodesAtHeightExecution) sidecarForNode(ctx context.Context, name s
 	if err := e.cfg.KubeClient.Get(ctx, types.NamespacedName{Name: name, Namespace: e.params.Namespace}, node); err != nil {
 		return nil, fmt.Errorf("getting node %s: %w", name, err)
 	}
-	return sidecarClientForNode(node)
+	return e.cfg.sidecarFor(node)
 }
 
 // awaitNodesCaughtUpExecution polls node sidecars until all report Ready.
@@ -156,7 +153,7 @@ func (e *awaitNodesCaughtUpExecution) isNodeReady(ctx context.Context, name stri
 	if err := e.cfg.KubeClient.Get(ctx, types.NamespacedName{Name: name, Namespace: e.params.Namespace}, node); err != nil {
 		return false
 	}
-	sc, err := sidecarClientForNode(node)
+	sc, err := e.cfg.sidecarFor(node)
 	if err != nil {
 		return false
 	}
@@ -165,19 +162,6 @@ func (e *awaitNodesCaughtUpExecution) isNodeReady(ctx context.Context, name stri
 		return false
 	}
 	return resp.Status == sidecar.Ready
-}
-
-// sidecarClientForNode constructs a SidecarClient pointed at a
-// SeiNode's pod. URL building lives in noderesource so this site and
-// cmd/main.go's factory stay in sync (planner can't be imported here
-// — planner already imports task).
-func sidecarClientForNode(node *seiv1alpha1.SeiNode) (*sidecar.SidecarClient, error) {
-	url := noderesource.SidecarURLForNode(node)
-	if noderesource.SidecarTLSEnabled(node) {
-		rt := sidecartransport.New(sidecartransport.Config{})
-		return sidecar.NewSidecarClient(url, sidecar.WithHTTPDoer(&http.Client{Transport: rt}))
-	}
-	return sidecar.NewSidecarClient(url)
 }
 
 // deterministicDeploymentTaskID generates a UUID v5 scoped to deployment operations.

--- a/internal/task/deployment_signal.go
+++ b/internal/task/deployment_signal.go
@@ -53,7 +53,7 @@ func (e *submitHaltSignalExecution) submitToNode(ctx context.Context, logger int
 		return
 	}
 
-	sc, err := sidecarClientForNode(node)
+	sc, err := e.cfg.sidecarFor(node)
 	if err != nil {
 		logger.Info("cannot build sidecar client for halt signal, skipping", "node", name, "error", err)
 		return

--- a/internal/task/genesis_peers.go
+++ b/internal/task/genesis_peers.go
@@ -64,7 +64,7 @@ func (e *collectAndSetPeersExecution) collectPeers(ctx context.Context) ([]strin
 			return nil, fmt.Errorf("getting node %s: %w", name, err)
 		}
 
-		sc, err := sidecarClientForNode(node)
+		sc, err := e.cfg.sidecarFor(node)
 		if err != nil {
 			return nil, fmt.Errorf("building sidecar client for %s: %w", name, err)
 		}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/platform"
 )
 
@@ -150,7 +151,10 @@ type SidecarClient interface {
 // ExecutePlan returns.
 type ExecutionConfig struct {
 	BuildSidecarClient func() (SidecarClient, error)
-	KubeClient         client.Client
+	// NewSidecarClient returns a client for an arbitrary SeiNode rather
+	// than the reconciled Resource.
+	NewSidecarClient func(*seiv1alpha1.SeiNode) (*sidecar.SidecarClient, error)
+	KubeClient       client.Client
 	// APIReader bypasses the controller-runtime cache. Use when reading a
 	// resource the same plan just wrote — the cached client lags behind
 	// SSA writes by milliseconds-to-unbounded.
@@ -159,6 +163,13 @@ type ExecutionConfig struct {
 	Resource    client.Object
 	Platform    platform.Config
 	ObjectStore platform.ObjectStore
+}
+
+func (c ExecutionConfig) sidecarFor(node *seiv1alpha1.SeiNode) (*sidecar.SidecarClient, error) {
+	if c.NewSidecarClient == nil {
+		return nil, fmt.Errorf("ExecutionConfig.NewSidecarClient not configured")
+	}
+	return c.NewSidecarClient(node)
 }
 
 // ResourceAs is a generic helper that type-asserts the Resource field.


### PR DESCRIPTION
## Summary

- Build one `*http.Client{Transport: sidecartransport.New(...)}` at controller startup and capture it in the sidecar client factory closures, so every call to a SeiNode sidecar reuses the keepalive pool and cached SA-token source instead of allocating a fresh transport per call.
- Add `ExecutionConfig.NewSidecarClient` so multi-node tasks (deployment await, halt signal, peer collection) can build a concrete `*sidecar.SidecarClient` for any child node without going through the `Resource`-bound `BuildSidecarClient`. Both factories now share the same transport singleton.
- Migrate the four call sites in `deployment_await.go`, `deployment_signal.go`, and `genesis_peers.go` off the free `sidecarClientForNode` helper (which was building a fresh transport per call) and delete the helper.

## Notes on the threat model

InsecureSkipVerify against the kube-rbac-proxy self-signed cert is preserved — trust comes from the bearer token, not cert identity. Long-lived pooled TLS sessions are a new but bounded delta: an attacker with a transient impersonation window already exfiltrates the SA token on the first intercepted request, and the token's scope is unchanged by session persistence. CA pinning is the follow-up (tracked at #224).

## Follow-ups (out of scope, will file as tracked issues)

- Tune `sidecartransport` connection-pool defaults — `MaxIdleConnsPerHost=2` (inherited from `http.DefaultTransport.Clone()`) becomes the bottleneck now that the pool is actually shared. Surface `MaxIdleConnsPerHost`/`MaxConnsPerHost` through `Config`.
- Defense-in-depth `Timeout` on the shared client and folding `BuildSidecarClient`/`NewSidecarClient` into one factory.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run --new-from-rev=origin/main` (0 issues)
- [x] Coral trio (platform-engineer, kubernetes-specialist, security-specialist) substance review on the diff — all approved
- [x] Coral trio comment-hygiene sweep — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the controller constructs sidecar HTTP clients by reusing a shared TLS-capable `http.Client` and introducing a new factory used by multi-node tasks, which could affect sidecar connectivity and authentication behavior under load.
> 
> **Overview**
> Reworks sidecar client construction to **reuse a single process-wide HTTP transport** for TLS-enabled sidecar calls, improving connection reuse and avoiding per-call transport/token-source allocation.
> 
> Extends `task.ExecutionConfig` with `NewSidecarClient` and migrates multi-node tasks (await-at-height, caught-up polling, halt-signal submission, peer collection) to use this injected factory; the old per-node helper is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f6fa9e9e2f052170f519a6fccc52f5c4bcdd05c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->