### PR TITLE
refactor: rename internal/taskimg → internal/taskruntime

### DIFF
--- a/cmd/seitask/keygen.go
+++ b/cmd/seitask/keygen.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/sei-protocol/sei-k8s-controller/internal/seitask/keygen"
-	"github.com/sei-protocol/sei-k8s-controller/internal/taskimg"
+	"github.com/sei-protocol/sei-k8s-controller/internal/taskruntime"
 )
 
 func newKeygenCommand() *cli.Command {
@@ -30,7 +30,7 @@ func newKeygenCommand() *cli.Command {
 }
 
 func runKeygen(ctx context.Context, cmd *cli.Command) error {
-	wf, err := taskimg.LoadWorkflowIdentity()
+	wf, err := taskruntime.LoadWorkflowIdentity()
 	if err != nil {
 		return err
 	}
@@ -45,10 +45,10 @@ func runKeygen(ctx context.Context, cmd *cli.Command) error {
 	})
 	if err != nil {
 		// Stamp EXIT_REASON so upload-report can recover the failure class.
-		taskimg.WriteExitReason(ctx, c, wf, err)
+		taskruntime.WriteExitReason(ctx, c, wf, err)
 		return err
 	}
-	taskimg.WriteExitReason(ctx, c, wf, nil)
+	taskruntime.WriteExitReason(ctx, c, wf, nil)
 	log.Printf("keygen: created Secret %q with address %s", res.SecretName, res.Address)
 	return nil
 }

--- a/cmd/seitask/main.go
+++ b/cmd/seitask/main.go
@@ -1,6 +1,6 @@
 // Command seitask is the monolithic Workflow-Task primitive binary: one
 // binary, multiple urfave/cli subcommands (keygen, provision-snd, …) that
-// share the internal/taskimg shared library. See
+// share the internal/taskruntime shared library. See
 // docs/design/test-harness-lld.md.
 package main
 
@@ -17,7 +17,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/sei-protocol/sei-k8s-controller/internal/taskimg"
+	"github.com/sei-protocol/sei-k8s-controller/internal/taskruntime"
 )
 
 func main() {
@@ -33,10 +33,10 @@ func main() {
 	}
 
 	if err := app.Run(ctx, os.Args); err != nil {
-		// Subcommands wrap with taskimg.Infra / taskimg.Task so this
+		// Subcommands wrap with taskruntime.Infra / taskruntime.Task so this
 		// mapping reaches the right 0/1/2 exit code.
 		log.Printf("seitask: %v", err)
-		os.Exit(taskimg.ExitCodeFor(err))
+		os.Exit(taskruntime.ExitCodeFor(err))
 	}
 }
 
@@ -45,11 +45,11 @@ func main() {
 func kubeClientFromEnv() (client.Client, error) {
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
-		return nil, taskimg.Infra(fmt.Errorf("loading kubeconfig: %w", err))
+		return nil, taskruntime.Infra(fmt.Errorf("loading kubeconfig: %w", err))
 	}
 	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
-		return nil, taskimg.Infra(fmt.Errorf("building client: %w", err))
+		return nil, taskruntime.Infra(fmt.Errorf("building client: %w", err))
 	}
 	return c, nil
 }

--- a/docs/design/test-harness-lld.md
+++ b/docs/design/test-harness-lld.md
@@ -74,9 +74,9 @@ The four sei-side images are all small Go binaries using controller-runtime clie
 ### Task image contract
 
 - **Inputs**: env vars (rendered by Chaos Mesh from Workflow template) + optionally a mounted ConfigMap with a typed spec (for `seitask-provision-snd`, which needs a structured SND payload too large for env). **No `envsubst`-style placeholders** inside scenario YAML. Per-run substitution uses Chaos Mesh's native `{{ .Workflow.Name }}` / `inputs.parameters.*` (rendered by the workflow controller, not by the orchestrator). The CronJob applies the scenario YAML literally; the per-run identifier is injected as a Workflow parameter.
-- **Outputs**: typed read/write of the per-run ConfigMap (`workflow-vars-<workflow-name>`) via controller-runtime `client.Patch(obj, client.MergeFromWithOptimisticLock{})`. **No `kubectl` shell-out from inside the Task images** — same status-patch discipline the controller uses (see `CLAUDE.md`). The CM ops live in `internal/taskimg/cm.go`. Downstream Tasks consume the merged CM via `envFrom: configMapRef:`.
+- **Outputs**: typed read/write of the per-run ConfigMap (`workflow-vars-<workflow-name>`) via controller-runtime `client.Patch(obj, client.MergeFromWithOptimisticLock{})`. **No `kubectl` shell-out from inside the Task images** — same status-patch discipline the controller uses (see `CLAUDE.md`). The CM ops live in `internal/taskruntime/cm.go`. Downstream Tasks consume the merged CM via `envFrom: configMapRef:`.
 - **Exit codes**: 0 pass / 1 task-fail / 2 infra-fail. Matches release-test.ts. Chaos Mesh treats any non-zero as Failed identically; the 1-vs-2 split surfaces only in `seitask-upload-report` (reads a sentinel key the failing Task writes to the CM before exit).
-- **Cleanup**: every resource a Task image creates (SND, Secret, ConfigMap entry) carries an `ownerReference` to the parent Workflow CR. The Workflow's UID is injected into each Task pod via the downward API on a fixed env var (`SEI_WORKFLOW_NAME`, `SEI_WORKFLOW_UID`) so the helper in `internal/taskimg/ownerref.go` can stamp it without an extra API lookup. Workflow deletion cascades to everything; no trap-on-EXIT logic. ownerReferences point at the Workflow CR, never at the Task pod or WorkflowNode (both go away before SND lifecycle completes).
+- **Cleanup**: every resource a Task image creates (SND, Secret, ConfigMap entry) carries an `ownerReference` to the parent Workflow CR. The Workflow's UID is injected into each Task pod via the downward API on a fixed env var (`SEI_WORKFLOW_NAME`, `SEI_WORKFLOW_UID`) so the helper in `internal/taskruntime/ownerref.go` can stamp it without an extra API lookup. Workflow deletion cascades to everything; no trap-on-EXIT logic. ownerReferences point at the Workflow CR, never at the Task pod or WorkflowNode (both go away before SND lifecycle completes).
 
 ### Cross-step state
 
@@ -89,7 +89,7 @@ The major-upgrade workflow already uses a per-run ConfigMap with an `ownerRefere
 
 #### workflow-vars schema
 
-The key vocabulary is enumerated in a Go file (`internal/taskimg/vars.go`) as typed constants so producer/consumer drift is a compile error, not a runtime mystery. Initial schema:
+The key vocabulary is enumerated in a Go file (`internal/taskruntime/vars.go`) as typed constants so producer/consumer drift is a compile error, not a runtime mystery. Initial schema:
 
 | Key | Type | Writer | Stability |
 |---|---|---|---|
@@ -212,7 +212,7 @@ sei-k8s-controller/
     upload-report/       # NEW — seitask-upload-report entry
     runner/              # NEW location for existing seitask-runner (moved from runner/)
   internal/
-    taskimg/             # NEW — shared library for the small task images
+    taskruntime/             # NEW — shared library for the small task images
       vars.go            # typed const keys for workflow-vars CM
       cm.go              # typed client.Patch helpers (MergeFromWithOptimisticLock)
       ownerref.go        # Workflow ownerReference helper (reads SEI_WORKFLOW_UID env)

--- a/internal/seitask/keygen/keygen.go
+++ b/internal/seitask/keygen/keygen.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/sei-protocol/sei-k8s-controller/internal/taskimg"
+	"github.com/sei-protocol/sei-k8s-controller/internal/taskruntime"
 )
 
 // cosmos BIP-44 path, coin type 118. Matches `seid keys add` so mnemonics
@@ -39,7 +39,7 @@ type Params struct {
 	// KeyName is the logical identity (e.g. "admin"). Secret name is
 	// "<KeyName>-<WorkflowName>" to disambiguate concurrent runs.
 	KeyName  string
-	Workflow taskimg.WorkflowIdentity
+	Workflow taskruntime.WorkflowIdentity
 }
 
 type Result struct {
@@ -69,19 +69,19 @@ func Run(ctx context.Context, c client.Client, p Params) (Result, error) {
 		// Re-stamp the workflow-vars CM in case it was cleared, then return.
 		addr, exists := existing.Data["address"]
 		if !exists {
-			return Result{}, taskimg.Infra(fmt.Errorf("existing Secret %q is missing address data", secretName))
+			return Result{}, taskruntime.Infra(fmt.Errorf("existing Secret %q is missing address data", secretName))
 		}
 		if err := writeWorkflowVars(ctx, c, p.Workflow, string(addr), secretName); err != nil {
 			return Result{}, err
 		}
 		return Result{SecretName: secretName, Address: string(addr)}, nil
 	case !apierrors.IsNotFound(err):
-		return Result{}, taskimg.Infra(fmt.Errorf("reading existing Secret %q: %w", secretName, err))
+		return Result{}, taskruntime.Infra(fmt.Errorf("reading existing Secret %q: %w", secretName, err))
 	}
 
 	mnemonic, address, err := deriveIdentity()
 	if err != nil {
-		return Result{}, taskimg.Infra(fmt.Errorf("deriving identity: %w", err))
+		return Result{}, taskruntime.Infra(fmt.Errorf("deriving identity: %w", err))
 	}
 
 	secret := &corev1.Secret{
@@ -105,7 +105,7 @@ func Run(ctx context.Context, c client.Client, p Params) (Result, error) {
 		if apierrors.IsAlreadyExists(err) {
 			return Run(ctx, c, p)
 		}
-		return Result{}, taskimg.Infra(fmt.Errorf("creating Secret %q: %w", secretName, err))
+		return Result{}, taskruntime.Infra(fmt.Errorf("creating Secret %q: %w", secretName, err))
 	}
 
 	if err := writeWorkflowVars(ctx, c, p.Workflow, address, secretName); err != nil {
@@ -114,15 +114,15 @@ func Run(ctx context.Context, c client.Client, p Params) (Result, error) {
 	return Result{SecretName: secretName, Address: address}, nil
 }
 
-func writeWorkflowVars(ctx context.Context, c client.Client, w taskimg.WorkflowIdentity, address, secretName string) error {
-	if err := taskimg.EnsureWorkflowVarsCM(ctx, c, w, map[taskimg.VarKey]string{
-		taskimg.KeyRunID: w.Name,
+func writeWorkflowVars(ctx context.Context, c client.Client, w taskruntime.WorkflowIdentity, address, secretName string) error {
+	if err := taskruntime.EnsureWorkflowVarsCM(ctx, c, w, map[taskruntime.VarKey]string{
+		taskruntime.KeyRunID: w.Name,
 	}); err != nil {
 		return err
 	}
-	return taskimg.SetVars(ctx, c, w, map[taskimg.VarKey]string{
-		taskimg.KeyAdminAddress:    address,
-		taskimg.KeyAdminSecretName: secretName,
+	return taskruntime.SetVars(ctx, c, w, map[taskruntime.VarKey]string{
+		taskruntime.KeyAdminAddress:    address,
+		taskruntime.KeyAdminSecretName: secretName,
 	})
 }
 

--- a/internal/seitask/keygen/keygen_test.go
+++ b/internal/seitask/keygen/keygen_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/sei-protocol/sei-k8s-controller/internal/taskimg"
+	"github.com/sei-protocol/sei-k8s-controller/internal/taskruntime"
 )
 
 func newScheme(t *testing.T) *runtime.Scheme {
@@ -31,8 +31,8 @@ const (
 	testWorkflowVarsCM = "workflow-vars-wf-test"
 )
 
-func testWorkflow() taskimg.WorkflowIdentity {
-	return taskimg.WorkflowIdentity{Name: testWorkflowName, UID: "uid-test", Namespace: testNamespace}
+func testWorkflow() taskruntime.WorkflowIdentity {
+	return taskruntime.WorkflowIdentity{Name: testWorkflowName, UID: "uid-test", Namespace: testNamespace}
 }
 
 // Sanity check: keygen produces a Secret with the right shape + a
@@ -75,13 +75,13 @@ func TestRun_CreatesSecretAndWorkflowVars(t *testing.T) {
 	if err := c.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testWorkflowVarsCM}, cm); err != nil {
 		t.Fatalf("Get CM: %v", err)
 	}
-	if got := cm.Data[string(taskimg.KeyAdminAddress)]; got != res.Address {
+	if got := cm.Data[string(taskruntime.KeyAdminAddress)]; got != res.Address {
 		t.Fatalf("CM ADMIN_ADDRESS = %q, want %q", got, res.Address)
 	}
-	if got := cm.Data[string(taskimg.KeyAdminSecretName)]; got != testSecretName {
+	if got := cm.Data[string(taskruntime.KeyAdminSecretName)]; got != testSecretName {
 		t.Fatalf("CM ADMIN_SECRET_NAME = %q, want admin-wf-test", got)
 	}
-	if got := cm.Data[string(taskimg.KeyRunID)]; got != testWorkflowName {
+	if got := cm.Data[string(taskruntime.KeyRunID)]; got != testWorkflowName {
 		t.Fatalf("CM RUN_ID = %q, want wf-test", got)
 	}
 }
@@ -126,8 +126,8 @@ func TestRun_RejectsBadInputs(t *testing.T) {
 		p    Params
 	}{
 		{"empty key name", Params{KeyName: "", Workflow: testWorkflow()}},
-		{"missing workflow name", Params{KeyName: testKeyName, Workflow: taskimg.WorkflowIdentity{Namespace: "ns"}}},
-		{"missing workflow namespace", Params{KeyName: testKeyName, Workflow: taskimg.WorkflowIdentity{Name: "wf"}}},
+		{"missing workflow name", Params{KeyName: testKeyName, Workflow: taskruntime.WorkflowIdentity{Namespace: "ns"}}},
+		{"missing workflow namespace", Params{KeyName: testKeyName, Workflow: taskruntime.WorkflowIdentity{Name: "wf"}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := Run(context.Background(), c, tc.p)

--- a/internal/taskruntime/cm.go
+++ b/internal/taskruntime/cm.go
@@ -1,4 +1,4 @@
-package taskimg
+package taskruntime
 
 import (
 	"context"

--- a/internal/taskruntime/cm_test.go
+++ b/internal/taskruntime/cm_test.go
@@ -1,4 +1,4 @@
-package taskimg
+package taskruntime
 
 import (
 	"context"

--- a/internal/taskruntime/exit.go
+++ b/internal/taskruntime/exit.go
@@ -1,6 +1,6 @@
-// Package taskimg is the shared library for seitask subcommands: typed exit
-// codes, ownerReference stamping, and workflow-vars ConfigMap helpers.
-package taskimg
+// Package taskruntime is the shared library for seitask subcommands: typed
+// exit codes, ownerReference stamping, and workflow-vars ConfigMap helpers.
+package taskruntime
 
 import (
 	"errors"

--- a/internal/taskruntime/exit_test.go
+++ b/internal/taskruntime/exit_test.go
@@ -1,4 +1,4 @@
-package taskimg
+package taskruntime
 
 import (
 	"errors"

--- a/internal/taskruntime/ownerref.go
+++ b/internal/taskruntime/ownerref.go
@@ -1,4 +1,4 @@
-package taskimg
+package taskruntime
 
 import (
 	"fmt"

--- a/internal/taskruntime/ownerref_test.go
+++ b/internal/taskruntime/ownerref_test.go
@@ -1,4 +1,4 @@
-package taskimg
+package taskruntime
 
 import (
 	"errors"

--- a/internal/taskruntime/vars.go
+++ b/internal/taskruntime/vars.go
@@ -1,4 +1,4 @@
-package taskimg
+package taskruntime
 
 // VarKey is a typed key for the workflow-vars ConfigMap. Producers and
 // consumers reference these constants so renames are compile errors. Schema +

--- a/internal/taskruntime/vars_test.go
+++ b/internal/taskruntime/vars_test.go
@@ -1,4 +1,4 @@
-package taskimg
+package taskruntime
 
 import (
 	"errors"


### PR DESCRIPTION
Mechanical rename of the Workflow-Task SDK package. `taskruntime` reads more naturally for what it is (the runtime helpers every seitask subcommand uses) than `taskimg`, which implied "image" even though it's a Go library.

All callers updated (`cmd/seitask/`, `internal/seitask/keygen/`); package docstrings in `exit.go` and `cmd/seitask/main.go` reflect the new name; LLD references updated. Full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)