### PR TITLE
fix(scenarios/major-upgrade): bump FEES above the chain min-gas-price floor

### DIFF
--- a/scenarios/major-upgrade.yaml
+++ b/scenarios/major-upgrade.yaml
@@ -215,7 +215,7 @@ spec:
             - --var=UPGRADE_NAME=$SEI_UPGRADE_NAME
             - --var=UPGRADE_HEIGHT=$(UPGRADE_HEIGHT)
             - --var=INITIAL_DEPOSIT=20000000usei
-            - --var=FEES=2000usei
+            - --var=FEES=10000usei
             - --var=GAS=500000
             - --timeout=8m
           envFrom:
@@ -307,7 +307,7 @@ spec:
             - --var=CHAIN_ID=$SEI_CHAIN_ID
             - --var=PROPOSAL_ID=$(PROPOSAL_ID)
             - --var=OPTION=yes
-            - --var=FEES=2000usei
+            - --var=FEES=10000usei
             - --var=GAS=200000
             - --timeout=5m
           envFrom:
@@ -327,7 +327,7 @@ spec:
             - --var=CHAIN_ID=$SEI_CHAIN_ID
             - --var=PROPOSAL_ID=$(PROPOSAL_ID)
             - --var=OPTION=yes
-            - --var=FEES=2000usei
+            - --var=FEES=10000usei
             - --var=GAS=200000
             - --timeout=5m
           envFrom:
@@ -347,7 +347,7 @@ spec:
             - --var=CHAIN_ID=$SEI_CHAIN_ID
             - --var=PROPOSAL_ID=$(PROPOSAL_ID)
             - --var=OPTION=yes
-            - --var=FEES=2000usei
+            - --var=FEES=10000usei
             - --var=GAS=200000
             - --timeout=5m
           envFrom:
@@ -367,7 +367,7 @@ spec:
             - --var=CHAIN_ID=$SEI_CHAIN_ID
             - --var=PROPOSAL_ID=$(PROPOSAL_ID)
             - --var=OPTION=yes
-            - --var=FEES=2000usei
+            - --var=FEES=10000usei
             - --var=GAS=200000
             - --timeout=5m
           envFrom:


### PR DESCRIPTION
Chain enforces \`min-gas-price 0.01usei/gas\`; at \`gas=500000\` the floor is \`5000usei\`. Prior \`2000usei\` was below the floor — every signed broadcast returned \`insufficient fees; got: 2000usei required: 5000usei\`. The sidecar correctly retried on its 15s backoff but the value was permanently below threshold.

Set to \`10000usei\` (2x floor) so a small chain-side \`min-gas-price\` bump doesn't break the scenario.

## Validation
Surfaced during the first end-to-end signing run after #296/#297 landed. Sidecar logs showed signed-tx broadcast working as designed — keyring loaded, uid resolved, signature produced; failure is now a chain-side fee-floor enforcement rather than any keyring-pipeline issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)