### PR TITLE
feat(controller): SEI_SIDECAR_IMAGE env var for sidecar image

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -157,12 +157,14 @@ func main() {
 		GatewayDomain:       os.Getenv("SEI_GATEWAY_DOMAIN"),
 		GatewayPublicDomain: os.Getenv("SEI_GATEWAY_PUBLIC_DOMAIN"),
 		KubeRBACProxyImage:  os.Getenv("SEI_KUBE_RBAC_PROXY_IMAGE"),
+		SidecarImage:        os.Getenv("SEI_SIDECAR_IMAGE"),
 	}
 
 	if err := platformCfg.Validate(); err != nil {
 		setupLog.Error(err, "Invalid platform configuration")
 		os.Exit(1)
 	}
+	setupLog.Info("Resolved sidecar image", "image", platformCfg.SidecarImage)
 
 	objectStore := platform.NewS3ObjectStore()
 	kc := mgr.GetClient()

--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -26,8 +26,7 @@ const (
 	// NodeLabel is the standard label key used on all SeiNode-owned resources.
 	NodeLabel = "sei.io/node"
 
-	dataDir             = platform.DataDir
-	defaultSidecarImage = platform.DefaultSidecarImage
+	dataDir = platform.DataDir
 
 	// Pod-spec container names. Used as both the .Name on built containers
 	// and the lookup key for the operator-keyring containment guard.
@@ -438,11 +437,11 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) corev1.PodSpe
 	return spec
 }
 
-func sidecarImage(node *seiv1alpha1.SeiNode) string {
+func sidecarImage(node *seiv1alpha1.SeiNode, p PlatformConfig) string {
 	if node.Spec.Sidecar != nil && node.Spec.Sidecar.Image != "" {
 		return node.Spec.Sidecar.Image
 	}
-	return defaultSidecarImage
+	return p.SidecarImage
 }
 
 // SidecarPort returns the sidecar HTTP port for the node.
@@ -484,7 +483,7 @@ func buildSidecarContainer(node *seiv1alpha1.SeiNode, p PlatformConfig) corev1.C
 
 	c := corev1.Container{
 		Name:          containerNameSidecar,
-		Image:         sidecarImage(node),
+		Image:         sidecarImage(node, p),
 		Command:       []string{"seictl", "serve"},
 		RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
 		Env:           env,

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -311,7 +311,7 @@ func TestSidecarImage_DefaultWhenEmpty(t *testing.T) {
 	node := newSnapshotNode("snap-0", "default")
 	node.Spec.Sidecar = &seiv1alpha1.SidecarConfig{}
 
-	g.Expect(sidecarImage(node)).To(Equal(defaultSidecarImage))
+	g.Expect(sidecarImage(node, platformtest.Config())).To(Equal(platformtest.Config().SidecarImage))
 }
 
 func TestSidecarImage_DefaultWhenNil(t *testing.T) {
@@ -319,7 +319,7 @@ func TestSidecarImage_DefaultWhenNil(t *testing.T) {
 	node := newSnapshotNode("snap-0", "default")
 	node.Spec.Sidecar = nil
 
-	g.Expect(sidecarImage(node)).To(Equal(defaultSidecarImage))
+	g.Expect(sidecarImage(node, platformtest.Config())).To(Equal(platformtest.Config().SidecarImage))
 }
 
 func TestSidecarImage_OverriddenWhenSet(t *testing.T) {
@@ -327,7 +327,7 @@ func TestSidecarImage_OverriddenWhenSet(t *testing.T) {
 	node := newSnapshotNode("snap-0", "default")
 	node.Spec.Sidecar = &seiv1alpha1.SidecarConfig{Image: "custom/sidecar:v2"}
 
-	g.Expect(sidecarImage(node)).To(Equal("custom/sidecar:v2"))
+	g.Expect(sidecarImage(node, platformtest.Config())).To(Equal("custom/sidecar:v2"))
 }
 
 func TestSidecarPort_DefaultWhenZero(t *testing.T) {
@@ -364,7 +364,7 @@ func TestSidecarContainer_DefaultImage(t *testing.T) {
 	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
 	sc := findInitContainer(sts.Spec.Template.Spec.InitContainers, "sei-sidecar")
 
-	g.Expect(sc.Image).To(Equal(defaultSidecarImage))
+	g.Expect(sc.Image).To(Equal(platformtest.Config().SidecarImage))
 }
 
 func TestSidecarContainer_CustomImage(t *testing.T) {
@@ -569,7 +569,7 @@ func TestSidecarMainContainer_NilSidecarConfig_UsesDefaults(t *testing.T) {
 	g.Expect(seid.Args[0]).To(ContainSubstring("/dev/tcp/localhost/7777"))
 
 	sc := findInitContainer(sts.Spec.Template.Spec.InitContainers, "sei-sidecar")
-	g.Expect(sc.Image).To(Equal(defaultSidecarImage))
+	g.Expect(sc.Image).To(Equal(platformtest.Config().SidecarImage))
 	g.Expect(sc.Ports[0].ContainerPort).To(Equal(seiconfig.PortSidecar))
 }
 

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,12 +1,11 @@
 package platform
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
-	// DefaultSidecarImage is the seictl sidecar image used when not overridden
-	// by the SeiNode spec. Shared between the node controller and bootstrap task.
-	DefaultSidecarImage = "ghcr.io/sei-protocol/seictl@sha256:a2af4e1b8ed4c12661a3c98cce050bae3f292cc7560abc2ba98fd7dfc80d9be5"
-
 	// DataDir is the mount path for the sei data volume inside node pods.
 	DataDir = "/sei"
 
@@ -47,6 +46,7 @@ type Config struct {
 	GatewayPublicDomain string
 
 	KubeRBACProxyImage string
+	SidecarImage       string
 }
 
 // NodepoolForMode returns the Karpenter NodePool name for the given
@@ -85,9 +85,10 @@ func (c Config) Validate() error {
 		"SEI_GATEWAY_NAME":          c.GatewayName,
 		"SEI_GATEWAY_NAMESPACE":     c.GatewayNamespace,
 		"SEI_GATEWAY_DOMAIN":        c.GatewayDomain,
+		"SEI_SIDECAR_IMAGE":         c.SidecarImage,
 	}
 	for name, val := range required {
-		if val == "" {
+		if strings.TrimSpace(val) == "" {
 			return fmt.Errorf("%s is required", name)
 		}
 	}

--- a/internal/platform/platformtest/config.go
+++ b/internal/platform/platformtest/config.go
@@ -31,5 +31,8 @@ func Config() platform.Config {
 		GatewayNamespace:    "istio-system",
 		GatewayDomain:       "test.platform.sei.io",
 		KubeRBACProxyImage:  "quay.io/brancz/kube-rbac-proxy:v0.19.1",
+		// Arbitrary fixture; not authoritative. Production digest is set
+		// via SEI_SIDECAR_IMAGE in the platform repo's controller Deployment.
+		SidecarImage: "ghcr.io/sei-protocol/seictl@sha256:a2af4e1b8ed4c12661a3c98cce050bae3f292cc7560abc2ba98fd7dfc80d9be5",
 	}
 }

--- a/internal/task/bootstrap_resources.go
+++ b/internal/task/bootstrap_resources.go
@@ -18,7 +18,6 @@ import (
 const (
 	bootstrapTerminationGracePeriod = int64(120)
 	bootstrapDataDir                = platform.DataDir
-	bootstrapDefaultSidecarImage    = platform.DefaultSidecarImage
 	bootstrapNodeLabel              = "sei.io/node"
 	bootstrapComponentLabel         = "sei.io/component"
 )
@@ -129,7 +128,7 @@ func buildBootstrapPodSpec(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.Snapshot
 	port := bootstrapSidecarPort(node)
 	sidecar := corev1.Container{
 		Name:          "sei-sidecar",
-		Image:         bootstrapSidecarImage(node),
+		Image:         bootstrapSidecarImage(node, platformCfg),
 		Command:       []string{"seictl", "serve"},
 		RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
 		Env: []corev1.EnvVar{
@@ -252,11 +251,11 @@ func bootstrapSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	}
 }
 
-func bootstrapSidecarImage(node *seiv1alpha1.SeiNode) string {
+func bootstrapSidecarImage(node *seiv1alpha1.SeiNode, p platform.Config) string {
 	if node.Spec.Sidecar != nil && node.Spec.Sidecar.Image != "" {
 		return node.Spec.Sidecar.Image
 	}
-	return bootstrapDefaultSidecarImage
+	return p.SidecarImage
 }
 
 func bootstrapSidecarPort(node *seiv1alpha1.SeiNode) int32 {


### PR DESCRIPTION
## Summary

- Add `platform.Config.SidecarImage`, required in `Validate()`, read from `SEI_SIDECAR_IMAGE` in `cmd/main.go`. Remove the hardcoded `platform.DefaultSidecarImage` const so the sidecar image is managed by the platform repo's Deployment manifests rather than baked into controller releases. Precedence is unchanged: `spec.sidecar.image` on a SeiNode still wins, otherwise `p.SidecarImage`.
- Tighten `Validate()` to apply `strings.TrimSpace` before the empty check so a whitespace-only env value cannot pass as non-empty. Applies uniformly to every required env var.
- Log the resolved sidecar image once at startup so on-call can recover what was deployed from controller logs without `kubectl describe`.

## Rollout order

This PR makes `SEI_SIDECAR_IMAGE` required. **The platform-repo PR that sets it on the controller Deployment must land first** — otherwise the next controller image bump will CrashLoopBackOff on `Validate()`. Bumping `SEI_SIDECAR_IMAGE` on the existing controller (pre-this-PR) is a no-op until the new controller image rolls.

## Fleet impact when bumping `SEI_SIDECAR_IMAGE`

The controller is authoritative on the sidecar container image via SSA on the StatefulSet pod template. Changing `SEI_SIDECAR_IMAGE` and rolling the controller causes every SeiNode StatefulSet to drift and roll its pod. There is no fleet-wide surge / maxUnavailable primitive — each StatefulSet rolls independently, staggered only by reconcile queue order. Treat sidecar image bumps as a fleet-wide sidecar restart.

## Deferred (will file as tracking issues)

- Enforce digest-pinned image refs in `Validate()` (`@sha256:` required) to prevent tag-based mutable refs in production.
- `status.currentSidecarImage` on SeiNode for fleet audit (mirrors the existing `status.currentImage` for seid).
- ValidatingAdmissionPolicy restricting `seinode.spec.sidecar.image` writes to admin principals.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run --new-from-rev=origin/main` (0 issues)
- [x] Coral trio (platform-engineer, kubernetes-specialist, security-specialist) review — all approved with follow-ups noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because the controller now fails startup if `SEI_SIDECAR_IMAGE` is unset/blank and changing it will roll sidecar pods across all nodes via reconciled pod templates.
> 
> **Overview**
> The controller now sources the default seictl sidecar image from a new required platform config field `SidecarImage` populated by `SEI_SIDECAR_IMAGE`, removing the previously hardcoded `platform.DefaultSidecarImage`.
> 
> Sidecar image selection in both `noderesource` StatefulSet generation and bootstrap Job pod-specs now falls back to `Platform.SidecarImage` when `SeiNode.spec.sidecar.image` is not set, and startup logs print the resolved sidecar image.
> 
> Platform config validation is tightened to treat whitespace-only environment variable values as missing, and tests/fixtures are updated to use the new config-driven default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fa7dc0c60352314e337c27fba9610932e130dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->