### PR TITLE
fix(noderesource): forward auth headers from kube-rbac-proxy to sidecar

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -950,6 +950,7 @@ func buildRBACProxyContainer(node *seiv1alpha1.SeiNode, p PlatformConfig) corev1
 			fmt.Sprintf("--upstream=http://127.0.0.1:%d/", SidecarPort(node)),
 			"--config-file=" + rbacProxyConfigMountPath + "/config.yaml",
 			"--ignore-paths=" + strings.Join(bypassPaths(), ","),
+			"--auth-header-fields-enabled=true",
 			"--v=0",
 		},
 		Ports: []corev1.ContainerPort{

--- a/internal/noderesource/sidecar_proxy_test.go
+++ b/internal/noderesource/sidecar_proxy_test.go
@@ -20,6 +20,8 @@ func TestPodSpec_AlwaysHasProxyContainer(t *testing.T) {
 	g.Expect(*proxy.RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
 	g.Expect(proxy.Args).To(ContainElement("--insecure-listen-address=0.0.0.0:8443"))
 	g.Expect(proxy.Args).To(ContainElement("--upstream=http://127.0.0.1:7777/"))
+	g.Expect(proxy.Args).To(ContainElement("--auth-header-fields-enabled=true"),
+		"sidecar trusted-header authn mode requires the proxy to forward X-Remote-User")
 
 	for _, a := range proxy.Args {
 		g.Expect(a).NotTo(HavePrefix("--tls-cert-file="), "TLS args must not appear")

--- a/internal/task/bootstrap_resources.go
+++ b/internal/task/bootstrap_resources.go
@@ -161,6 +161,7 @@ func buildBootstrapPodSpec(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.Snapshot
 			fmt.Sprintf("--insecure-listen-address=0.0.0.0:%d", noderesource.RBACProxyPort),
 			fmt.Sprintf("--upstream=http://127.0.0.1:%d/", port),
 			"--config-file=/etc/kube-rbac-proxy/config.yaml",
+			"--auth-header-fields-enabled=true",
 			"--v=0",
 		},
 		Ports: []corev1.ContainerPort{


### PR DESCRIPTION
## Summary

Adds \`--auth-header-fields-enabled=true\` to the kube-rbac-proxy args so the proxy emits \`X-Remote-User\` after a successful TokenReview + SAR. The sidecar runs in \`trusted-header\` authn mode and rejects any upstream-forwarded request that lacks this header with 401.

## How it surfaced

After PR #274 fixed the \`apiGroup\` field name, the smoke test progressed past the proxy's SAR check — and immediately tripped the sidecar's authn:

```
sidecar generate-identity task submission returned 401: {"error":"missing X-Remote-User header"}
```

\`--auth-header-fields-enabled\` defaults to \`false\` in kube-rbac-proxy v0.19.x. With it off, the proxy authorizes successfully but forwards a bare request — the sidecar then has no way to know which identity passed auth, so it rejects.

## Scope

- SeiNode StatefulSet proxy (\`internal/noderesource/noderesource.go\`)
- Bootstrap pod proxy (\`internal/task/bootstrap_resources.go\`)

Both proxy instances need the flag; the bootstrap pod uses the same sidecar trusted-header authn path.

## Test plan

- [x] \`TestPodSpec_KubeRBACProxyContainerArgs\` asserts the new flag is present
- [x] \`make test\` passes
- [ ] After merge + image build + harbor manager-patch bump: re-trigger nightly-load, confirm both SNDs reach Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)