### PR TITLE
chore(config): bump default manager image to d9b15de (post-#257)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:92a79436b60a5d602c6f294dbcf19e581c6e477f
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:d9b15dec8b20485390588c9fface0e33d68db9df
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Auto-style bump following the merge of [#257](https://github.com/sei-protocol/sei-k8s-controller/pull/257). Image built and pushed to ECR at 2026-05-16T12:02:08-07:00.

```
189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:d9b15dec8b20485390588c9fface0e33d68db9df
```

Manual bump — usually the auto-bump workflow opens this, but didn't trigger today; opening manually to unblock the platform image-roll that's required before the kubectl sweep tracked on [platform#580](https://github.com/sei-protocol/platform/issues/580) can run.

After this merges, Flux on the platform cluster reconciles the new image tag (the platform kustomization references `config/default?ref=main`), the manager Deployment rolls, and the ServiceMonitor reconciler is gone from the live binary.