### PR TITLE
chore(manager): bump controller image to 80f148f

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:bff54e789613b3a56468da5a4bcebf294738f1e5
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:80f148fec0bf6915d1fc0a82225f19720765ac07
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Picks up:

- #296 fix(noderesource): wire SEI_KEYRING_BACKEND; add gentx-key fallback path
- #297 feat(nodetask): derive keyName from target SeiNode on gov tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)