### PR TITLE
chore: audit godocs across all packages for accuracy and terseness

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -91,10 +91,10 @@ type SnapshotSource struct {
 	BootstrapImage string `json:"bootstrapImage,omitempty"`
 }
 
-// S3SnapshotSource configures snapshot download from an S3 bucket.
-// The controller infers the bucket from the chain ID using the well-known
-// convention {chainId}-snapshots/state-sync/ and selects the latest snapshot
-// via latest.txt.
+// S3SnapshotSource configures snapshot download from the platform
+// snapshot bucket. The sidecar resolves objects under
+// {SEI_SNAPSHOT_BUCKET}/{chainID}/state-sync/ and selects the latest
+// snapshot via latest.txt.
 type S3SnapshotSource struct {
 	// TargetHeight is the block height the node should sync to after restoring.
 	// +kubebuilder:validation:Minimum=1

--- a/api/v1alpha1/networking_types.go
+++ b/api/v1alpha1/networking_types.go
@@ -10,14 +10,19 @@ const (
 	DeletionPolicyRetain DeletionPolicy = "Retain"
 )
 
-// NetworkingConfig enables public networking for the deployment.
+// NetworkingConfig is a presence-signal struct: its presence on a
+// SeiNodeDeployment opts the deployment into public networking.
 //
-// When present, the controller creates a ClusterIP Service (as the
-// HTTPRoute backend) and generates HTTPRoute resources on the platform
-// Gateway for each protocol the node mode supports. Hostnames are
-// derived automatically from the deployment name, namespace, and the
-// platform domain env vars.
+// Present: the controller provisions a ClusterIP Service plus HTTPRoute
+// resources on the platform Gateway for each protocol the node mode
+// supports, with hostnames derived from the deployment name, namespace,
+// and platform domain env vars.
 //
-// When absent (nil), the deployment is private — only per-node headless
-// Services exist for in-cluster access.
+// Absent (nil): the deployment is in-cluster only — the unconditional
+// internal ClusterIP Service and per-node headless Services exist, but
+// no Gateway-attached routes are created.
+//
+// The empty-struct shape is intentional. Concrete knobs (TLS, hostname
+// override, gateway-class selection) will be added here when real needs
+// emerge; the type exists today only to carry presence.
 type NetworkingConfig struct{}

--- a/api/v1alpha1/seinode_types.go
+++ b/api/v1alpha1/seinode_types.go
@@ -127,7 +127,7 @@ func (s *SeiNodeSpec) SnapshotSource() *SnapshotSource {
 // Status
 // ---------------------------------------------------------------------------
 
-// TaskPlanPhase represents the overall state of an initialization plan.
+// TaskPlanPhase represents the overall state of a TaskPlan.
 // +kubebuilder:validation:Enum=Active;Complete;Failed
 type TaskPlanPhase string
 
@@ -137,7 +137,7 @@ const (
 	TaskPlanFailed   TaskPlanPhase = "Failed"
 )
 
-// TaskStatus represents the lifecycle state of a task (plan, monitor, etc.).
+// TaskStatus is the lifecycle state of a single PlannedTask.
 // +kubebuilder:validation:Enum=Pending;Complete;Failed
 type TaskStatus string
 

--- a/internal/controller/observability/metrics.go
+++ b/internal/controller/observability/metrics.go
@@ -1,3 +1,6 @@
+// Package observability holds the shared OTel meter/attribute keys and the
+// PhaseTracker used by both controllers to surface kube-state-metrics-style
+// phase gauges and reconcile counters.
 package observability
 
 import (

--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -436,10 +436,10 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) (corev1.PodSp
 	pool := p.NodepoolForMode(NodeMode(node))
 
 	spec := corev1.PodSpec{
-		// AutomountServiceAccountToken is explicit here because the future
-		// kube-rbac-proxy fronting the sidecar API (sei-protocol/seictl#165)
-		// calls TokenReview + SubjectAccessReview against the K8s API using
-		// the pod's projected SA token. Cluster-default flips that silently
+		// AutomountServiceAccountToken is explicit here because the
+		// kube-rbac-proxy fronting the sidecar API calls TokenReview +
+		// SubjectAccessReview against the K8s API using the pod's
+		// projected SA token. Cluster-default flips that silently
 		// disable this would break the auth path.
 		AutomountServiceAccountToken: ptr.To(true), //nolint:modernize // ptr.To(true) is idiomatic; new(true) is invalid Go
 		ServiceAccountName:           p.ServiceAccount,
@@ -466,10 +466,8 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) (corev1.PodSp
 	// compromised seid container can therefore read /proc/<sidecar>/environ
 	// and /proc/<sidecar>/mem, including the operator-keyring passphrase and
 	// the unlocked in-memory keyring. This is a known limitation of the v1
-	// trust boundary — not a one-way door. The broader sidecar/seid isolation
-	// hardening (drop shareProcessNamespace, harden the seid main container's
-	// SecurityContext, separate the sidecar's SA) is tracked as a follow-up.
-	// See PR #220 review thread.
+	// trust boundary; tightening it (drop shareProcessNamespace, harden the
+	// seid SecurityContext, separate sidecar SA) is a separate workstream.
 	spec.ShareProcessNamespace = ptr.To(true)
 	// Kubelet handles PVC ownership migration: on first mount of a legacy
 	// root-owned volume, OnRootMismatch triggers a recursive `chown :65532`
@@ -743,8 +741,7 @@ func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 // seidNonRootSecurityContext is shared by seid main and seid-init (same
 // binary, same mount, same privilege floor). PSA `restricted`-eligible.
 // ReadOnlyRootFilesystem omitted: seid's Go runtime may use /tmp on the
-// rootfs and we don't wire an emptyDir for it on seid containers.
-// Closing this gap is tracked in #230.
+// rootfs and no emptyDir is wired for it on seid containers.
 func seidNonRootSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		RunAsNonRoot:             ptr.To(true),              //nolint:modernize // ptr.To(true) is idiomatic; new(true) is invalid Go
@@ -930,8 +927,8 @@ func sidecarSecurityContext() *corev1.SecurityContext {
 	}
 }
 
-// RBACProxyConfigMapName is the ConfigMap carrying the proxy's
-// resourceAttributes + allow-paths config. Exported for the same reason.
+// RBACProxyConfigMapName returns the name of the ConfigMap carrying the
+// kube-rbac-proxy authorization config for a given SeiNode.
 func RBACProxyConfigMapName(node *seiv1alpha1.SeiNode) string {
 	return node.Name + "-rbac-proxy-config"
 }

--- a/internal/planner/doc.go
+++ b/internal/planner/doc.go
@@ -35,10 +35,13 @@
 //
 // NodeUpdate plans roll out image changes on Running nodes. They are built
 // when spec.image != status.currentImage (drift detection). The task sequence
-// is: apply-statefulset, apply-service, observe-image, mark-ready. The planner
-// sets NodeUpdateInProgress=True on creation and clears it when the plan
-// completes or fails. FailedPhase is empty — failures retry on the next
-// reconcile rather than transitioning to Failed.
+// is: apply-statefulset, apply-service, replace-pod, observe-image, mark-ready.
+// replace-pod proactively deletes pods at the old StatefulSet revision so the
+// rollout proceeds even when seid is intentionally unready (e.g. halted at a
+// chain upgrade height). The planner sets NodeUpdateInProgress=True on
+// creation and clears it when the plan completes or fails. FailedPhase is
+// empty — failures retry on the next reconcile rather than transitioning to
+// Failed.
 //
 // When no drift is detected for a Running node, no plan is built. The node
 // sits in steady state with no active plan.

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -445,9 +445,8 @@ func bootstrapMode(snap *seiv1alpha1.SnapshotSource) string {
 	return "genesis"
 }
 
-// SidecarURLForNode re-exports noderesource.SidecarURLForNode so
-// existing planner callers (and external tests) don't need to update
-// their import path.
+// SidecarURLForNode re-exports noderesource.SidecarURLForNode for callers
+// that already depend on the planner package.
 var SidecarURLForNode = noderesource.SidecarURLForNode
 
 // marshalParams serializes a task params struct to apiextensionsv1.JSON.

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,3 +1,6 @@
+// Package platform exposes the cluster-environment knobs (storage classes,
+// node pools, sidecar/exporter images, S3 buckets, Gateway coordinates)
+// the controller consumes when generating workload resources.
 package platform
 
 import (
@@ -53,7 +56,7 @@ type Config struct {
 	SidecarImage       string
 
 	// CosmosExporterImage is the sei-cosmos-exporter sidecar image.
-	// Required when any SeiNode sets spec.cosmosExporter: true.
+	// The cosmos-exporter container is attached to every SeiNode pod.
 	CosmosExporterImage string
 }
 

--- a/internal/task/ensure_pvc.go
+++ b/internal/task/ensure_pvc.go
@@ -58,8 +58,8 @@ func (e *ensureDataPVCExecution) Execute(ctx context.Context) error {
 	return e.executeCreate(ctx, node)
 }
 
-// executeCreate is Get-then-Create, failing if an unexpected PVC already exists.
-// Fixes #104.
+// executeCreate is Get-then-Create, failing if an unexpected PVC already
+// exists that the SeiNode does not own.
 func (e *ensureDataPVCExecution) executeCreate(ctx context.Context, node *seiv1alpha1.SeiNode) error {
 	desired := noderesource.GenerateDataPVC(node, e.cfg.Platform)
 	if err := ctrl.SetControllerReference(node, desired, e.cfg.Scheme); err != nil {

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -1,3 +1,8 @@
+// Package task contains the concrete TaskExecution implementations the
+// planner enqueues and the executor drives. Controller-side tasks talk
+// to the Kubernetes API; sidecar tasks proxy to the seictl sidecar HTTP
+// API. The registry maps task-type strings (as stored in PlannedTask.Type)
+// to their deserializers.
 package task
 
 import (


### PR DESCRIPTION
## Summary

Sweep godocs across all packages for accuracy and terseness, anchored on the CLAUDE.md philosophy:

> Default to writing no comments. Only add one when the WHY is non-obvious... Don't reference the current task, fix, or callers, since those belong in the PR description and rot as the codebase evolves... No PR references in code comments.

One commit per package so reviewers can diff package-at-a-time.

## Per-package changes

- **api/v1alpha1**: Spell out `NetworkingConfig` presence/absence semantics and that the empty-struct shape is intentional. Drop misleading "initialization plan" / "(plan, monitor, etc.)" framing on `TaskPlanPhase` / `TaskStatus` — plans cover init, update, and group lifecycles. Correct the `S3SnapshotSource` bucket layout to match the actual `{SEI_SNAPSHOT_BUCKET}/{chainID}/state-sync/` convention.
- **platform**: Correct the `CosmosExporterImage` doc — the cosmos-exporter container is unconditionally attached; the doc previously implied a non-existent `spec.cosmosExporter` toggle. Add a package-level doc.
- **noderesource**: Drop "PR #220 review thread" and "tracked in #230" issue breadcrumbs in `ShareProcessNamespace` and `seidNonRootSecurityContext` comments. Drop "(sei-protocol/seictl#165)" + "the future kube-rbac-proxy" framing on `AutomountServiceAccountToken` — the proxy is the live auth path. Replace the dangling "Exported for the same reason" doc on `RBACProxyConfigMapName` with a concrete description.
- **planner**: Update the package doc to include `replace-pod` in the NodeUpdate task sequence and explain why it's there (rollout proceeds even when seid is intentionally unready at a chain upgrade height). Drop "existing callers (and external tests) don't need to update their import path" framing on `SidecarURLForNode`.
- **task**: Add a package-level doc explaining the registry-driven shape (sidecar vs controller-side tasks). Drop "Fixes #104" reference on `ensureDataPVCExecution.executeCreate`.
- **observability**: Add a package-level doc.

## Already in good shape (no commit)

- **cmd**: Minimal exported surface; the existing `initMeterProvider` doc is accurate.
- **internal/sidecartransport**: Package doc and `New` doc were already terse and accurate.
- **internal/platform/platformtest**: One-function fixture; the existing doc is correct.
- **internal/controller/node** and **internal/controller/nodedeployment**: Docstrings already trace cleanly to current behavior; no PR/issue refs were found in active code paths.

## Inaccuracies discovered but not surfaced as docs-only changes

None of the controller-side code carried docstring lies. The CRD-side `S3SnapshotSource` bucket layout was the one factual error and is now fixed.

## Names flagged but not renamed (per audit scope)

- `noderesource.PlatformConfig` is a type alias for `platform.Config` — the alias name is slightly confusing (`PlatformConfig` already exists in `platform` as the package name, not a type). Acceptable as a short-hand re-export; flagged here for visibility, not action.
- `task.taskIDNamespace` and `task.deploymentTaskNamespace` — both UUID v5 namespaces; calling out that this is two distinct UUIDs and not a typo. Currently the docstrings say so. No action.

## Manifest regeneration

`make manifests generate` produced no diff — the docstring edits in `api/v1alpha1/` were either on Go-only types (`TaskPlanPhase`, `TaskStatus`) or on bodies (`NetworkingConfig`, `S3SnapshotSource`) whose field-level descriptions in `seinodedeployment_types.go` / `seinode_types.go` are what kubebuilder lifts into the CRD YAML.

## Test plan

- [x] `GOWORK=off go test ./...` — all green
- [x] `GOWORK=off go vet ./...` — clean
- [x] `make manifests generate` — no manifest diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)