### PR TITLE
chore: bump sei-config to v0.0.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.38.2
-	github.com/sei-protocol/sei-config v0.0.14
+	github.com/sei-protocol/sei-config v0.0.15
 	github.com/sei-protocol/seictl v0.0.50
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -1569,6 +1569,8 @@ github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7 h1:k
 github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7/go.mod h1:R1/EoOY+MKvwH0k5ivTtG9mLYOQvm0Ni/Trjxrep3t4=
 github.com/sei-protocol/sei-config v0.0.14 h1:1KS0EteCBEsjglNEPS/8VAOA7/NDLxEuPHPZg0MvSaM=
 github.com/sei-protocol/sei-config v0.0.14/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/sei-config v0.0.15 h1:kd9ZbDYq4eAJxpELI8oISVXFiPr3Jf1kTHL/V3gf5TU=
+github.com/sei-protocol/sei-config v0.0.15/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=
 github.com/sei-protocol/sei-tm-db v0.0.5/go.mod h1:Cpa6rGyczgthq7/0pI31jys2Fw0Nfrc+/jKdP1prVqY=
 github.com/sei-protocol/seictl v0.0.47 h1:crV++ft3/i3VVZ5ITyh5rZmQyQCos7t9g7FMGz4gb5s=


### PR DESCRIPTION
## Summary

Bumps `github.com/sei-protocol/sei-config` from `v0.0.14` to `v0.0.15`.

v0.0.15 is a single-feature release: gRPC enabled on validator mode (parity with sei-infra canonical). The controller consumes sei-config via `seiconfig.NodePortsForMode()` and similar helpers, so the new gRPC port flows through automatically with no controller-side changes.

Net: **2 files, +3 / -1.**

## Test plan

- [x] `go build ./...` exits 0
- [x] `go test ./...` exits 0 (all 8 test-bearing packages pass)
- [x] `go.sum` regenerated cleanly

## References

- sei-config tag `v0.0.15`
- sei-config PR #19: `feat: enable gRPC on validator mode (parity with sei-infra canonical)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)