### PR TITLE
chore(config): bump default manager image to b2b4742 (post-#267)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:d9b15dec8b20485390588c9fface0e33d68db9df
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:b2b4742773cf0e333e373b58736988119b5c51df
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Image bump following the TLS-removal merge in #267.