### PR TITLE
fix(noderesource): recursive chown /sei/config so sidecar can overwrite seid-init files

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -615,15 +615,18 @@ func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 
 // buildSeidInitContainer runs seid init and prepares /sei, /sei/config,
 // /sei/data as 0:sidecarNonRootUID mode 2775 — group-writable with setgid
-// so new files seid creates inherit gid sidecarNonRootUID, which the
-// non-root sidecar needs for genesis assembly and snapshot restore.
+// so new files seid creates inherit gid sidecarNonRootUID. The recursive
+// chown + chmod g+rwX over /sei/config covers the validator-key files
+// seid init creates as mode 0600 so the non-root sidecar can overwrite
+// them with operator-derived identity (generate-identity task).
 func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	script := fmt.Sprintf(
-		`echo "preparing /sei perms" && mkdir -p %s/config %s/data && chown 0:%d %s %s/config %s/data && chmod 2775 %s %s/config %s/data && if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
+		`echo "preparing /sei perms" && mkdir -p %s/config %s/data && chown 0:%d %s %s/config %s/data && chmod 2775 %s %s/config %s/data && if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && chown -R 0:%d %s/config && chmod -R g+rwX %s/config && mkdir -p %s/tmp`,
 		dataDir, dataDir,
 		sidecarNonRootUID, dataDir, dataDir, dataDir,
 		dataDir, dataDir, dataDir,
-		dataDir, node.Spec.ChainID, node.Spec.ChainID, dataDir, dataDir,
+		dataDir, node.Spec.ChainID, node.Spec.ChainID, dataDir,
+		sidecarNonRootUID, dataDir, dataDir, dataDir,
 	)
 	return corev1.Container{
 		Name:  "seid-init",

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -1091,12 +1091,18 @@ func TestSeidInitContainer_PreparesSharedDirs(t *testing.T) {
 	chownIdx := strings.Index(script, "chown 0:65532 /sei /sei/config /sei/data")
 	chmodIdx := strings.Index(script, "chmod 2775 /sei /sei/config /sei/data")
 	seidInitIdx := strings.Index(script, "seid init")
+	chownRIdx := strings.Index(script, "chown -R 0:65532 /sei/config")
+	chmodRIdx := strings.Index(script, "chmod -R g+rwX /sei/config")
 
 	g.Expect(mkdirIdx).To(BeNumerically(">=", 0))
 	g.Expect(chownIdx).To(BeNumerically(">", mkdirIdx))
 	g.Expect(chmodIdx).To(BeNumerically(">", chownIdx))
 	g.Expect(seidInitIdx).To(BeNumerically(">", chmodIdx),
 		"shared-dir prep must precede seid init so subsequent files inherit setgid group")
+	g.Expect(chownRIdx).To(BeNumerically(">", seidInitIdx),
+		"recursive chown must follow seid init to relax the mode-0600 files it creates")
+	g.Expect(chmodRIdx).To(BeNumerically(">", chownRIdx),
+		"recursive chmod follows the recursive chown")
 }
 
 func TestSeidInitContainer_SecurityContext(t *testing.T) {


### PR DESCRIPTION
## Summary

Hotfix on top of #229. The smoke test (harbor-pr-229 chain on harbor) surfaced a second permission-denied failure that the original PR's directory-perm work didn't cover.

## Failure mode

```
generate-identity: initializing validator files: open /sei/config/node_key.json: permission denied
```

`seid init` (run inside the seid-init container as uid 0) creates `/sei/config/node_key.json` and `/sei/config/priv_validator_key.json` as **uid 0, mode 0600** — the Cosmos SDK security default for validator-key files. The directory inherits gid 65532 via #229's setgid bit, so *new files* the sidecar creates work. But these files **already exist** when the sidecar's `generate-identity` task runs, and the sidecar (uid 65532) can't `open(..., O_WRONLY)` on a root-owned mode-0600 file regardless of group membership — owner perms apply by uid match, not gid match.

#229 closed the create path (`mkdir /sei/config/gentx: permission denied`). This PR closes the overwrite path.

## Fix

Extend the seid-init script with two recursive operations on `/sei/config` after `seid init` runs:

```sh
chown -R 0:65532 /sei/config && chmod -R g+rwX /sei/config
```

- **chown -R 0:65532**: covers everything seid init created. Owner stays uid 0 (seid main, which writes priv_validator_state.json on every block, still operates as owner). Group becomes 65532 so the sidecar inherits group-write via primary-gid membership.
- **chmod -R g+rwX**: adds group read+write on all files; group rwx on directories (uppercase X applies execute only where it makes sense). The validator-key files transition from 0600 to 0660 — still inaccessible to other/world.

Idempotent on pod restart — `chown -R` and `chmod -R` over the same paths are no-ops. Scope is `/sei/config` only; `/sei/data` retains whatever mode seid sets on blockstore files.

## Why #229's review missed this

The trio review surface was scoped to the originally-reported failure (`mkdir /sei/config/gentx: permission denied`). Both reviewers flagged the directory-creation path and approved the fix for that path. The OVERWRITE path on root-created files inside the dir wasn't exercised — there was no test for it because the validator-init plan (`generate-identity` task) wasn't the failing surface in the reported bug.

## Operational impact

Same as #229: pod-template drift on rollout → fleet-wide rolling restart of every SeiNode pod. The recursive chown on first pod start under this controller takes maybe 50ms (a handful of small files in `/sei/config`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go test ./...`
- [x] `go test -race ./internal/noderesource/...`
- [x] `golangci-lint run --new-from-rev=origin/main` (0 issues)
- [x] `TestSeidInitContainer_PreparesSharedDirs` extended to assert the new recursive ops run after `seid init`
- [ ] Smoke: harbor controller bumped to merge-commit, harbor-pr-229 chain reaches Ready (the test #229 didn't complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)