### PR TITLE
feat(noderesource): non-root seid + seid-init via kubelet fsGroup migration

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -418,15 +418,21 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) corev1.PodSpe
 	// FSGroup grants the non-root sidecar UID read access to 0o400
 	// Secret-projected files. ChangePolicy=OnRootMismatch avoids recursive
 	// chown on every pod start (the "Always" default is costly on archive PVCs).
+	// fsGroup with OnRootMismatch is the load-bearing migration primitive:
+	// on first mount of a legacy root-owned PVC, kubelet recursively chowns
+	// the volume's gid to sidecarNonRootUID and adds group rwX. seid + the
+	// sidecar both run as uid sidecarNonRootUID and access chain data via
+	// group perms. On subsequent mounts kubelet sees the root gid already
+	// matches and skips the walk — near-zero cost. New files seid creates
+	// land as uid:gid sidecarNonRootUID:sidecarNonRootUID via the process's
+	// own primary identity; legacy files retain uid 0 but become readable
+	// via the recursive gid chown. The volume self-converges to uniform
+	// uid 65532 ownership over time as files rotate.
 	fsGroup := sidecarNonRootUID
 	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
 	spec.SecurityContext = &corev1.PodSecurityContext{
 		FSGroup:             &fsGroup,
 		FSGroupChangePolicy: &fsGroupChangePolicy,
-		// seid (uid 0) writes into gid-65532-owned dirs created by seid-init,
-		// so its supplementary groups must include the sidecar gid to pick up
-		// group-write perms on /sei/config and /sei/data.
-		SupplementalGroups: []int64{sidecarNonRootUID},
 	}
 	initContainers := []corev1.Container{
 		buildSeidInitContainer(node),
@@ -582,8 +588,9 @@ func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	mounts = append(mounts, signingMounts...)
 	mounts = append(mounts, nodeMounts...)
 	container := corev1.Container{
-		Name:  containerNameSeid,
-		Image: node.Spec.Image,
+		Name:            containerNameSeid,
+		Image:           node.Spec.Image,
+		SecurityContext: seidNonRootSecurityContext(),
 		Env: []corev1.EnvVar{
 			{Name: "TMPDIR", Value: dataDir + "/tmp"},
 		},
@@ -613,16 +620,14 @@ func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	return container
 }
 
-// buildSeidInitContainer runs seid init and prepares /sei, /sei/config,
-// /sei/data as 0:sidecarNonRootUID mode 2775 — group-writable with setgid
-// so new files seid creates inherit gid sidecarNonRootUID, which the
-// non-root sidecar needs for genesis assembly and snapshot restore.
+// buildSeidInitContainer runs `seid init` on first boot to materialize
+// /sei/config and ensures /sei/tmp exists. Runs as non-root; PVC
+// ownership is handled by kubelet's fsGroup OnRootMismatch (see
+// PodSecurityContext setup in buildNodePodSpec), so this container
+// needs no caps and no chown logic.
 func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	script := fmt.Sprintf(
-		`echo "preparing /sei perms" && mkdir -p %s/config %s/data && chown 0:%d %s %s/config %s/data && chmod 2775 %s %s/config %s/data && if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
-		dataDir, dataDir,
-		sidecarNonRootUID, dataDir, dataDir, dataDir,
-		dataDir, dataDir, dataDir,
+		`if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
 		dataDir, node.Spec.ChainID, node.Spec.ChainID, dataDir, dataDir,
 	)
 	return corev1.Container{
@@ -634,25 +639,27 @@ func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: dataDir},
 		},
-		SecurityContext: seidInitSecurityContext(),
+		SecurityContext: seidNonRootSecurityContext(),
 	}
 }
 
-// seidInitSecurityContext keeps the init at uid 0 (chown requires it) but
-// drops every cap except the three needed by the prep script: CHOWN for
-// `chown 0:65532`, FSETID to preserve the setgid bit on `chmod 2775`
-// (else chmod silently clears setgid when the file gid isn't the caller's
-// primary), and FOWNER as defense-in-depth for chmod on PVC dirs whose
-// uid may not match if a future script edit operates on paths it didn't
-// just chown.
-func seidInitSecurityContext() *corev1.SecurityContext {
+// seidNonRootSecurityContext is shared between seid main and seid-init.
+// Both run the same binary, share the same /sei mount, and have the same
+// (low) privilege needs. ReadOnlyRootFilesystem is deliberately omitted —
+// seid is a Go binary that may use /tmp on the rootfs; the sidecar can
+// enforce RORFS because we mount an emptyDir at its /tmp, and we don't
+// duplicate that wiring on seid containers.
+//
+// PSA `restricted`-eligible: RunAsNonRoot, RunAsUser>0, drop ALL caps,
+// no privilege escalation, RuntimeDefault seccomp.
+func seidNonRootSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
-		AllowPrivilegeEscalation: ptr.To(false), //nolint:modernize // ptr.To(false) is idiomatic; new(false) is invalid Go
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-			Add:  []corev1.Capability{"CHOWN", "FOWNER", "FSETID"},
-		},
-		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		RunAsNonRoot:             ptr.To(true),              //nolint:modernize // ptr.To(true) is idiomatic; new(true) is invalid Go
+		RunAsUser:                ptr.To(sidecarNonRootUID), //nolint:modernize // ptr.To(65532) is idiomatic; new(int64) would zero
+		RunAsGroup:               ptr.To(sidecarNonRootUID), //nolint:modernize // ptr.To(65532) is idiomatic; new(int64) would zero
+		AllowPrivilegeEscalation: ptr.To(false),             //nolint:modernize // ptr.To(false) is idiomatic; new(false) is invalid Go
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
 }
 

--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -415,19 +415,9 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) corev1.PodSpe
 	// SecurityContext, separate the sidecar's SA) is tracked as a follow-up.
 	// See PR #220 review thread.
 	spec.ShareProcessNamespace = ptr.To(true)
-	// FSGroup grants the non-root sidecar UID read access to 0o400
-	// Secret-projected files. ChangePolicy=OnRootMismatch avoids recursive
-	// chown on every pod start (the "Always" default is costly on archive PVCs).
-	// fsGroup with OnRootMismatch is the load-bearing migration primitive:
-	// on first mount of a legacy root-owned PVC, kubelet recursively chowns
-	// the volume's gid to sidecarNonRootUID and adds group rwX. seid + the
-	// sidecar both run as uid sidecarNonRootUID and access chain data via
-	// group perms. On subsequent mounts kubelet sees the root gid already
-	// matches and skips the walk — near-zero cost. New files seid creates
-	// land as uid:gid sidecarNonRootUID:sidecarNonRootUID via the process's
-	// own primary identity; legacy files retain uid 0 but become readable
-	// via the recursive gid chown. The volume self-converges to uniform
-	// uid 65532 ownership over time as files rotate.
+	// Kubelet handles PVC ownership migration: on first mount of a legacy
+	// root-owned volume, OnRootMismatch triggers a recursive `chown :65532`
+	// + `chmod g+rwX`. Subsequent mounts skip the walk.
 	fsGroup := sidecarNonRootUID
 	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
 	spec.SecurityContext = &corev1.PodSecurityContext{
@@ -620,11 +610,9 @@ func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	return container
 }
 
-// buildSeidInitContainer runs `seid init` on first boot to materialize
-// /sei/config and ensures /sei/tmp exists. Runs as non-root; PVC
-// ownership is handled by kubelet's fsGroup OnRootMismatch (see
-// PodSecurityContext setup in buildNodePodSpec), so this container
-// needs no caps and no chown logic.
+// buildSeidInitContainer materializes /sei/config on first boot via
+// `seid init` and ensures /sei/tmp exists. No chown logic — kubelet
+// fsGroup handles PVC ownership.
 func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	script := fmt.Sprintf(
 		`if [ -f %s/config/genesis.json ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home %s --overwrite; fi && mkdir -p %s/tmp`,
@@ -643,15 +631,10 @@ func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	}
 }
 
-// seidNonRootSecurityContext is shared between seid main and seid-init.
-// Both run the same binary, share the same /sei mount, and have the same
-// (low) privilege needs. ReadOnlyRootFilesystem is deliberately omitted —
-// seid is a Go binary that may use /tmp on the rootfs; the sidecar can
-// enforce RORFS because we mount an emptyDir at its /tmp, and we don't
-// duplicate that wiring on seid containers.
-//
-// PSA `restricted`-eligible: RunAsNonRoot, RunAsUser>0, drop ALL caps,
-// no privilege escalation, RuntimeDefault seccomp.
+// seidNonRootSecurityContext is shared by seid main and seid-init (same
+// binary, same mount, same privilege floor). PSA `restricted`-eligible.
+// ReadOnlyRootFilesystem omitted: seid's Go runtime may use /tmp on the
+// rootfs and we don't wire an emptyDir for it on seid containers.
 func seidNonRootSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		RunAsNonRoot:             ptr.To(true),              //nolint:modernize // ptr.To(true) is idiomatic; new(true) is invalid Go

--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -635,6 +635,7 @@ func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 // binary, same mount, same privilege floor). PSA `restricted`-eligible.
 // ReadOnlyRootFilesystem omitted: seid's Go runtime may use /tmp on the
 // rootfs and we don't wire an emptyDir for it on seid containers.
+// Closing this gap is tracked in #230.
 func seidNonRootSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		RunAsNonRoot:             ptr.To(true),              //nolint:modernize // ptr.To(true) is idiomatic; new(true) is invalid Go

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -1,7 +1,6 @@
 package noderesource
 
 import (
-	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -1045,18 +1044,6 @@ func TestSidecarContainer_SecurityContext(t *testing.T) {
 	g.Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
 }
 
-func TestSeidMainContainer_NoSecurityContextChange(t *testing.T) {
-	g := NewWithT(t)
-	node := newSnapshotNode("snap-0", "default")
-
-	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
-	seid := findContainer(sts.Spec.Template.Spec.Containers, "seid")
-	g.Expect(seid).NotTo(BeNil())
-	// seid main container hardening is an out-of-scope, larger blast-radius
-	// change owned by a different workstream.
-	g.Expect(seid.SecurityContext).To(BeNil())
-}
-
 func TestPodSpec_FSGroup(t *testing.T) {
 	g := NewWithT(t)
 	node := newSnapshotNode("snap-0", "default")
@@ -1064,20 +1051,34 @@ func TestPodSpec_FSGroup(t *testing.T) {
 	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
 	g.Expect(sts.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
 	g.Expect(*sts.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(int64(65532)),
-		"pod-level fsGroup must match sidecar UID so non-root sidecar can read 0o400 Secret mounts")
+		"pod-level fsGroup is the migration primitive — kubelet OnRootMismatch chowns the volume gid on first mount")
+	g.Expect(*sts.Spec.Template.Spec.SecurityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch),
+		"OnRootMismatch keeps the chown cost to once-per-PVC")
+	g.Expect(sts.Spec.Template.Spec.SecurityContext.SupplementalGroups).To(BeEmpty(),
+		"workaround for root-seid is no longer needed once seid runs as gid 65532 natively")
 }
 
-func TestPodSpec_SupplementalGroups(t *testing.T) {
+func TestSeidMainContainer_RunsAsNonRoot(t *testing.T) {
 	g := NewWithT(t)
 	node := newSnapshotNode("snap-0", "default")
 
 	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
-	g.Expect(sts.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
-	g.Expect(sts.Spec.Template.Spec.SecurityContext.SupplementalGroups).To(ContainElement(int64(65532)),
-		"seid (uid 0) must be a member of the sidecar gid to write into gid-65532-owned dirs")
+	seid := findContainer(sts.Spec.Template.Spec.Containers, "seid")
+	g.Expect(seid).NotTo(BeNil())
+	expectSeidNonRootSecurityContext(g, seid.SecurityContext)
 }
 
-func TestSeidInitContainer_PreparesSharedDirs(t *testing.T) {
+func TestSeidInitContainer_RunsAsNonRoot(t *testing.T) {
+	g := NewWithT(t)
+	node := newGenesisNode("mynet-0", "default")
+
+	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
+	seidInit := findInitContainer(sts.Spec.Template.Spec.InitContainers, "seid-init")
+	g.Expect(seidInit).NotTo(BeNil())
+	expectSeidNonRootSecurityContext(g, seidInit.SecurityContext)
+}
+
+func TestSeidInitContainer_BareScript(t *testing.T) {
 	g := NewWithT(t)
 	node := newGenesisNode("mynet-0", "default")
 
@@ -1087,32 +1088,25 @@ func TestSeidInitContainer_PreparesSharedDirs(t *testing.T) {
 	g.Expect(seidInit.Command).To(HaveLen(3))
 
 	script := seidInit.Command[2]
-	mkdirIdx := strings.Index(script, "mkdir -p /sei/config /sei/data")
-	chownIdx := strings.Index(script, "chown 0:65532 /sei /sei/config /sei/data")
-	chmodIdx := strings.Index(script, "chmod 2775 /sei /sei/config /sei/data")
-	seidInitIdx := strings.Index(script, "seid init")
-
-	g.Expect(mkdirIdx).To(BeNumerically(">=", 0))
-	g.Expect(chownIdx).To(BeNumerically(">", mkdirIdx))
-	g.Expect(chmodIdx).To(BeNumerically(">", chownIdx))
-	g.Expect(seidInitIdx).To(BeNumerically(">", chmodIdx),
-		"shared-dir prep must precede seid init so subsequent files inherit setgid group")
+	// Migration logic (chown, chmod, sentinel) lives in the kubelet via
+	// fsGroup OnRootMismatch — not in this script.
+	g.Expect(script).NotTo(ContainSubstring("chown"))
+	g.Expect(script).NotTo(ContainSubstring("chmod"))
+	g.Expect(script).To(ContainSubstring("seid init sei-test --chain-id sei-test --home /sei --overwrite"))
+	g.Expect(script).To(ContainSubstring("mkdir -p /sei/tmp"))
 }
 
-func TestSeidInitContainer_SecurityContext(t *testing.T) {
-	g := NewWithT(t)
-	node := newGenesisNode("mynet-0", "default")
-
-	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
-	seidInit := findInitContainer(sts.Spec.Template.Spec.InitContainers, "seid-init")
-	g.Expect(seidInit).NotTo(BeNil())
-	g.Expect(seidInit.SecurityContext).NotTo(BeNil())
-	g.Expect(seidInit.SecurityContext.AllowPrivilegeEscalation).To(Equal(ptr.To(false))) //nolint:modernize // ptr.To(false) is idiomatic; new(false) is invalid Go
-	g.Expect(seidInit.SecurityContext.Capabilities).NotTo(BeNil())
-	g.Expect(seidInit.SecurityContext.Capabilities.Drop).To(ConsistOf(corev1.Capability("ALL")))
-	g.Expect(seidInit.SecurityContext.Capabilities.Add).To(ConsistOf(
-		corev1.Capability("CHOWN"), corev1.Capability("FOWNER"), corev1.Capability("FSETID"),
-	))
+func expectSeidNonRootSecurityContext(g Gomega, sc *corev1.SecurityContext) {
+	g.Expect(sc).NotTo(BeNil())
+	g.Expect(sc.RunAsNonRoot).To(Equal(ptr.To(true)))              //nolint:modernize
+	g.Expect(sc.RunAsUser).To(Equal(ptr.To(int64(65532))))         //nolint:modernize
+	g.Expect(sc.RunAsGroup).To(Equal(ptr.To(int64(65532))))        //nolint:modernize
+	g.Expect(sc.AllowPrivilegeEscalation).To(Equal(ptr.To(false))) //nolint:modernize
+	g.Expect(sc.Capabilities).NotTo(BeNil())
+	g.Expect(sc.Capabilities.Drop).To(ConsistOf(corev1.Capability("ALL")))
+	g.Expect(sc.Capabilities.Add).To(BeEmpty())
+	g.Expect(sc.SeccompProfile).NotTo(BeNil())
+	g.Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
 }
 
 // --- assertNoOperatorKeyringOnSeidContainers ---


### PR DESCRIPTION
## Summary

Closes the SeiNode pod security story (#230). Collapses the asymmetry workaround from #229 by running **all three SeiNode pod containers as uid 65532** and leaning on kubelet's existing `fsGroup=65532` + `FSGroupChangePolicy=OnRootMismatch` to handle PVC ownership transitions natively.

**Supersedes #232** (which built an in-controller migration shell with sentinel files). That PR was scrapped after Coral trio review independently concluded that kubelet's primitives already do the job — permanent controller complexity for transient state across <10 nodes is the wrong trade.

## What ships

| Container | Before | After |
|---|---|---|
| `seid` main | no SecurityContext (ran as root) | non-root SecurityContext (`RunAsUser/Group=65532`, drop ALL, no privesc, RuntimeDefault) |
| `seid-init` | uid 0 with `CHOWN/FOWNER/FSETID` caps + chown/chmod shell logic | non-root SecurityContext (same as seid main); script collapses to `seid init` (if needed) + `mkdir tmp` |
| `sei-sidecar` | non-root from #220 | unchanged |
| `PodSecurityContext.SupplementalGroups` | `[65532]` (workaround for root-seid writing into gid-65532 dirs) | removed |
| `fsGroup=65532` + `OnRootMismatch` | present | unchanged — now load-bearing |

The diff is ~70 lines net. Two test files, one source file. No new packages, no embedded templates, no sentinel constants.

## Why kubelet's fsGroup is the right primitive

Validated by Coral trio (k8s, platform, security) with online research where possible:

- **Kubelet `SetVolumeOwnership`** (`pkg/volume/volume_linux.go`, stable since 1.23) walks the volume on root-mismatch and applies `chown(-1, fsGroup)` + `chmod g+rw` on files / `g+rwx` on dirs with setgid. Once volume root gid matches, kubelet does a single `stat()` and skips the walk.
- **EBS CSI driver** doesn't advertise `VOLUME_MOUNT_GROUP`, so kubelet (not the driver) owns the walk. xfs/ext4 identical. Verified `ebs.csi.aws.com` is `fsGroupPolicy: ReadWriteOnceWithFSType` on harbor; SeiNode PVCs default to `ReadWriteOnce` so the policy applies.
- **Cosmos SDK / CometBFT** never call `Chown`; `priv_validator_state.json` uses `WriteFileAtomic` (O_CREAT + rename), files inherit the process's primary gid. No UID-match assertions anywhere in the codepath.
- **Legacy uid 0 files** stay owned uid 0; seid reads via group perms. New files written by seid (every block: state JSON, WAL rotation, SST compaction) land as 65532:65532. The volume self-converges to uniform 65532 ownership over time.

## Operational impact

- **First-mount cost** on a non-empty legacy PVC: pod sits in `ContainerCreating` during the kubelet walk. Bound by inode count, not bytes.
  - Harbor smoke chains (<100GB / few-thousand inodes): sub-second to seconds.
  - Prod archive nodes (~10TB / ~50M files on EBS gp3 cold metadata): 10-30 min one-time per PVC.
- **Subsequent mounts**: single `stat()` on volume root; near-zero.
- **PSA `restricted` eligibility**: now achievable. No container in a SeiNode pod runs as uid 0. Namespaces can be labeled `pod-security.kubernetes.io/enforce=restricted` once the rollout completes.
- **Rollback safety**: rolling back to a #229-era controller is functionally safe — seid runs as uid 0 again with `CAP_DAC_OVERRIDE`, bypasses DAC, reads/writes 65532-owned files fine. The pre-this-PR controller already sets `supplementalGroups=[65532]` so the workaround layer is back in place automatically. **One-way door to flag**: kubelet only chowns the volume gid on mount; once this PR has run on a PVC, those files are gid 65532 permanently (rollback does not un-chown). This is fine for any controller version that has fsGroup wiring (which is everything since #229). Rolling back further than #229 would technically still work via DAC_OVERRIDE but the supplementalGroups workaround would be missing — not relevant in practice given current fleet state.
- **BYOV ergonomics**: imported PVCs work transparently — `OnRootMismatch` keys on volume-root gid regardless of provenance. No documented constraint needed for engineers.

## Operator runbook

- **No operator action required.** Bump the controller image; existing SeiNodes pick up the new pod template via the `NodeUpdate` plan's `replace-pod` task. Kubelet handles the chown on first restart per PVC.
- **What you see during rollout**: each SeiNode's pod restarts; on first restart under the new controller, pod stays in `ContainerCreating` for the kubelet walk duration (seconds for harbor, minutes for prod archives). Then Ready as normal.
- **Recovery if a specific PVC misbehaves**: `kubectl delete pod` to force a remount — fsGroup runs again because root gid still matches (it's not the chown that failed if seid then EACCESes; suspect the file in question).

## Coral trio review

Three rounds. All three converged on this shape after independently rejecting #232's controller-side migration approach:
- **k8s-specialist**: validated kubelet `SetVolumeOwnership` semantics, CometBFT file ops, KEP-695 (`FSGroupChangePolicy`).
- **platform-engineer**: validated rollout signature, EBS CSI behavior, monitoring loss (negligible), rollback safety.
- **security-specialist**: validated PSA `restricted` eligibility, sidecar-compromise blast radius (no expansion given pre-existing `ShareProcessNamespace`), keyring containment unchanged.

## Deferred to tracking issues

- **`ShareProcessNamespace=true`** between seid and sidecar means a compromised sidecar can `/proc/<seid>/mem` regardless of filesystem boundaries — the same-uid posture in this PR doesn't materially change the blast radius. Real fix is a separate workstream (drop shareProcessNamespace, separate SAs). Security flagged.
- **Bootstrap Job pod-spec** (`internal/task/bootstrap_resources.go`) still runs seid as root. Bootstrap pods carry no credentials per the existing containment comment. Optional cleanup; not required for this PR's correctness because the StatefulSet pod's seid-init + kubelet's fsGroup migrate whatever bootstrap wrote.
- **Pre-existing ChainID command-injection** in `seid init %s --chain-id %s` — separate security tracking issue.
- **Replace `seid-init` entirely with `postStart` hook on the sidecar** — k8s flagged as a future cut.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go test ./...`
- [x] `go test -race ./internal/noderesource/...`
- [x] `golangci-lint run --new-from-rev=origin/main` (0 issues)
- [x] Coral trio (platform, k8s, security) cross-review — three rounds, all converged
- [ ] Smoke: harbor controller bumped, fresh genesis chain reaches Ready end-to-end (the test #229 didn't complete). Existing harbor Failed SeiNodes (`harbor-pr-229-{0,1}`) deleted; SeiNodeDeployment recreates fresh on the new pod template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)