### PR TITLE
feat(noderesource): migrate seid main to non-root, recursive PVC chown

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -5,9 +5,12 @@
 package noderesource
 
 import (
+	"bytes"
+	_ "embed"
 	"fmt"
 	"maps"
 	"strings"
+	"text/template"
 
 	seiconfig "github.com/sei-protocol/sei-config"
 	appsv1 "k8s.io/api/apps/v1"
@@ -21,6 +24,22 @@ import (
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/platform"
 )
+
+// OwnershipSentinelV1 is the per-PVC marker for migration-v1 (data volume
+// chowned to sidecarNonRootUID:sidecarNonRootUID). Exported because
+// internal/task/bootstrap_resources.go must clear it on re-bootstrap so
+// the StatefulSet's seid-init re-runs the migration over whatever the
+// bootstrap Job rewrote as uid 0.
+//
+// Any future ownership migration MUST define a new sentinel (V2, etc.)
+// rather than reuse this path — old PVCs would otherwise short-circuit
+// the new migration on a stale marker.
+const OwnershipSentinelV1 = ".sei-k8s-controller-ownership-v1"
+
+//go:embed seid_init.sh.tmpl
+var seidInitScriptTmpl string
+
+var seidInitTemplate = template.Must(template.New("seid-init").Parse(seidInitScriptTmpl))
 
 const (
 	// NodeLabel is the standard label key used on all SeiNode-owned resources.
@@ -423,10 +442,6 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) corev1.PodSpe
 	spec.SecurityContext = &corev1.PodSecurityContext{
 		FSGroup:             &fsGroup,
 		FSGroupChangePolicy: &fsGroupChangePolicy,
-		// seid (uid 0) writes into gid-65532-owned dirs created by seid-init,
-		// so its supplementary groups must include the sidecar gid to pick up
-		// group-write perms on /sei/config and /sei/data.
-		SupplementalGroups: []int64{sidecarNonRootUID},
 	}
 	initContainers := []corev1.Container{
 		buildSeidInitContainer(node),
@@ -582,8 +597,9 @@ func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	mounts = append(mounts, signingMounts...)
 	mounts = append(mounts, nodeMounts...)
 	container := corev1.Container{
-		Name:  containerNameSeid,
-		Image: node.Spec.Image,
+		Name:            containerNameSeid,
+		Image:           node.Spec.Image,
+		SecurityContext: seidMainSecurityContext(),
 		Env: []corev1.EnvVar{
 			{Name: "TMPDIR", Value: dataDir + "/tmp"},
 		},
@@ -613,23 +629,16 @@ func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	return container
 }
 
-// buildSeidInitContainer runs seid init and prepares /sei, /sei/config,
-// /sei/data as 0:sidecarNonRootUID mode 2775 — group-writable with setgid
-// so new files seid creates inherit gid sidecarNonRootUID, which the
-// non-root sidecar needs for genesis assembly and snapshot restore.
+// buildSeidInitContainer wires the rendered seid_init.sh.tmpl into the
+// pod spec. The script's behavior, sentinel-versioning contract, and
+// ordering invariants live in the template comment block; keep that as
+// the source of truth.
 func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
-	script := fmt.Sprintf(
-		`echo "preparing /sei perms" && mkdir -p %s/config %s/data && chown 0:%d %s %s/config %s/data && chmod 2775 %s %s/config %s/data && if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
-		dataDir, dataDir,
-		sidecarNonRootUID, dataDir, dataDir, dataDir,
-		dataDir, dataDir, dataDir,
-		dataDir, node.Spec.ChainID, node.Spec.ChainID, dataDir, dataDir,
-	)
 	return corev1.Container{
 		Name:  "seid-init",
 		Image: node.Spec.Image,
 		Command: []string{
-			"/bin/sh", "-c", script,
+			"/bin/sh", "-c", renderSeidInitScript(node.Spec.ChainID),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: dataDir},
@@ -638,13 +647,35 @@ func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	}
 }
 
-// seidInitSecurityContext keeps the init at uid 0 (chown requires it) but
-// drops every cap except the three needed by the prep script: CHOWN for
-// `chown 0:65532`, FSETID to preserve the setgid bit on `chmod 2775`
-// (else chmod silently clears setgid when the file gid isn't the caller's
-// primary), and FOWNER as defense-in-depth for chmod on PVC dirs whose
-// uid may not match if a future script edit operates on paths it didn't
-// just chown.
+// renderSeidInitScript executes the embedded seid-init template with the
+// package-level constants and the per-node chain ID. The template parses
+// at init and the data fields match the schema, so the only failure mode
+// is a programmer mistake — surface via panic rather than threading an
+// unreachable error through every caller.
+func renderSeidInitScript(chainID string) string {
+	var buf bytes.Buffer
+	err := seidInitTemplate.Execute(&buf, struct {
+		DataDir      string
+		NonRootUID   int64
+		SentinelName string
+		ChainID      string
+	}{
+		DataDir:      dataDir,
+		NonRootUID:   sidecarNonRootUID,
+		SentinelName: OwnershipSentinelV1,
+		ChainID:      chainID,
+	})
+	if err != nil {
+		panic(fmt.Errorf("rendering seid-init template: %w", err))
+	}
+	return buf.String()
+}
+
+// seidInitSecurityContext keeps the init at uid 0 because the one-time
+// PVC ownership migration runs chown(2) which requires CAP_CHOWN. Drops
+// every other cap; FOWNER + FSETID are kept as defense-in-depth for the
+// chmod (FOWNER when operating on dirs the caller doesn't own, FSETID
+// to preserve setgid on `chmod 2775`).
 func seidInitSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		AllowPrivilegeEscalation: ptr.To(false), //nolint:modernize // ptr.To(false) is idiomatic; new(false) is invalid Go
@@ -653,6 +684,19 @@ func seidInitSecurityContext() *corev1.SecurityContext {
 			Add:  []corev1.Capability{"CHOWN", "FOWNER", "FSETID"},
 		},
 		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
+}
+
+// seidMainSecurityContext runs seid as the same uid/gid as the sidecar so
+// both processes operate as owner on /sei/config files and the kernel's
+// uid-match check shortcircuits permission resolution. Replaces the
+// supplementalGroups + setgid asymmetry workaround that #229 layered on
+// top of the root-running seid.
+func seidMainSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		RunAsNonRoot: ptr.To(true),              //nolint:modernize // ptr.To(true) is idiomatic; new(true) is invalid Go
+		RunAsUser:    ptr.To(sidecarNonRootUID), //nolint:modernize // ptr.To(65532) is idiomatic; new(int64) would zero
+		RunAsGroup:   ptr.To(sidecarNonRootUID), //nolint:modernize // ptr.To(65532) is idiomatic; new(int64) would zero
 	}
 }
 

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -1045,16 +1045,17 @@ func TestSidecarContainer_SecurityContext(t *testing.T) {
 	g.Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
 }
 
-func TestSeidMainContainer_NoSecurityContextChange(t *testing.T) {
+func TestSeidMainContainer_RunsAsNonRoot(t *testing.T) {
 	g := NewWithT(t)
 	node := newSnapshotNode("snap-0", "default")
 
 	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
 	seid := findContainer(sts.Spec.Template.Spec.Containers, "seid")
 	g.Expect(seid).NotTo(BeNil())
-	// seid main container hardening is an out-of-scope, larger blast-radius
-	// change owned by a different workstream.
-	g.Expect(seid.SecurityContext).To(BeNil())
+	g.Expect(seid.SecurityContext).NotTo(BeNil())
+	g.Expect(seid.SecurityContext.RunAsNonRoot).To(Equal(ptr.To(true)))       //nolint:modernize // ptr.To(true) is idiomatic; new(true) is invalid Go
+	g.Expect(seid.SecurityContext.RunAsUser).To(Equal(ptr.To(int64(65532))))  //nolint:modernize
+	g.Expect(seid.SecurityContext.RunAsGroup).To(Equal(ptr.To(int64(65532)))) //nolint:modernize
 }
 
 func TestPodSpec_FSGroup(t *testing.T) {
@@ -1067,17 +1068,17 @@ func TestPodSpec_FSGroup(t *testing.T) {
 		"pod-level fsGroup must match sidecar UID so non-root sidecar can read 0o400 Secret mounts")
 }
 
-func TestPodSpec_SupplementalGroups(t *testing.T) {
+func TestPodSpec_NoSupplementalGroups(t *testing.T) {
 	g := NewWithT(t)
 	node := newSnapshotNode("snap-0", "default")
 
 	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
 	g.Expect(sts.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
-	g.Expect(sts.Spec.Template.Spec.SecurityContext.SupplementalGroups).To(ContainElement(int64(65532)),
-		"seid (uid 0) must be a member of the sidecar gid to write into gid-65532-owned dirs")
+	g.Expect(sts.Spec.Template.Spec.SecurityContext.SupplementalGroups).To(BeEmpty(),
+		"workaround for root-seid is no longer needed once seid runs as gid 65532 natively")
 }
 
-func TestSeidInitContainer_PreparesSharedDirs(t *testing.T) {
+func TestSeidInitContainer_OneTimeOwnershipMigration(t *testing.T) {
 	g := NewWithT(t)
 	node := newGenesisNode("mynet-0", "default")
 
@@ -1087,16 +1088,25 @@ func TestSeidInitContainer_PreparesSharedDirs(t *testing.T) {
 	g.Expect(seidInit.Command).To(HaveLen(3))
 
 	script := seidInit.Command[2]
-	mkdirIdx := strings.Index(script, "mkdir -p /sei/config /sei/data")
-	chownIdx := strings.Index(script, "chown 0:65532 /sei /sei/config /sei/data")
+	mkdirIdx := strings.Index(script, "mkdir -p /sei/config /sei/data /sei/tmp")
+	seidInitIdx := strings.Index(script, "seid init sei-test --chain-id sei-test --home /sei --overwrite")
+	sentinelGuardIdx := strings.Index(script, "[ ! -f /sei/.sei-k8s-controller-ownership-v1 ]")
+	chownRIdx := strings.Index(script, "chown -R 65532:65532 /sei")
+	sentinelTouchIdx := strings.Index(script, "touch /sei/.sei-k8s-controller-ownership-v1")
 	chmodIdx := strings.Index(script, "chmod 2775 /sei /sei/config /sei/data")
-	seidInitIdx := strings.Index(script, "seid init")
 
-	g.Expect(mkdirIdx).To(BeNumerically(">=", 0))
-	g.Expect(chownIdx).To(BeNumerically(">", mkdirIdx))
-	g.Expect(chmodIdx).To(BeNumerically(">", chownIdx))
-	g.Expect(seidInitIdx).To(BeNumerically(">", chmodIdx),
-		"shared-dir prep must precede seid init so subsequent files inherit setgid group")
+	g.Expect(mkdirIdx).To(BeNumerically(">=", 0),
+		"/sei/tmp must be created with /sei/config and /sei/data so the chown -R migration covers it; otherwise seid main (uid 65532) EACCEScreate-after-sentinel")
+	g.Expect(seidInitIdx).To(BeNumerically(">", mkdirIdx),
+		"seid init runs after dirs exist")
+	g.Expect(sentinelGuardIdx).To(BeNumerically(">", seidInitIdx),
+		"ownership migration must follow seid init so the files it creates also get chowned")
+	g.Expect(chownRIdx).To(BeNumerically(">", sentinelGuardIdx),
+		"recursive chown is inside the sentinel guard")
+	g.Expect(sentinelTouchIdx).To(BeNumerically(">", chownRIdx),
+		"sentinel marker is created after a successful chown")
+	g.Expect(chmodIdx).To(BeNumerically(">", sentinelTouchIdx),
+		"top-level chmod runs after the migration step")
 }
 
 func TestSeidInitContainer_SecurityContext(t *testing.T) {

--- a/internal/noderesource/seid_init.sh.tmpl
+++ b/internal/noderesource/seid_init.sh.tmpl
@@ -1,0 +1,35 @@
+#!/bin/sh
+# seid init + one-time {{.DataDir}} ownership migration to {{.NonRootUID}}:{{.NonRootUID}}.
+# Rendered by internal/noderesource.renderSeidInitScript; constants flow in
+# from the package-level Go consts.
+#
+# Container runs as uid 0 (chown(2) needs CAP_CHOWN). After the migration
+# sentinel is set, the chown branch is skipped and the script is a no-op
+# on subsequent restarts.
+#
+# Sentinel path is migration-v1. Any future ownership migration MUST use
+# a distinct sentinel path so old markers don't short-circuit it.
+#
+# Order matters: any new shared dir under {{.DataDir}} MUST be added to
+# the initial mkdir set so the chown -R covers it. /sei/tmp is here for
+# exactly that reason — seid main writes via TMPDIR and would EACCES if
+# a sub-dir got created after the sentinel locked the migration in.
+set -e
+
+echo "preparing {{.DataDir}} perms"
+
+mkdir -p {{.DataDir}}/config {{.DataDir}}/data {{.DataDir}}/tmp
+
+if [ -f {{.DataDir}}/config/genesis.json ]; then
+  echo "data directory already initialized, skipping seid init"
+else
+  seid init {{.ChainID}} --chain-id {{.ChainID}} --home {{.DataDir}} --overwrite
+fi
+
+if [ ! -f {{.DataDir}}/{{.SentinelName}} ]; then
+  echo "migrating {{.DataDir}} ownership to {{.NonRootUID}}:{{.NonRootUID}}"
+  chown -R {{.NonRootUID}}:{{.NonRootUID}} {{.DataDir}}
+  touch {{.DataDir}}/{{.SentinelName}}
+fi
+
+chmod 2775 {{.DataDir}} {{.DataDir}}/config {{.DataDir}}/data

--- a/internal/task/bootstrap_resources.go
+++ b/internal/task/bootstrap_resources.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/noderesource"
 	"github.com/sei-protocol/sei-k8s-controller/internal/platform"
 )
 
@@ -234,10 +235,22 @@ func bootstrapWaitCommand(port int32, haltHeight int64) (command []string, args 
 	return []string{"/bin/bash", "-c"}, []string{script}
 }
 
+// bootstrapSeidInitContainer prepares the bootstrap Job's data directory.
+// Runs as uid 0; the bootstrap pod doesn't carry the StatefulSet's
+// SecurityContext + sidecar hardening because the Job writes chain data
+// then exits.
+//
+// Clears the StatefulSet's ownership-migration sentinel on exit so the
+// next StatefulSet pod's seid-init re-runs the chown -R over whatever
+// the bootstrap Job (running as root) just wrote. Without this, a
+// re-bootstrap on a previously-migrated PVC leaves root-owned files
+// behind a stamped sentinel and the StatefulSet's seid main (uid 65532)
+// EACCES on them.
 func bootstrapSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	script := fmt.Sprintf(
-		`if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
+		`if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp && rm -f %s/%s`,
 		bootstrapDataDir, node.Spec.ChainID, node.Spec.ChainID, bootstrapDataDir, bootstrapDataDir,
+		bootstrapDataDir, noderesource.OwnershipSentinelV1,
 	)
 	return corev1.Container{
 		Name:  "seid-init",


### PR DESCRIPTION
## Summary

Collapses the asymmetry workaround layer from #229 (and supersedes the now-closed #231) into the proper non-root seid migration that the long-term tracking issue #230 called for.

- **seid main** now runs as `RunAsUser=65532, RunAsGroup=65532, RunAsNonRoot=true` — matches the sidecar's uid/gid from #220.
- **seid-init script** extracted to `seid_init.sh.tmpl` + `text/template` render. Adds a sentinel-gated one-time `chown -R 65532:65532 /sei` after `seid init`, gated on `/sei/.sei-k8s-controller-ownership-v1`. Sentinel const exported (`OwnershipSentinelV1`) so bootstrap_resources.go can clear it on re-bootstrap.
- **bootstrap Job's seid-init** now `rm -f`s the sentinel before exit (re-bootstrap on a previously-migrated PVC otherwise writes root-owned files past the stamped sentinel; seid main would EACCES).
- **`PodSecurityContext.SupplementalGroups: [65532]`** removed — the workaround that gave root-seid group access to gid-65532-owned files is no longer needed once seid IS gid 65532.

## Why this shape

Three trio rounds. The shape that won out:

1. **Symmetric uid/gid** between seid main and sei-sidecar is the load-bearing simplification. Owner-uid match shortcircuits the kernel permission check in `generic_permission()`; group/setgid/supplementalGroups workarounds disappear.
2. **One-time PVC migration via sentinel** rather than recursive-chown-every-restart amortizes the cost. First-restart per PVC pays the chown; subsequent restarts skip via single `stat`.
3. **seid-init stays at uid 0** because `chown(2)` needs `CAP_CHOWN`. Drops every other cap; keeps `CHOWN/FOWNER/FSETID` only.
4. **Template extraction**: the inline 13-arg `fmt.Sprintf` was unwieldy. Now the script lives in `seid_init.sh.tmpl` with named template fields; the Go side just hands it `{DataDir, NonRootUID, SentinelName, ChainID}`.

## Rollback safety

Rolling back to a pre-this-PR controller is safe: the old controller renders seid as uid 0. uid 0 has `CAP_DAC_OVERRIDE` and bypasses DAC checks against 65532-owned files. No filesystem migration is needed to roll back. Worth noting: new files seid (uid 0) writes during a rollback window are owned 0:0; if you roll forward again, the sentinel still exists, so those root-owned files would lock out seid 65532. Recovery: `rm /sei/.sei-k8s-controller-ownership-v1` on the affected PVC to re-trigger migration. Document this in the rollout runbook.

## Pod Security Standards

seid-init still runs as uid 0 (chown needs it), so namespaces hosting SeiNode pods must enforce `pod-security.kubernetes.io/enforce=baseline`, **not** `restricted`. Full `restricted` eligibility is a future workstream (init must drop to uid 65532 once the fleet is fully migrated and the chown branch becomes dead code, or replace seid-init with a kubelet-driven `FSGroupChangePolicy=Always` approach).

## First-rollout operational impact

Every existing SeiNode StatefulSet drifts on this controller's rollout. The `NodeUpdate` plan's `replace-pod` task fires per-node, rolling each pod individually. **First restart per PVC pays the recursive chown cost**:
- Harbor smoke chains (small datasets): seconds.
- Prod archive nodes (~10TB / ~50M files on EBS gp3): estimated ~10-30 min one-time. Subsequent restarts: single `stat` on the sentinel, near-zero.

Existing chain data is preserved — `chown -R` is a metadata-only walk; file contents are untouched.

**`Failed`-phase SeiNodes don't auto-reconcile** onto the new pod template (the planner has no path back from terminal Failed). The two `harbor-pr-229-{0,1}` validators currently in Failed state need `kubectl delete seinode` + SND recreate to pick up the migration; harbor is small so this is acceptable as the smoke-test reset.

## Deferred to follow-up tracking issues

- **Sentinel as JSON content marker** (vs plain dotfile) before introducing migration-v2 — path-based versioning is brittle; security flagged.
- **Parallel chown for multi-TB archives** — current `chown -R` is single-threaded. `find … -print0 | xargs -0 -P N chown` would parallelize. Not needed for the harbor smoke; could matter for prod archive nodes if the 10-30 min estimate is wrong.
- **Operator recovery runbook entry**: `rm /sei/.sei-k8s-controller-ownership-v1` + restart pod when migration goes wrong on a specific PVC.
- **Migration-in-progress event emission** — emit a controller event when the init container is running pre-sentinel so operators see it in `kubectl describe`.
- **Shell-exec idempotency test harness** — current tests check rendered strings; an actual shell execution against a tmpdir would catch regressions like the Issue A bug (which was caught by code review, not tests).
- **Replace seid-init with kubelet `FSGroupChangePolicy=Always`** — security flagged as the long-long-term shape; deletes the entire init container in favor of CSI-driven recursive chown. Unblocks PSA `restricted`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go test ./...`
- [x] `go test -race ./internal/noderesource/...`
- [x] `golangci-lint run --new-from-rev=origin/main` (0 issues)
- [x] Coral trio (platform-engineer, kubernetes-specialist, security-specialist) — three rounds, all converged on the current shape. Real bug caught in round 2 (Issue A: trailing `mkdir -p /sei/tmp` post-sentinel) and fixed.
- [ ] Smoke: harbor controller bumped, fresh genesis chain reaches Ready end-to-end. Two old Failed SeiNodes deleted; SeiNodeDeployment recreates fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)