### PR TITLE
fix(noderesource): mode-conditional startup probe for cosmos-exporter

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -483,7 +483,7 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) (corev1.PodSp
 		buildSidecarContainer(node, p),
 		buildRBACProxyContainer(node, p),
 	}
-	ceContainer, err := buildCosmosExporterContainer(p)
+	ceContainer, err := buildCosmosExporterContainer(node, p)
 	if err != nil {
 		return corev1.PodSpec{}, err
 	}
@@ -599,9 +599,17 @@ func defaultCosmosExporterResources() corev1.ResourceRequirements {
 	}
 }
 
+// cosmosExporterStartupProbePort: validators probe Tendermint RPC (gRPC
+// is disabled), other modes probe seid's gRPC.
+func cosmosExporterStartupProbePort(node *seiv1alpha1.SeiNode) int32 {
+	if node.Spec.Validator != nil {
+		return seiconfig.PortRPC
+	}
+	return seiconfig.PortGRPC
+}
+
 // buildCosmosExporterContainer renders the cosmos-exporter sidecar.
-// Image, args, port, and resources are fixed — no per-node knobs.
-func buildCosmosExporterContainer(p PlatformConfig) (corev1.Container, error) {
+func buildCosmosExporterContainer(node *seiv1alpha1.SeiNode, p PlatformConfig) (corev1.Container, error) {
 	if p.CosmosExporterImage == "" {
 		return corev1.Container{}, fmt.Errorf("SEI_COSMOS_EXPORTER_IMAGE is required on the operator Deployment")
 	}
@@ -625,18 +633,15 @@ func buildCosmosExporterContainer(p PlatformConfig) (corev1.Container, error) {
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: sidecarTmpVolumeName, MountPath: sidecarTmpMountPath},
 		},
-		// cosmos-exporter Fatal()s on its initial gRPC dial. Gate
-		// startup on seid's gRPC port so we don't crash-loop until
-		// seid is up.
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt32(seiconfig.PortGRPC),
+					Port: intstr.FromInt32(cosmosExporterStartupProbePort(node)),
 				},
 			},
 			InitialDelaySeconds: 5,
 			PeriodSeconds:       5,
-			FailureThreshold:    60,
+			FailureThreshold:    120,
 		},
 	}, nil
 }

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -1346,18 +1346,30 @@ func TestCosmosExporter_ErrorWhenImageUnset(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("SEI_COSMOS_EXPORTER_IMAGE is required"))
 }
 
-func TestCosmosExporter_StartupProbeOnSeidGRPC(t *testing.T) {
+func TestCosmosExporter_StartupProbe_FullNodeTargetsGRPC(t *testing.T) {
 	g := NewWithT(t)
-	node := newSnapshotNode("ce-0", "default")
+	node := newSnapshotNode("ce-fn-0", "default")
 
 	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
 	ce := findContainer(sts.Spec.Template.Spec.Containers, containerNameCosmosExporter)
 
-	// Startup probe gates ListenAndServe on seid's gRPC being up so the
-	// exporter doesn't log.Fatal() on its initial dial.
 	g.Expect(ce.StartupProbe).NotTo(BeNil())
 	g.Expect(ce.StartupProbe.TCPSocket).NotTo(BeNil())
 	g.Expect(ce.StartupProbe.TCPSocket.Port.IntVal).To(Equal(int32(9090)))
+	g.Expect(ce.StartupProbe.FailureThreshold).To(Equal(int32(120)))
+}
+
+func TestCosmosExporter_StartupProbe_ValidatorTargetsTendermintRPC(t *testing.T) {
+	g := NewWithT(t)
+	node := newGenesisNode("ce-val-0", "default")
+
+	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
+	ce := findContainer(sts.Spec.Template.Spec.Containers, containerNameCosmosExporter)
+
+	g.Expect(ce.StartupProbe).NotTo(BeNil())
+	g.Expect(ce.StartupProbe.TCPSocket).NotTo(BeNil())
+	g.Expect(ce.StartupProbe.TCPSocket.Port.IntVal).To(Equal(int32(26657)))
+	g.Expect(ce.StartupProbe.FailureThreshold).To(Equal(int32(120)))
 }
 
 func TestCosmosExporter_MountsTmpEmptyDir(t *testing.T) {


### PR DESCRIPTION
## Summary

The cosmos-exporter startup probe targeted seid's gRPC port (`9090`) for all node modes. Validators don't expose gRPC by default — only Tendermint RPC (`26657`) — so the probe permanently failed on validator pods and the kubelet kill-looped the container every five minutes (matching the `5 + 60*5 = 305s` threshold exactly).

Observed on harbor-shortunbond: `restartCount=147+` across 12h on all four validators; rpc-0 stable.

## Change

`internal/noderesource/noderesource.go`:

- New helper `cosmosExporterStartupProbePort(node)` — returns `26657` for validators, `9090` for all other modes.
- `buildCosmosExporterContainer` now takes the node so it can select the right probe target.
- `FailureThreshold` bumped 60 → 120 (~10min) to accommodate slow snapshot-restore paths.

`internal/noderesource/noderesource_test.go`:

- `TestCosmosExporter_StartupProbe_FullNodeTargetsGRPC` (renamed from `TestCosmosExporter_StartupProbeOnSeidGRPC`)
- `TestCosmosExporter_StartupProbe_ValidatorTargetsTendermintRPC` (new)

Both assert the target port + the new `FailureThreshold=120`.

## Cross-review

Platform engineer + Kubernetes specialist were consulted on the design. The mode-conditional shape (this PR) is the platform reviewer's preferred fix; the K8s reviewer accepted it after the user weighed in on keeping a startup gate. Both agreed `FailureThreshold` should grow for snapshot restores.

Two follow-ups both reviewers flagged for separate tracking:

1. Convert StartupProbe → ReadinessProbe — better matches cosmos-exporter's role as a long-running poller (no warm-up phase, retries internally, transient upstream blips shouldn't restart the container).
2. Migrate cosmos-exporter to a K8s 1.28+ native sidecar (init container with `restartPolicy: Always`) — decouples pod-Ready from the exporter and gets ordered shutdown for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)