### PR TITLE
chore: bump manager image to :92a79436 (post-#244)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8a896d9079ffdd18ac8ae58ee821828dd5ea3011
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:92a79436b60a5d602c6f294dbcf19e581c6e477f
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Bumps `config/manager/manager.yaml` from `:8a896d90` → `:92a79436` (the merge commit of #244). Cuts dev + prod over to the new `.status.endpoints` shape.

```diff
- image: ...sei-k8s-controller:8a896d9079ffdd18ac8ae58ee821828dd5ea3011
+ image: ...sei-k8s-controller:92a79436b60a5d602c6f294dbcf19e581c6e477f
```

## Why this affects both dev and prod (and not harbor)

dev's and prod's Flux kustomizations both reference `github.com/sei-protocol/sei-k8s-controller/config/default?ref=main` with **no image override** in their respective `manager-patch.yaml` files. So they inherit whatever image tag this manifest pins. Harbor pins its own image via `clusters/harbor/sei-k8s-controller/manager-patch.yaml` and was cut over in sei-protocol/platform#534 already.

## Pre-merge requirement on prod

The new controller's typed Go decoder can't read existing-stored SND `.status.endpoints` in the OLD `[]string`-per-protocol shape — `json.Unmarshal` errors on array-into-string mismatch and the informer can't list. Before this PR merges, the operator must pre-patch each SND in pacific-1 to remove `.status.endpoints` so the new controller starts on clean state and repopulates with the new shape on first reconcile.

Validated end-to-end on harbor earlier today (#534):
- 3 SNDs pre-patched (`pacific-1/syncer-0`, `eng-brandon/harbor-pr-229`, `eng-brandon/harbor-pr-229-rpc`)
- Flux applied new image, controller pods rolled cleanly (0 restarts, no decode errors)
- All 3 SNDs reconciled to new-shape `.status.endpoints` within seconds: scalar `tendermintRpc`/`tendermintRest` + per-pod `nodes[].evmJsonRpc`/`evmWs`

## Dev

No SNDs in dev currently. New controller will start with no reconciliation work; trivial cutover.

## Coordination

Don't merge until operator confirms prod SND pre-patch is complete. Sequence:
1. Operator runs `kubectl patch snd ... --subresource=status -p '{"status":{"endpoints":null}}'` on each prod SND (4 in pacific-1).
2. Verify all show `endpoints=` empty.
3. Merge this PR.
4. Trigger Flux reconcile on dev + prod (annotation-based) for fast cutover.
5. Verify controller image flips, pods cycle, prod SNDs repopulate `.status.endpoints` in new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)