### PR TITLE
fix(dockerignore): re-include runner/templates so the runner image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,10 @@
 
 # Re-include embedded shell scripts
 !**/*.sh
+
+# Re-include the runner image's per-kind Go text templates. The runner
+# Dockerfile (runner/Dockerfile) bakes runner/templates/ into the image
+# at /templates/. Without this re-include the seitask-runner build fails
+# at `COPY --from=builder /workspace/runner/templates /templates` with
+# "not found".
+!runner/templates/**


### PR DESCRIPTION
The ECR publish workflow from #291 fails on the seitask-runner build:

```
COPY --from=builder /workspace/runner/templates /templates
ERROR: failed to compute cache key: "/workspace/runner/templates": not found
```

Source: [run #26120617262](https://github.com/sei-protocol/sei-k8s-controller/actions/runs/26120617262/job/76821319830)

## Root cause

`.dockerignore` is whitelist-style — `**` ignores everything, then specific patterns re-include only what the controller image needs: `*.go`, `go.mod`, `go.sum`, `*.sh`.

The runner image (added in #286) also needs `runner/templates/*.yaml.tmpl` baked into the image at `/templates/` so it can render per-kind SeiNodeTask manifests at runtime. The controller image doesn't need these files, so they were never on the re-include list. The runner Dockerfile fails as soon as it tries to copy them out of the builder stage.

## Fix

One pattern added to `.dockerignore`:

```diff
 # Re-include embedded shell scripts
 !**/*.sh
+
+# Re-include the runner image's per-kind Go text templates.
+!runner/templates/**
```

Verified locally:

```
$ docker build --platform linux/amd64 -f runner/Dockerfile -t seitask-runner-test:local .
...
#15 [stage-1 3/4] COPY --from=builder /workspace/runner/templates /templates
#15 DONE 0.0s
...
naming to docker.io/library/seitask-runner-test:local done
```

## Same shape as #287

Same root cause as the prod outage from #287: a new artifact lands but a separate "what-to-include" list elsewhere doesn't pick it up.

| Bug | Generated artifact | Missed in |
|---|---|---|
| #287 | `config/crd/sei.io_seinodetasks.yaml` | `config/crd/kustomization.yaml` resource list |
| **This** | `runner/templates/*.yaml.tmpl` | `.dockerignore` re-include list |

Both are recoverable with one-line additions but cost a deploy iteration to detect. The CI-gap follow-up I previously dropped (#288's PR body item 3) is worth resurrecting — a build-time check that the runner Dockerfile's `COPY` paths all resolve in the build context would have caught this in PR review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)