### PR TITLE
fix(noderesource): grant sidecar group-write on shared /sei dirs

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -423,6 +423,10 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) corev1.PodSpe
 	spec.SecurityContext = &corev1.PodSecurityContext{
 		FSGroup:             &fsGroup,
 		FSGroupChangePolicy: &fsGroupChangePolicy,
+		// seid (uid 0) writes into gid-65532-owned dirs created by seid-init,
+		// so its supplementary groups must include the sidecar gid to pick up
+		// group-write perms on /sei/config and /sei/data.
+		SupplementalGroups: []int64{sidecarNonRootUID},
 	}
 	initContainers := []corev1.Container{
 		buildSeidInitContainer(node),
@@ -611,7 +615,10 @@ func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 
 func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	script := fmt.Sprintf(
-		`if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
+		`mkdir -p %s/config %s/data && chown 0:%d %s %s/config %s/data && chmod 2775 %s %s/config %s/data && if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
+		dataDir, dataDir,
+		sidecarNonRootUID, dataDir, dataDir, dataDir,
+		dataDir, dataDir, dataDir,
 		dataDir, node.Spec.ChainID, node.Spec.ChainID, dataDir, dataDir,
 	)
 	return corev1.Container{

--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -634,6 +634,21 @@ func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: dataDir},
 		},
+		SecurityContext: seidInitSecurityContext(),
+	}
+}
+
+// seidInitSecurityContext keeps the init at uid 0 (chown requires it) but
+// drops every cap except the three needed to chown, chmod, and set the
+// setgid bit on the prepared dirs.
+func seidInitSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: new(bool),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+			Add:  []corev1.Capability{"CHOWN", "FOWNER", "FSETID"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
 }
 

--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -613,9 +613,13 @@ func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	return container
 }
 
+// buildSeidInitContainer runs seid init and prepares /sei, /sei/config,
+// /sei/data as 0:sidecarNonRootUID mode 2775 — group-writable with setgid
+// so new files seid creates inherit gid sidecarNonRootUID, which the
+// non-root sidecar needs for genesis assembly and snapshot restore.
 func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	script := fmt.Sprintf(
-		`mkdir -p %s/config %s/data && chown 0:%d %s %s/config %s/data && chmod 2775 %s %s/config %s/data && if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
+		`echo "preparing /sei perms" && mkdir -p %s/config %s/data && chown 0:%d %s %s/config %s/data && chmod 2775 %s %s/config %s/data && if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
 		dataDir, dataDir,
 		sidecarNonRootUID, dataDir, dataDir, dataDir,
 		dataDir, dataDir, dataDir,

--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -639,11 +639,15 @@ func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 }
 
 // seidInitSecurityContext keeps the init at uid 0 (chown requires it) but
-// drops every cap except the three needed to chown, chmod, and set the
-// setgid bit on the prepared dirs.
+// drops every cap except the three needed by the prep script: CHOWN for
+// `chown 0:65532`, FSETID to preserve the setgid bit on `chmod 2775`
+// (else chmod silently clears setgid when the file gid isn't the caller's
+// primary), and FOWNER as defense-in-depth for chmod on PVC dirs whose
+// uid may not match if a future script edit operates on paths it didn't
+// just chown.
 func seidInitSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
-		AllowPrivilegeEscalation: new(bool),
+		AllowPrivilegeEscalation: ptr.To(false), //nolint:modernize // ptr.To(false) is idiomatic; new(false) is invalid Go
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 			Add:  []corev1.Capability{"CHOWN", "FOWNER", "FSETID"},

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -1,6 +1,7 @@
 package noderesource
 
 import (
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -1067,6 +1068,38 @@ func TestPodSpec_FSGroup(t *testing.T) {
 	g.Expect(sts.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
 	g.Expect(*sts.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(int64(65532)),
 		"pod-level fsGroup must match sidecar UID so non-root sidecar can read 0o400 Secret mounts")
+}
+
+func TestPodSpec_SupplementalGroups(t *testing.T) {
+	g := NewWithT(t)
+	node := newSnapshotNode("snap-0", "default")
+
+	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
+	g.Expect(sts.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+	g.Expect(sts.Spec.Template.Spec.SecurityContext.SupplementalGroups).To(ContainElement(int64(65532)),
+		"seid (uid 0) must be a member of the sidecar gid to write into gid-65532-owned dirs")
+}
+
+func TestSeidInitContainer_PreparesSharedDirs(t *testing.T) {
+	g := NewWithT(t)
+	node := newGenesisNode("mynet-0", "default")
+
+	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
+	seidInit := findInitContainer(sts.Spec.Template.Spec.InitContainers, "seid-init")
+	g.Expect(seidInit).NotTo(BeNil())
+	g.Expect(seidInit.Command).To(HaveLen(3))
+
+	script := seidInit.Command[2]
+	mkdirIdx := strings.Index(script, "mkdir -p /sei/config /sei/data")
+	chownIdx := strings.Index(script, "chown 0:65532 /sei /sei/config /sei/data")
+	chmodIdx := strings.Index(script, "chmod 2775 /sei /sei/config /sei/data")
+	seidInitIdx := strings.Index(script, "seid init")
+
+	g.Expect(mkdirIdx).To(BeNumerically(">=", 0))
+	g.Expect(chownIdx).To(BeNumerically(">", mkdirIdx))
+	g.Expect(chmodIdx).To(BeNumerically(">", chownIdx))
+	g.Expect(seidInitIdx).To(BeNumerically(">", chmodIdx),
+		"shared-dir prep must precede seid init so subsequent files inherit setgid group")
 }
 
 // --- assertNoOperatorKeyringOnSeidContainers ---

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/platform/platformtest"
@@ -1106,8 +1107,7 @@ func TestSeidInitContainer_SecurityContext(t *testing.T) {
 	seidInit := findInitContainer(sts.Spec.Template.Spec.InitContainers, "seid-init")
 	g.Expect(seidInit).NotTo(BeNil())
 	g.Expect(seidInit.SecurityContext).NotTo(BeNil())
-	g.Expect(seidInit.SecurityContext.AllowPrivilegeEscalation).NotTo(BeNil())
-	g.Expect(*seidInit.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+	g.Expect(seidInit.SecurityContext.AllowPrivilegeEscalation).To(Equal(ptr.To(false))) //nolint:modernize // ptr.To(false) is idiomatic; new(false) is invalid Go
 	g.Expect(seidInit.SecurityContext.Capabilities).NotTo(BeNil())
 	g.Expect(seidInit.SecurityContext.Capabilities.Drop).To(ConsistOf(corev1.Capability("ALL")))
 	g.Expect(seidInit.SecurityContext.Capabilities.Add).To(ConsistOf(

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -1054,10 +1054,6 @@ func TestSeidMainContainer_NoSecurityContextChange(t *testing.T) {
 	// seid main container hardening is an out-of-scope, larger blast-radius
 	// change owned by a different workstream.
 	g.Expect(seid.SecurityContext).To(BeNil())
-
-	seidInit := findInitContainer(sts.Spec.Template.Spec.InitContainers, "seid-init")
-	g.Expect(seidInit).NotTo(BeNil())
-	g.Expect(seidInit.SecurityContext).To(BeNil())
 }
 
 func TestPodSpec_FSGroup(t *testing.T) {
@@ -1100,6 +1096,23 @@ func TestSeidInitContainer_PreparesSharedDirs(t *testing.T) {
 	g.Expect(chmodIdx).To(BeNumerically(">", chownIdx))
 	g.Expect(seidInitIdx).To(BeNumerically(">", chmodIdx),
 		"shared-dir prep must precede seid init so subsequent files inherit setgid group")
+}
+
+func TestSeidInitContainer_SecurityContext(t *testing.T) {
+	g := NewWithT(t)
+	node := newGenesisNode("mynet-0", "default")
+
+	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
+	seidInit := findInitContainer(sts.Spec.Template.Spec.InitContainers, "seid-init")
+	g.Expect(seidInit).NotTo(BeNil())
+	g.Expect(seidInit.SecurityContext).NotTo(BeNil())
+	g.Expect(seidInit.SecurityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	g.Expect(*seidInit.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+	g.Expect(seidInit.SecurityContext.Capabilities).NotTo(BeNil())
+	g.Expect(seidInit.SecurityContext.Capabilities.Drop).To(ConsistOf(corev1.Capability("ALL")))
+	g.Expect(seidInit.SecurityContext.Capabilities.Add).To(ConsistOf(
+		corev1.Capability("CHOWN"), corev1.Capability("FOWNER"), corev1.Capability("FSETID"),
+	))
 }
 
 // --- assertNoOperatorKeyringOnSeidContainers ---


### PR DESCRIPTION
## Summary

New genesis chains on harbor fail with `mkdir /sei/config/gentx: permission denied` in the sidecar's `assemble-and-upload-genesis` task. This PR fixes the shared-volume permission asymmetry between the root-running seid main container and the non-root (uid 65532) hardened sidecar introduced in #220, and hardens the seid-init container itself in the same surface.

## Root cause

PR #220 locked the sidecar to `RunAsUser=65532, ReadOnlyRootFilesystem=true` for operator-keyring containment. The pod has `fsGroup=65532` with `FSGroupChangePolicy=OnRootMismatch`, but fsGroup only chowns the volume **at mount time** — it does not affect new files created later. When seid main (running as root) creates `/sei/config/` after mount, it's owned `0:0` mode `0755`, so the sidecar has no path to write inside it.

Existing chains (created by the pre-#220 controller image) work because their sidecars run as root and can write anywhere.

## Fix

Three changes in `internal/noderesource/noderesource.go`:

1. **`PodSecurityContext.SupplementalGroups: [sidecarNonRootUID]`** — adds gid 65532 to seid's supplementary group list. The kubelet passes this to the OCI runtime, which calls `setgroups(2)` before `execve(2)` of the container entrypoint. seid then runs with `uid=0, gid=0, groups=[0, 65532]` and the kernel's group-permission check (`generic_permission()`) grants group-write on files owned by gid 65532. Without this, seid would fall through to "other" perms.

2. **Extended `buildSeidInitContainer` script** — runs `mkdir -p`, `chown 0:65532`, `chmod 2775` on `/sei`, `/sei/config`, `/sei/data` *before* `seid init`. The setgid bit (`2` in `2775`) makes new files seid creates inside these dirs inherit gid 65532 — so the sidecar keeps write access to whatever seid creates. Idempotent on existing PVCs: only touches the three top-level dirs, never recursive, never touches chain data.

3. **`seidInitSecurityContext()` on the init container** — `AllowPrivilegeEscalation=false`, `Capabilities.Drop=[ALL]`, `Capabilities.Add=[CHOWN, FOWNER, FSETID]`, `SeccompProfile=RuntimeDefault`. Init stays at uid 0 because `chown(2)` requires `CAP_CHOWN`. `FSETID` is load-bearing — preserves the setgid bit on `chmod 2775` (else chmod silently clears setgid). `FOWNER` is defense-in-depth for future script edits on paths the init didn't just chown.

The three changes are complementary: the init container sets up the *filesystem state* and runs with a minimal cap set; supplementalGroups gives seid the *group identity* to use that state. Sidecar SecurityContext from #220 is untouched.

## Pod Security Admission

The init container runs as uid 0 (necessary for `chown`). This means namespaces hosting SeiNode pods must be labeled `pod-security.kubernetes.io/enforce=baseline`, **not** `restricted` — the `restricted` profile requires `RunAsNonRoot=true` and `RunAsUser != 0`, which this PR's init container deliberately violates. `baseline` is satisfied by `AllowPrivilegeEscalation=false` + drop ALL + seccomp=RuntimeDefault.

## Operational impact

This is pod-template drift. On the next controller image rollout, every existing SeiNode's StatefulSet template drifts and the `NodeUpdate` plan's `replace-pod` task fires fleet-wide. Operators should expect `NodeUpdateInProgress` to be active on every SeiNode briefly during the rolling restart. Existing chain data is preserved (top-level chown is non-recursive; PVC subtrees are untouched).

## Unblocks

The harbor cluster is currently unable to create new genesis chains on the post-#220 controller. This PR + a follow-up image bump in the platform repo's harbor manager-patch restores new-chain capability.

## Deferred to follow-up tracking issues

- Long-term: migrate seid main container to run as uid 65532 with a one-shot PVC migration init container gated by a status field.
- CRD validation regex on `spec.chainID` (pre-existing command-injection surface in `seid init %s --chain-id %s`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run --new-from-rev=origin/main` (0 issues)
- [x] Coral trio (platform-engineer, kubernetes-specialist, security-specialist) reviewed in two rounds — all approved
- [ ] Smoke: harbor controller bumped to post-merge image, fresh genesis chain reaches Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)