### PR TITLE
fix(scenarios/major-upgrade): widen upgrade-height margin past voting_period

### DIFF
--- a/scenarios/major-upgrade.yaml
+++ b/scenarios/major-upgrade.yaml
@@ -108,8 +108,9 @@ spec:
 
     # ----------------------------------------------------------------------
     # Step 1. compute-target-height
-    # Mirrors scripts/proposal_target_height.sh: current height + 100 blocks
-    # (30s at 300ms block time). Creates the workflow-vars ConfigMap and
+    # Sets upgrade height = current + 200 blocks (~120s at Sei's ~600ms
+    # block time) to comfortably outlast the 60s gov voting_period plus
+    # tally + plan-execution slack. Creates the workflow-vars ConfigMap and
     # populates it with:
     #   TARGET_HEIGHT       -- upgrade height + downgrade-side panic boundary
     #   UPGRADE_HEIGHT      -- consumed by gov-software-upgrade.yaml.tmpl
@@ -160,7 +161,7 @@ spec:
                 echo "failed to parse latest_block_height from ${RPC}/status after 30 attempts" >&2
                 exit 1
               fi
-              TARGET=$((CUR + 100))
+              TARGET=$((CUR + 200))
               POST=$((TARGET + 10))
               PANIC_BOUNDARY=$((TARGET - 1))
               echo "current=${CUR} target=${TARGET} post=${POST} panic_boundary=${PANIC_BOUNDARY}"


### PR DESCRIPTION
`TARGET=CUR+100` (~60s at Sei's ~600ms blocks) lines up with the 60s gov `voting_period` exactly: the chain reaches the plan height at the same moment voting closes, so x/upgrade sees the plan as already-past at tally → `PROPOSAL_STATUS_FAILED` even with unanimous yes votes.

Bump to `CUR+200` (~120s) so the plan height stays comfortably in the future across voting + tally + plan execution. The original comment also misread block time as 300ms; Sei runs ~600ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)