### PR TITLE
chore(config): bump default manager image to 8a896d9

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:0d3a15608316c806f9792d65b99fbf81b213a414
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8a896d9079ffdd18ac8ae58ee821828dd5ea3011
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Bumps the default manager image in `config/manager/manager.yaml` from `0d3a156` to `8a896d9`. This is the image inherited by **dev** and **prod** clusters (both consume `github.com/sei-protocol/sei-k8s-controller/config/default?ref=main` with no overlay-level image pin), so this bump deploys to both clusters on next Flux reconcile.

**Harbor is unaffected** — it has its own overlay-level pin in the platform repo and was bumped to `8a896d9` independently via sei-protocol/platform#523.

## Cumulative changes since 0d3a156 (prior pin)

| PR | Change |
|---|---|
| #240 | `platform.DataDir` flip from `/sei` to the conventional Cosmos SDK home layout `/.sei`. HOME on seid container, SEI_HOME on sidecar container, mountPath, and `--home \$(HOME)` all route through the single `platform.DataDir` constant. Test fixtures updated; in-tree sample manifests cleaned of deprecated `spec.entrypoint`. |

## Validated on harbor

End-to-end test: harbor-pr-229 chain (2 validators + 1 RPC) rolled through `NodeUpdate` plans via digest-bump (same v6.4.4 bits, different image string to trip the drift comparator). Came up with `mountPath=/.sei`, `HOME=/.sei` on seid, `SEI_HOME=/.sei` on sidecar, kept producing consensus. Validation block in the workspace-repo PR (sei-protocol/harbor-engineering-workspace#8).

## Rollout shape

Controller bump is **passive on existing dev/prod pods**. `buildRunningPlan` (`internal/planner/planner.go:708`) only triggers `NodeUpdate` plans on `spec.image` drift — env/args/mountPath changes alone don't propagate. Per-chain image bumps in the gitops repo are what actually roll pods onto the new `/.sei` template.

For dev's `release-6-5/*` (bdchatham mock images): tag → digest bump or next mock image bump.

For prod chains (arctic-1, atlantic-2, pacific-1):
- Non-archives first (syncer, node, shadow-giga) — sequenced one at a time, digest-bump trigger (same seid version)
- Archives last (multi-TB PVCs) — pre-flight PVC snapshot per chain; the first roll under the new template will fire the kubelet fsGroup recursive chown if the volume root isn't already group 65532

## Test plan

- [x] Image `8a896d9` published to ECR (CI/ECR workflows on sei-k8s-controller@main both succeeded)
- [x] Harbor end-to-end validated (post-platform#523 + post-harbor-engineering-workspace#8)
- [x] Post-merge: dev Flux reconciles → controller pods roll to `8a896d9`
- [x] Post-merge: prod Flux reconciles → controller pods roll to `8a896d9` (3 replicas)
- [x] Per-chain SND image bumps on **prod pacific-1** exercised the new template (sei-protocol/platform#525 — 4 of 5 SNDs rolled; shadow-giga out of scope). **Dev**: no live chains (release-6-5 decommissioned via sei-protocol/platform#529). **Prod arctic-1 / atlantic-2**: not exercised in this workstream — rollout will happen on next natural image bump for those chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)