### PR TITLE
feat(platform): flip dataDir to conventional /.sei home layout

### DIFF
--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -939,7 +939,7 @@ func TestNodeKey_BothMountsCoexist(t *testing.T) {
 	g.Expect(signingMount).NotTo(BeNil())
 	g.Expect(nodeMount).NotTo(BeNil())
 	g.Expect(signingMount.MountPath).NotTo(Equal(nodeMount.MountPath),
-		"signing-key and node-key mounts must target distinct paths under /sei/config/")
+		"signing-key and node-key mounts must target distinct paths under dataDir/config/")
 }
 
 // --- Operator keyring (validator) ---
@@ -1116,7 +1116,7 @@ func TestSeidInitContainer_BareScript(t *testing.T) {
 	// lock-step with the HOME env var declared on the container.
 	g.Expect(script).To(ContainSubstring(`seid init sei-test --chain-id sei-test --home "$HOME" --overwrite`))
 	g.Expect(script).To(ContainSubstring(`mkdir -p "$HOME/tmp"`))
-	g.Expect(script).NotTo(ContainSubstring("/sei"),
+	g.Expect(script).NotTo(ContainSubstring(dataDir),
 		"no hardcoded data dir — script must route through $HOME")
 
 	env := map[string]string{}
@@ -1145,7 +1145,7 @@ func expectSeidNonRootSecurityContext(g Gomega, sc *corev1.SecurityContext) {
 const (
 	keyringTestSeidInitName        = "seid-init"
 	keyringTestSidecarName         = "sei-sidecar"
-	keyringTestMountPath           = "/sei/keyring-file"
+	keyringTestMountPath           = "/.sei/keyring-file"
 	keyringTestPassphraseSecret    = "validator-0-opk-pass"
 	keyringTestPassphraseSecretKey = "passphrase"
 )

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -7,7 +7,11 @@ import (
 
 const (
 	// DataDir is the mount path for the sei data volume inside node pods.
-	DataDir = "/sei"
+	// `/.sei` follows the conventional Cosmos SDK home layout (`~/.sei`),
+	// resolved against the seid container's HOME env var. Lock-step with
+	// the SEI_HOME env var injected on the sidecar container; both flow
+	// from this single constant.
+	DataDir = "/.sei"
 
 	// modeArchive matches seiconfig.ModeArchive without importing sei-config.
 	modeArchive = "archive"

--- a/manifests/samples/seinode/pacific-1-full-node.yaml
+++ b/manifests/samples/seinode/pacific-1-full-node.yaml
@@ -12,10 +12,6 @@ spec:
   chainId: pacific-1
   image: "ghcr.io/sei-protocol/sei:v6.3.0"
 
-  entrypoint:
-    command: ["seid"]
-    args: ["start", "--home", "/sei"]
-
   sidecar:
     image: ghcr.io/sei-protocol/seictl@sha256:2cb320dd583000765520293d4e28ecc79fed4432c76760923d3aaa47803a4dbf
 

--- a/manifests/samples/seinode/pacific-1-shadow-replayer.yaml
+++ b/manifests/samples/seinode/pacific-1-shadow-replayer.yaml
@@ -16,10 +16,6 @@ spec:
   sidecar:
     image: ghcr.io/sei-protocol/seictl@sha256:2cb320dd583000765520293d4e28ecc79fed4432c76760923d3aaa47803a4dbf
 
-  entrypoint:
-    command: ["seid"]
-    args: ["start", "--home", "/sei", "--skip-app-hash-validation"]
-
   overrides:
     giga_executor.enabled: "true"
     giga_executor.occ_enabled: "true"

--- a/manifests/samples/seinode/pacific-1-snapshotter.yaml
+++ b/manifests/samples/seinode/pacific-1-snapshotter.yaml
@@ -15,10 +15,6 @@ spec:
   sidecar:
     image: ghcr.io/sei-protocol/seictl@sha256:2cb320dd583000765520293d4e28ecc79fed4432c76760923d3aaa47803a4dbf
 
-  entrypoint:
-    command: ["seid"]
-    args: ["start", "--home", "/sei"]
-
   peers:
     - ec2Tags:
         region: eu-central-1

--- a/manifests/samples/seinode/pacific-1-state-syncer.yaml
+++ b/manifests/samples/seinode/pacific-1-state-syncer.yaml
@@ -14,10 +14,6 @@ spec:
   sidecar:
     image: ghcr.io/sei-protocol/seictl@sha256:2cb320dd583000765520293d4e28ecc79fed4432c76760923d3aaa47803a4dbf
 
-  entrypoint:
-    command: ["seid"]
-    args: ["start", "--home", "/sei"]
-
   genesis:
     s3:
       uri: s3://sei-testnet-genesis-config/pacific-1/genesis.json

--- a/manifests/samples/seinodedeployment/genesis-ceremony.yaml
+++ b/manifests/samples/seinodedeployment/genesis-ceremony.yaml
@@ -26,10 +26,6 @@ spec:
       chainId: genesis-test-1
       image: "ghcr.io/sei-protocol/sei:v6.3.0"
 
-      entrypoint:
-        command: ["seid"]
-        args: ["start", "--home", "/sei"]
-
       sidecar:
         image: ghcr.io/sei-protocol/seictl@sha256:2cb320dd583000765520293d4e28ecc79fed4432c76760923d3aaa47803a4dbf
 

--- a/manifests/samples/seinodedeployment/pacific-1-rpc-group.yaml
+++ b/manifests/samples/seinodedeployment/pacific-1-rpc-group.yaml
@@ -20,10 +20,6 @@ spec:
       chainId: pacific-1
       image: "ghcr.io/sei-protocol/sei:v6.3.0"
 
-      entrypoint:
-        command: ["seid"]
-        args: ["start", "--home", "/sei"]
-
       sidecar:
         image: ghcr.io/sei-protocol/seictl@sha256:2cb320dd583000765520293d4e28ecc79fed4432c76760923d3aaa47803a4dbf
 


### PR DESCRIPTION
## Summary

PR 3b of the home-path migration sequence (1 = sei-protocol/sei-k8s-controller#234, 2 = sei-protocol/platform#522). This one flips `platform.DataDir` from `/sei` to the conventional Cosmos SDK home layout `/.sei` (i.e. `~/.sei` resolved against the seid container's HOME env).

The diff is two commits:

1. **The flip itself** (`55f5972`): single-line change in `internal/platform/platform.go` + three test literal fixes routed through the `dataDir` constant.
2. **Sample manifest cleanup** (`54ed008`): strips the deprecated `spec.entrypoint` blocks from all 6 in-tree samples — same shape as platform#522 applied to the fleet. The k8s-specialist flagged this as a sign-off blocker because the samples otherwise become misleading copy-paste material post-flip.

## Mental model — verified by Coral trio

Single source of truth: `platform.DataDir`. Every reference routes through it:

- **seid main container**: `mountPath`, `HOME` env, and `--home \$(HOME)` (K8s VariableReference resolved by kubelet) all become `/.sei`.
- **sidecar container**: `mountPath` and `SEI_HOME` env both become `/.sei`. seictl reads `SEI_HOME` via its top-level `--home` flag's env source (`seictl/main.go:54-66`); all task handlers receive `homeDir` from that single value. No coordinated sidecar bump needed.
- **bootstrap ceremony container**: same shape.

PVC content is filesystem-relative — lives at the volume root inode, not under `/sei`. The flip is a kernel-side mount-path change; no bytes move. Round-trip safe.

## Cross-review

Coral trio sign-off against this exact diff:

- **platform-engineer**: GO. No coordinated sidecar bump required (sidecar pin holds; `SEI_HOME` contract is durable). Recommended overlay SHA pins for canary, but that's orthogonal — deferred.
- **kubernetes-specialist**: Conditional GO — required the sample manifest cleanup, which is the second commit on this branch. Now satisfied.
- **security-specialist**: GO. No threat model delta. Earlier follow-ups (#236 ChainID validation, #237 snapshot uploader scope) unchanged in urgency. Dotfile-convention exploit path remains theoretical in our stack.

## Rollout

Pod-spec change with no controller-image change required by *this PR alone*. `buildRunningPlan` only triggers `NodeUpdate` plans on `spec.image` drift (`internal/planner/planner.go:708`), so existing SeiNodes stay on their current template until each chain's `spec.image` is bumped. Same propagation mechanism PR 1 (#234) used. sei-protocol/sei-k8s-controller#235 tracks extending drift detection to pod-template-hash, which would let this flip propagate automatically.

Order of operations to fleet-roll the new layout:

1. Merge this PR → controller builds with `platform.DataDir = "/.sei"`.
2. Controller image bumps on dev/prod (default image in `config/manager/manager.yaml` will pick this up on next bump; harbor's overlay-pinned image needs its own bump).
3. Per-chain `spec.image` bumps → `NodeUpdate` plans → new pods come up with mount at `/.sei`. Sequence harbor → dev → prod-non-archives → prod-archives, with pre-flight snapshot of archive PVCs.

## Follow-up filed

- #239 — Restore surface for non-default seid args (shadow-replayer use case). Surfaced during the sample cleanup: `pacific-1-shadow-replayer.yaml` was pinning `--skip-app-hash-validation` via `spec.entrypoint`, which #234 silently drops. Real gap, separate scope.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test ./...` green
- [x] `go test -race ./...` green
- [x] `golangci-lint run --new-from-rev=origin/main` clean
- [x] Coral trio sign-off against the final diff
- [x] Post-merge: controller image bumps on dev/prod (separate platform PR)
- [x] Post-merge: per-chain `spec.image` bumps trigger `NodeUpdate` plans; new pods mount at `/.sei`; `HOME=/.sei` resolves cleanly for `eth_accounts` and friends — *verified indirectly via `HOME=/.sei` env on rolled pods + zero `permission denied` errors in seid logs + chain producing blocks. Literal `eth_accounts` curl wasn't executed (seid bound port 8545 to a non-loopback address; port-forward returned connection refused). Fix is confirmed working in practice.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)