### PR TITLE
fix(crd): add seinodetasks to config/crd/kustomization.yaml

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - sei.io_seinodes.yaml
   - sei.io_seinodedeployments.yaml
+  - sei.io_seinodetasks.yaml


### PR DESCRIPTION
**Prod is crash-looping** — sei-k8s-controller-manager pods cannot start because the SeiNodeTask CRD is not installed cluster-wide. This is a fix-forward.

## Root cause

PR 1 (#281) generated `sei.io_seinodetasks.yaml` under `config/crd/` via controller-gen and updated the Makefile's `cp` step to mirror it into `manifests/`, but the **`config/crd/kustomization.yaml` resource list was not updated**.

As a result, deployments via `github.com/sei-protocol/sei-k8s-controller/config/default?ref=main` (which the platform repo points to) shipped the controller binary — which calls `SeiNodeTaskReconciler.SetupWithManager(...)` and starts a watch on `SeiNodeTask.sei.io` — without applying the CRD itself.

The controller fails to start because the cache cannot sync a kind with no API binding:

```
"if kind is a CRD, it should be installed before calling Start"
 kind=SeiNodeTask.sei.io
 error=no matches for kind "SeiNodeTask" in version "sei.io/v1alpha1"
```

After ~2 minutes the manager exits, crash-looping the pod.

## Fix

Add `sei.io_seinodetasks.yaml` to the kustomization resource list:

```diff
 resources:
   - sei.io_seinodes.yaml
   - sei.io_seinodedeployments.yaml
+  - sei.io_seinodetasks.yaml
```

No code or RBAC changes — purely a manifest oversight from PR 1.

## Recovery

Once this merges, the next Flux reconcile applies the CRD cluster-wide. Existing crash-looping `sei-k8s-controller-manager` pods will start successfully on their next retry (Kubernetes' exponential backoff is already restarting them every few minutes).

No manual kubectl apply needed — Flux owns this state.

## Verification done

- Confirmed `config/crd/sei.io_seinodetasks.yaml` exists and is well-formed (was generated correctly by `make manifests` in PR 1).
- Confirmed only one place enumerates the CRD list (`config/crd/kustomization.yaml`); the Makefile `cp` line was already updated in PR 1.
- Confirmed prod cluster currently has `seinodes.sei.io` and `seinodedeployments.sei.io` but NOT `seinodetasks.sei.io`.

## Follow-up consideration

Long-term we should add a CI check that fails the build if any CRD file under `config/crd/` is not referenced in `kustomization.yaml`. Tracking as a separate issue rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)