### PR TITLE
fix(scenarios): use -internal aggregate Service for TM RPC/REST endpoints

### DIFF
--- a/scenarios/major-upgrade.yaml
+++ b/scenarios/major-upgrade.yaml
@@ -140,7 +140,7 @@ spec:
                 echo "TARGET_HEIGHT=${EXISTING} already set; short-circuiting"
                 exit 0
               fi
-              RPC="http://${SEI_DEPLOYMENT}-0.${SEI_NAMESPACE}.svc.cluster.local:26657"
+              RPC="http://${SEI_DEPLOYMENT}-internal.${SEI_NAMESPACE}.svc.cluster.local:26657"
               CUR=$(curl -fsS "${RPC}/status" | sed -n 's/.*"latest_block_height":"\([0-9]*\)".*/\1/p')
               if [ -z "${CUR}" ]; then
                 echo "failed to parse latest_block_height from ${RPC}/status" >&2
@@ -233,7 +233,7 @@ spec:
           args:
             - |
               set -eu
-              REST="http://${SEI_DEPLOYMENT}-0.${SEI_NAMESPACE}.svc.cluster.local:1317"
+              REST="http://${SEI_DEPLOYMENT}-internal.${SEI_NAMESPACE}.svc.cluster.local:1317"
               # gov v1beta1 voting_period = 2
               for i in $(seq 1 150); do
                 BODY=$(curl -fsS "${REST}/cosmos/gov/v1beta1/proposals?proposal_status=2" || true)
@@ -382,7 +382,7 @@ spec:
           args:
             - |
               set -eu
-              REST="http://${SEI_DEPLOYMENT}-0.${SEI_NAMESPACE}.svc.cluster.local:1317"
+              REST="http://${SEI_DEPLOYMENT}-internal.${SEI_NAMESPACE}.svc.cluster.local:1317"
               for i in $(seq 1 300); do
                 STATUS=$(curl -fsS "${REST}/cosmos/gov/v1beta1/proposals/${PROPOSAL_ID}" \
                           | sed -n 's/.*"status":"\([A-Z_]*\)".*/\1/p' | head -1)


### PR DESCRIPTION
The major-upgrade scenario's bash steps (compute-target-height, resolve-proposal-id, wait-for-proposal-to-pass) curl Tendermint endpoints at per-pod Service DNS:

\`\`\`
http://\${SEI_DEPLOYMENT}-0.\${SEI_NAMESPACE}.svc.cluster.local:26657/status
http://\${SEI_DEPLOYMENT}-0.\${SEI_NAMESPACE}.svc.cluster.local:1317/cosmos/...
\`\`\`

On the live harbor manual run this dies with:

\`\`\`
curl: (7) Failed to connect to bench-major-upgrade-X-0.nightly.svc:26657:
Could not connect to server
\`\`\`

## Root cause

Per-pod Services on a SeiNodeDeployment expose **only the EVM ports** (8545/8546). Tendermint RPC (26657) and REST (1317) are surfaced **only on the deployment-scoped \`<snd-name>-internal\` aggregate Service**. From a recent SND's \`.status\`:

\`\`\`yaml
internalService:
  name: bench-major-upgrade-X-internal
  ports:
    evmHttp: 8545
    rest: 1317
    rpc: 26657
perPodServices:
  - name: bench-major-upgrade-X-0
    ports:
      evmHttp: 8545
      evmWs: 8546    # no 26657, no 1317
endpoints:
  tendermintRpc:  http://bench-major-upgrade-X-internal.nightly.svc:26657
  tendermintRest: http://bench-major-upgrade-X-internal.nightly.svc:1317
\`\`\`

## Fix

Three sed substitutions in \`scenarios/major-upgrade.yaml\`:

- L143: \`\${SEI_DEPLOYMENT}-0...:26657\` → \`\${SEI_DEPLOYMENT}-internal...:26657\`
- L236: \`\${SEI_DEPLOYMENT}-0...:1317\` → \`\${SEI_DEPLOYMENT}-internal...:1317\`
- L385: same as L236 in the wait-for-proposal-to-pass step

TM RPC/REST are stateless query endpoints so the aggregate (any healthy validator backing the Service) is the right target.

## Symptom chain on the live run

- \`compute-target-height\` failed with curl rc=7 → exited 1
- \`workflow-vars-<run-id>\` ConfigMap never got created
- Downstream \`submit-upgrade-proposal\` step's seitask-runner pod went into \`CreateContainerConfigError\` because its \`envFrom: configMapRef\` pointed at a ConfigMap that didn't exist

Single fix at the source resolves the whole cascade.

## Bug count

Fix #8 in the major-upgrade-runs-end-to-end debugging chain. Same shape as several earlier ones: an assumption about the wider system that doesn't survive contact with the actual cluster. The audit's "trust but verify" principle continues to earn its keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)