### PR TITLE
fix(scenarios): retry RPC query in compute-target-height (chain-RPC bind race)

### DIFF
--- a/scenarios/major-upgrade.yaml
+++ b/scenarios/major-upgrade.yaml
@@ -141,9 +141,23 @@ spec:
                 exit 0
               fi
               RPC="http://${SEI_DEPLOYMENT}-internal.${SEI_NAMESPACE}.svc.cluster.local:26657"
-              CUR=$(curl -fsS "${RPC}/status" | sed -n 's/.*"latest_block_height":"\([0-9]*\)".*/\1/p')
+              # `seictl nd watch --until=Ready` returns when SeiNode pods
+              # report Running, but seid's RPC server may take a few more
+              # seconds to actually bind port 26657. Retry the first chain
+              # query for up to 90s rather than fail single-shot.
+              CUR=""
+              for i in $(seq 1 30); do
+                CUR=$(curl -fsS --connect-timeout 3 "${RPC}/status" 2>/dev/null \
+                  | sed -n 's/.*"latest_block_height":"\([0-9]*\)".*/\1/p' || true)
+                if [ -n "${CUR}" ]; then
+                  echo "got height=${CUR} on attempt=${i}"
+                  break
+                fi
+                echo "attempt=${i} RPC not ready yet; retrying in 3s"
+                sleep 3
+              done
               if [ -z "${CUR}" ]; then
-                echo "failed to parse latest_block_height from ${RPC}/status" >&2
+                echo "failed to parse latest_block_height from ${RPC}/status after 30 attempts" >&2
                 exit 1
               fi
               TARGET=$((CUR + 100))


### PR DESCRIPTION
Live manual run on harbor: \`seictl nd watch --until=Ready\` returns when SeiNode pods report Running, but seid's Tendermint RPC server takes a few more seconds AFTER that to bind port 26657. The single-shot curl in \`compute-target-height\` loses that race:

\`\`\`
curl: (7) Failed to connect to <snd>-internal.nightly.svc:26657 after 10 ms:
Could not connect to server
failed to parse latest_block_height from .../status
\`\`\`

Manual curl from a fresh pod 90s later returns HTTP 200 with \`height: 286\` — the chain IS up, just not at the instant \`nd watch\` returned.

## Fix

Wrap the curl in a 30-attempt retry loop with 3s sleep (90s window) + 3s \`--connect-timeout\` per attempt. Matches the retry pattern \`resolve-proposal-id\` already uses (different step, same shape: chain-side query that tolerates brief warmup).

## Symptom chain

- compute-target-height exits 1 → workflow-vars ConfigMap not created
- Downstream \`submit-upgrade-proposal\` seitask-runner pod stuck in \`CreateContainerConfigError\` because its \`envFrom: configMapRef\` can't resolve

Single fix at the source resolves the whole cascade.

## Should \`seictl nd watch --until=Ready\` itself wait for RPC?

Probably. The SeiNode controller's Ready signal currently means "pods are scheduled and plan is complete." A "RPC bound" stricter condition would push this retry logic into the controller and let scenarios stay single-shot. Not in scope here — file as a separate follow-up.

Bug #9 in the major-upgrade-runs-end-to-end debugging chain. Same shape as several earlier ones: a timing/readiness assumption that doesn't hold under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)