### PR TITLE
fix(runner/gov-vote): quote OPTION so YAML doesn't parse "yes" as bool

### DIFF
--- a/runner/templates/gov-vote.yaml.tmpl
+++ b/runner/templates/gov-vote.yaml.tmpl
@@ -14,6 +14,6 @@ spec:
     keyName: {{ . }}
     {{- end }}
     proposalId: {{ .PROPOSAL_ID }}
-    option: {{ .OPTION }}
+    option: "{{ .OPTION }}"
     fees: {{ .FEES }}
     gas: {{ .GAS }}


### PR DESCRIPTION
The template emitted \`option: {{ .OPTION }}\` (unquoted). With \`OPTION=yes\`, YAML 1.1's bare-string rules promote \`yes\`/\`no\`/\`on\`/\`off\` to booleans, so kubectl's server-side apply saw \`option: true\` (bool) for a field the CRD declares string. Apply failed:

\`\`\`
.spec.govVote.option: expected string, got &value.valueUnstructured{Value:true}
\`\`\`

Quote the value so YAML always sees a string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)