### PR TITLE
feat(seitask): provision-snd subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@ Thumbs.db
 # but shouldn't be committed
 bin/k8s/
 .council/
-seitask
+/seitask
 /manager

--- a/cmd/seitask/main.go
+++ b/cmd/seitask/main.go
@@ -29,6 +29,7 @@ func main() {
 		Usage: "Workflow Task primitives for the sei-k8s-controller test harness",
 		Commands: []*cli.Command{
 			newKeygenCommand(),
+			newProvisionSNDCommand(),
 		},
 	}
 

--- a/cmd/seitask/provision_snd.go
+++ b/cmd/seitask/provision_snd.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/sei-protocol/sei-k8s-controller/internal/seitask/provisionsnd"
+	"github.com/sei-protocol/sei-k8s-controller/internal/taskruntime"
+)
+
+func newProvisionSNDCommand() *cli.Command {
+	return &cli.Command{
+		Name: "provision-snd",
+		Usage: "Apply a SeiNodeDeployment from a YAML spec, wait for Ready + first block, " +
+			"and publish role-scoped endpoints to workflow-vars",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "role",
+				Usage:    "Role tag for workflow-vars keys (e.g. validator, rpc)",
+				Sources:  cli.EnvVars("ROLE"),
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "name",
+				Usage:   "SND metadata.name (defaults to <workflow>-<role>)",
+				Sources: cli.EnvVars("SND_NAME"),
+			},
+			&cli.StringFlag{
+				Name:    "spec-file",
+				Usage:   "Path to the SeiNodeDeployment YAML",
+				Sources: cli.EnvVars("SND_SPEC_FILE"),
+				Value:   "/etc/scenario/snd.yaml",
+			},
+			&cli.StringFlag{
+				Name:     "chain-id",
+				Usage:    "Chain ID (overrides spec.template.spec.chainId + spec.genesis.chainId)",
+				Sources:  cli.EnvVars("CHAIN_ID"),
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "image",
+				Usage:    "seid container image (overrides spec.template.spec.image)",
+				Sources:  cli.EnvVars("SEID_IMAGE"),
+				Required: true,
+			},
+			&cli.IntFlag{
+				Name:    "replicas",
+				Usage:   "Replica count override (0 = use YAML)",
+				Sources: cli.EnvVars("REPLICAS"),
+			},
+			&cli.DurationFlag{
+				Name:  "ready-timeout",
+				Usage: "Max wait for status.phase=Ready",
+				Value: 15 * time.Minute,
+			},
+			&cli.DurationFlag{
+				Name:  "first-block-timeout",
+				Usage: "Max post-Ready wait for the chain to produce its first block",
+				Value: 5 * time.Minute,
+			},
+		},
+		Action: runProvisionSND,
+	}
+}
+
+func runProvisionSND(ctx context.Context, cmd *cli.Command) error {
+	wf, err := taskruntime.LoadWorkflowIdentity()
+	if err != nil {
+		return err
+	}
+	c, err := kubeClientFromEnv()
+	if err != nil {
+		return err
+	}
+
+	p := provisionsnd.Params{
+		Role:              cmd.String("role"),
+		Name:              cmd.String("name"),
+		SpecFile:          cmd.String("spec-file"),
+		ChainID:           cmd.String("chain-id"),
+		Image:             cmd.String("image"),
+		Replicas:          int32(cmd.Int("replicas")),
+		ReadyTimeout:      cmd.Duration("ready-timeout"),
+		FirstBlockTimeout: cmd.Duration("first-block-timeout"),
+		Workflow:          wf,
+	}
+	res, err := provisionsnd.Run(ctx, c, p)
+	if err != nil {
+		taskruntime.WriteExitReason(ctx, c, wf, err)
+		return err
+	}
+	taskruntime.WriteExitReason(ctx, c, wf, nil)
+	log.Printf("provision-snd: SND %q Ready, chainID=%s, TM=%s", res.Name, res.ChainID, res.Endpoints.TendermintRpc)
+	return nil
+}

--- a/internal/seitask/provisionsnd/provision.go
+++ b/internal/seitask/provisionsnd/provision.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -249,7 +248,7 @@ func waitForFirstBlock(ctx context.Context, hc *http.Client, tmRPC string, timeo
 		if err != nil {
 			return false, nil // transient connect failure during chain warmup; keep polling
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode/100 != 2 {
 			return false, nil
 		}
@@ -267,8 +266,8 @@ func waitForFirstBlock(ctx context.Context, hc *http.Client, tmRPC string, timeo
 
 func publishEndpoints(ctx context.Context, c client.Client, w taskruntime.WorkflowIdentity, role, chainID string, ep seiv1alpha1.Endpoints) error {
 	kv := map[taskruntime.VarKey]string{
-		taskruntime.RoleScoped(role, taskruntime.KeyChainID):       chainID,
-		taskruntime.RoleScoped(role, taskruntime.KeyTendermintRPC): ep.TendermintRpc,
+		taskruntime.RoleScoped(role, taskruntime.KeyChainID):        chainID,
+		taskruntime.RoleScoped(role, taskruntime.KeyTendermintRPC):  ep.TendermintRpc,
 		taskruntime.RoleScoped(role, taskruntime.KeyTendermintREST): ep.TendermintRest,
 	}
 	// EVM JSON-RPC is per-pod (stateful); publish the first node's URL when
@@ -281,8 +280,3 @@ func publishEndpoints(ctx context.Context, c client.Client, w taskruntime.Workfl
 	}
 	return taskruntime.SetVars(ctx, c, w, kv)
 }
-
-// EnsureKubernetesObjectShape is a no-op corev1 import-pinner; the package
-// needs corev1 in transitive test contexts (fake client scheme) and Go's
-// goimports otherwise drops it.
-var _ = corev1.NamespaceAll

--- a/internal/seitask/provisionsnd/provision.go
+++ b/internal/seitask/provisionsnd/provision.go
@@ -1,0 +1,288 @@
+// Package provisionsnd implements `seitask provision-snd`: read a typed
+// SeiNodeDeployment YAML from a mounted ConfigMap, apply CLI overrides,
+// stamp an ownerRef to the parent Workflow, Create it, await Ready, poll
+// the chain RPC for first block, then publish endpoints to workflow-vars
+// under role-scoped keys (VALIDATOR_TM_RPC, RPC_EVM_RPC, etc.).
+//
+// The YAML is the source of truth for SND shape (preset, overrides, genesis
+// config). CLI flags carry the per-run values (chain-id, image, replicas,
+// name) so the same YAML is reusable across nightly runs.
+package provisionsnd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/taskruntime"
+)
+
+const fieldOwner client.FieldOwner = "seitask-provision-snd"
+
+// Params carries the typed inputs to Run.
+type Params struct {
+	// Role tags the workflow-vars keys this Task writes (e.g. "validator",
+	// "rpc"). Required when running multiple provision-snd Tasks in one
+	// scenario; values get uppercased to compose VALIDATOR_TM_RPC etc.
+	Role string
+
+	// Name is the SeiNodeDeployment metadata.name. Defaults to
+	// "<Workflow.Name>-<Role>" when empty.
+	Name string
+
+	// SpecFile is the YAML path to read the SeiNodeDeployment spec from.
+	// Operator-authored; lives in the scenario ConfigMap mounted at /etc/scenario.
+	SpecFile string
+
+	// ChainID overrides spec.template.spec.chainId + spec.genesis.chainId.
+	// Required.
+	ChainID string
+
+	// Image overrides spec.template.spec.image. Required.
+	Image string
+
+	// Replicas overrides spec.replicas. 0 means "use what's in the YAML".
+	Replicas int32
+
+	// ReadyTimeout bounds the wait for status.phase=Ready.
+	ReadyTimeout time.Duration
+
+	// FirstBlockTimeout bounds the post-Ready wait for the chain to produce
+	// its first block.
+	FirstBlockTimeout time.Duration
+
+	// PollInterval is the interval between status reads (Ready) and chain
+	// RPC reads (first block). Same value used for both — tightly tunable
+	// from tests.
+	PollInterval time.Duration
+
+	// HTTPClient overrides the chain-RPC client; nil means http.DefaultClient.
+	// Tests use this seam.
+	HTTPClient *http.Client
+
+	// Workflow is the parent Chaos Mesh Workflow identity (downward-API).
+	Workflow taskruntime.WorkflowIdentity
+}
+
+// Result is the post-Run summary, returned so main can log it before exit.
+type Result struct {
+	Name      string
+	ChainID   string
+	Endpoints seiv1alpha1.Endpoints
+}
+
+// Run reads the spec YAML, applies overrides, creates the SND with an
+// ownerRef to the parent Workflow, waits for Ready, polls the chain RPC for
+// first block, and writes role-scoped endpoints to workflow-vars.
+func Run(ctx context.Context, c client.Client, p Params) (Result, error) {
+	if err := validateParams(p); err != nil {
+		return Result{}, err
+	}
+	p = withDefaults(p)
+
+	snd, err := loadSpec(p.SpecFile)
+	if err != nil {
+		return Result{}, taskruntime.Infra(fmt.Errorf("loading spec %s: %w", p.SpecFile, err))
+	}
+	applyOverrides(snd, p)
+	stampMetadata(snd, p)
+
+	if err := c.Create(ctx, snd, fieldOwner); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return Result{}, taskruntime.Infra(fmt.Errorf("creating SeiNodeDeployment %s/%s: %w", snd.Namespace, snd.Name, err))
+		}
+		// Re-runs of provision-snd land here on the existing SND — that's
+		// idempotent for our purposes (the controller is reconciling it).
+	}
+
+	if err := waitForReady(ctx, c, types.NamespacedName{Namespace: snd.Namespace, Name: snd.Name}, p.ReadyTimeout, p.PollInterval); err != nil {
+		return Result{}, err
+	}
+
+	current := &seiv1alpha1.SeiNodeDeployment{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: snd.Namespace, Name: snd.Name}, current); err != nil {
+		return Result{}, taskruntime.Infra(fmt.Errorf("re-reading SND post-Ready: %w", err))
+	}
+	if current.Status.Endpoints == nil || current.Status.Endpoints.TendermintRpc == "" {
+		return Result{}, taskruntime.Infra(fmt.Errorf("SND %s reached Ready but .status.endpoints.tendermintRpc is empty", current.Name))
+	}
+	endpoints := *current.Status.Endpoints
+
+	httpClient := p.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	if err := waitForFirstBlock(ctx, httpClient, endpoints.TendermintRpc, p.FirstBlockTimeout, p.PollInterval); err != nil {
+		return Result{}, err
+	}
+
+	if err := publishEndpoints(ctx, c, p.Workflow, p.Role, p.ChainID, endpoints); err != nil {
+		return Result{}, err
+	}
+	return Result{Name: snd.Name, ChainID: p.ChainID, Endpoints: endpoints}, nil
+}
+
+func validateParams(p Params) error {
+	switch {
+	case p.Role == "":
+		return fmt.Errorf("provision-snd: --role is required")
+	case p.SpecFile == "":
+		return fmt.Errorf("provision-snd: --spec-file is required")
+	case p.ChainID == "":
+		return fmt.Errorf("provision-snd: --chain-id is required")
+	case p.Image == "":
+		return fmt.Errorf("provision-snd: --image is required")
+	case p.Workflow.Name == "" || p.Workflow.Namespace == "":
+		return fmt.Errorf("provision-snd: workflow identity not loaded")
+	}
+	return nil
+}
+
+func withDefaults(p Params) Params {
+	if p.Name == "" {
+		p.Name = p.Workflow.Name + "-" + p.Role
+	}
+	if p.ReadyTimeout == 0 {
+		p.ReadyTimeout = 15 * time.Minute
+	}
+	if p.FirstBlockTimeout == 0 {
+		p.FirstBlockTimeout = 5 * time.Minute
+	}
+	if p.PollInterval == 0 {
+		p.PollInterval = 5 * time.Second
+	}
+	return p
+}
+
+func loadSpec(path string) (*seiv1alpha1.SeiNodeDeployment, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	out := &seiv1alpha1.SeiNodeDeployment{}
+	if err := yaml.UnmarshalStrict(data, out); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	return out, nil
+}
+
+func applyOverrides(snd *seiv1alpha1.SeiNodeDeployment, p Params) {
+	snd.Spec.Template.Spec.ChainID = p.ChainID
+	snd.Spec.Template.Spec.Image = p.Image
+	if p.Replicas > 0 {
+		snd.Spec.Replicas = p.Replicas
+	}
+	if snd.Spec.Genesis != nil {
+		snd.Spec.Genesis.ChainID = p.ChainID
+	}
+}
+
+func stampMetadata(snd *seiv1alpha1.SeiNodeDeployment, p Params) {
+	snd.APIVersion = seiv1alpha1.GroupVersion.String()
+	snd.Kind = "SeiNodeDeployment"
+	snd.Name = p.Name
+	snd.Namespace = p.Workflow.Namespace
+	snd.OwnerReferences = append(snd.OwnerReferences, p.Workflow.OwnerRef())
+}
+
+func waitForReady(ctx context.Context, c client.Client, key types.NamespacedName, timeout, interval time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		snd := &seiv1alpha1.SeiNodeDeployment{}
+		if err := c.Get(ctx, key, snd); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil // newly-created, kube-apiserver hasn't observed our Create yet
+			}
+			return false, taskruntime.Infra(fmt.Errorf("reading SND %s: %w", key, err))
+		}
+		switch snd.Status.Phase {
+		case seiv1alpha1.GroupPhaseReady:
+			return true, nil
+		case seiv1alpha1.GroupPhaseFailed:
+			return false, taskruntime.Task(fmt.Errorf("SND %s reached Failed phase", key))
+		}
+		return false, nil
+	})
+}
+
+// tendermintStatusResponse models the subset of Tendermint /status we need.
+// Sei's CometBFT fork sometimes returns the body unwrapped (no JSON-RPC
+// envelope), so we accept both shapes and fall back via Result/SyncInfo.
+type tendermintStatusResponse struct {
+	Result *struct {
+		SyncInfo struct {
+			LatestBlockHeight string `json:"latest_block_height"`
+		} `json:"sync_info"`
+	} `json:"result,omitempty"`
+	SyncInfo *struct {
+		LatestBlockHeight string `json:"latest_block_height"`
+	} `json:"sync_info,omitempty"`
+}
+
+func (r *tendermintStatusResponse) latestHeight() string {
+	if r.Result != nil {
+		return r.Result.SyncInfo.LatestBlockHeight
+	}
+	if r.SyncInfo != nil {
+		return r.SyncInfo.LatestBlockHeight
+	}
+	return ""
+}
+
+func waitForFirstBlock(ctx context.Context, hc *http.Client, tmRPC string, timeout, interval time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, tmRPC+"/status", nil)
+		if err != nil {
+			return false, taskruntime.Infra(fmt.Errorf("building /status request: %w", err))
+		}
+		resp, err := hc.Do(req)
+		if err != nil {
+			return false, nil // transient connect failure during chain warmup; keep polling
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode/100 != 2 {
+			return false, nil
+		}
+		var parsed tendermintStatusResponse
+		if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+			return false, nil // mid-warmup the body can be empty/incomplete
+		}
+		h := parsed.latestHeight()
+		if h == "" || h == "0" {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func publishEndpoints(ctx context.Context, c client.Client, w taskruntime.WorkflowIdentity, role, chainID string, ep seiv1alpha1.Endpoints) error {
+	kv := map[taskruntime.VarKey]string{
+		taskruntime.RoleScoped(role, taskruntime.KeyChainID):       chainID,
+		taskruntime.RoleScoped(role, taskruntime.KeyTendermintRPC): ep.TendermintRpc,
+		taskruntime.RoleScoped(role, taskruntime.KeyTendermintREST): ep.TendermintRest,
+	}
+	// EVM JSON-RPC is per-pod (stateful); publish the first node's URL when
+	// present. Multi-pod EVM consumers should pin to a specific node anyway.
+	if len(ep.Nodes) > 0 && ep.Nodes[0].EvmJsonRpc != "" {
+		kv[taskruntime.RoleScoped(role, taskruntime.KeyEVMJSONRPC)] = ep.Nodes[0].EvmJsonRpc
+	}
+	if err := taskruntime.EnsureWorkflowVarsCM(ctx, c, w, nil); err != nil {
+		return err
+	}
+	return taskruntime.SetVars(ctx, c, w, kv)
+}
+
+// EnsureKubernetesObjectShape is a no-op corev1 import-pinner; the package
+// needs corev1 in transitive test contexts (fake client scheme) and Go's
+// goimports otherwise drops it.
+var _ = corev1.NamespaceAll

--- a/internal/seitask/provisionsnd/provision_test.go
+++ b/internal/seitask/provisionsnd/provision_test.go
@@ -83,7 +83,7 @@ func TestLoadSpec_AppliesOverridesAndOwnerRef(t *testing.T) {
 
 	p := Params{
 		Role:     testRole,
-		Name:     "validator",
+		Name:     testRole,
 		SpecFile: specPath,
 		ChainID:  testChainID,
 		Image:    testImage,
@@ -105,7 +105,7 @@ func TestLoadSpec_AppliesOverridesAndOwnerRef(t *testing.T) {
 	if snd.Spec.Genesis == nil || snd.Spec.Genesis.ChainID != testChainID {
 		t.Fatalf("Genesis.ChainID not propagated: %+v", snd.Spec.Genesis)
 	}
-	if snd.Name != "validator" || snd.Namespace != testNamespace {
+	if snd.Name != testRole || snd.Namespace != testNamespace {
 		t.Fatalf("metadata wrong: %s/%s", snd.Namespace, snd.Name)
 	}
 	if len(snd.OwnerReferences) != 1 || snd.OwnerReferences[0].Kind != "Workflow" {
@@ -162,7 +162,7 @@ func TestRun_EndToEnd_FakeClient(t *testing.T) {
 	prestaged := &seiv1alpha1.SeiNodeDeployment{}
 	if err := loadAndDecorate(specPath, &Params{
 		Role:     testRole,
-		Name:     "validator",
+		Name:     testRole,
 		ChainID:  testChainID,
 		Image:    testImage,
 		Workflow: w,
@@ -186,7 +186,7 @@ func TestRun_EndToEnd_FakeClient(t *testing.T) {
 	defer srv.Close()
 	// Rewrite the prestaged SND's TM RPC to the fake server so the
 	// first-block poll points at something live.
-	if err := c.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: "validator"}, prestaged); err != nil {
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testRole}, prestaged); err != nil {
 		t.Fatal(err)
 	}
 	prestaged.Status.Endpoints.TendermintRpc = srv.URL
@@ -196,7 +196,7 @@ func TestRun_EndToEnd_FakeClient(t *testing.T) {
 
 	res, err := Run(context.Background(), c, Params{
 		Role:              testRole,
-		Name:              "validator",
+		Name:              testRole,
 		SpecFile:          specPath,
 		ChainID:           testChainID,
 		Image:             testImage,
@@ -209,7 +209,7 @@ func TestRun_EndToEnd_FakeClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if res.Name != "validator" || res.ChainID != testChainID {
+	if res.Name != testRole || res.ChainID != testChainID {
 		t.Fatalf("Result: %+v", res)
 	}
 

--- a/internal/seitask/provisionsnd/provision_test.go
+++ b/internal/seitask/provisionsnd/provision_test.go
@@ -1,0 +1,289 @@
+package provisionsnd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/taskruntime"
+)
+
+const (
+	testNamespace      = "nightly"
+	testWorkflowName   = "wf-test"
+	testWorkflowVarsCM = "workflow-vars-wf-test"
+	testRole           = "validator"
+	testChainID        = "bench-1"
+	testImage          = "ghcr.io/sei/sei-chain:abc123"
+)
+
+const baseSpecYAML = `
+apiVersion: sei.io/v1alpha1
+kind: SeiNodeDeployment
+spec:
+  replicas: 4
+  template:
+    spec:
+      validator: {}
+  genesis: {}
+  updateStrategy:
+    type: InPlace
+`
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme,
+		seiv1alpha1.AddToScheme,
+	} {
+		if err := add(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return s
+}
+
+func writeSpec(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "snd.yaml")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func testWorkflow() taskruntime.WorkflowIdentity {
+	return taskruntime.WorkflowIdentity{Name: testWorkflowName, UID: "uid-test", Namespace: testNamespace}
+}
+
+func TestLoadSpec_AppliesOverridesAndOwnerRef(t *testing.T) {
+	specPath := writeSpec(t, baseSpecYAML)
+
+	snd, err := loadSpec(specPath)
+	if err != nil {
+		t.Fatalf("loadSpec: %v", err)
+	}
+	if snd.Spec.Replicas != 4 {
+		t.Fatalf("base replicas: %d", snd.Spec.Replicas)
+	}
+
+	p := Params{
+		Role:     testRole,
+		Name:     "validator",
+		SpecFile: specPath,
+		ChainID:  testChainID,
+		Image:    testImage,
+		Replicas: 7,
+		Workflow: testWorkflow(),
+	}
+	applyOverrides(snd, p)
+	stampMetadata(snd, p)
+
+	if snd.Spec.Template.Spec.ChainID != testChainID {
+		t.Fatalf("ChainID not propagated: %q", snd.Spec.Template.Spec.ChainID)
+	}
+	if snd.Spec.Template.Spec.Image != testImage {
+		t.Fatalf("Image not propagated: %q", snd.Spec.Template.Spec.Image)
+	}
+	if snd.Spec.Replicas != 7 {
+		t.Fatalf("Replicas override not applied: %d", snd.Spec.Replicas)
+	}
+	if snd.Spec.Genesis == nil || snd.Spec.Genesis.ChainID != testChainID {
+		t.Fatalf("Genesis.ChainID not propagated: %+v", snd.Spec.Genesis)
+	}
+	if snd.Name != "validator" || snd.Namespace != testNamespace {
+		t.Fatalf("metadata wrong: %s/%s", snd.Namespace, snd.Name)
+	}
+	if len(snd.OwnerReferences) != 1 || snd.OwnerReferences[0].Kind != "Workflow" {
+		t.Fatalf("ownerRef not stamped: %+v", snd.OwnerReferences)
+	}
+}
+
+func TestLoadSpec_RejectsMalformed(t *testing.T) {
+	specPath := writeSpec(t, "not: valid: yaml: ::")
+	if _, err := loadSpec(specPath); err == nil {
+		t.Fatalf("expected unmarshal error")
+	}
+}
+
+func TestValidateParams(t *testing.T) {
+	full := Params{
+		Role:     testRole,
+		SpecFile: "x.yaml",
+		ChainID:  testChainID,
+		Image:    testImage,
+		Workflow: testWorkflow(),
+	}
+	cases := []struct {
+		name string
+		mut  func(*Params)
+		want bool // wantErr
+	}{
+		{"complete", func(*Params) {}, false},
+		{"missing role", func(p *Params) { p.Role = "" }, true},
+		{"missing spec-file", func(p *Params) { p.SpecFile = "" }, true},
+		{"missing chain-id", func(p *Params) { p.ChainID = "" }, true},
+		{"missing image", func(p *Params) { p.Image = "" }, true},
+		{"missing workflow.Name", func(p *Params) { p.Workflow.Name = "" }, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := full
+			tc.mut(&p)
+			err := validateParams(p)
+			if (err != nil) != tc.want {
+				t.Fatalf("validateParams err=%v wantErr=%v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRun_EndToEnd_FakeClient(t *testing.T) {
+	specPath := writeSpec(t, baseSpecYAML)
+	w := testWorkflow()
+
+	// Pre-stage a Ready SND with endpoints so waitForReady's polling sees
+	// the terminal state on the first tick. Mirrors how the controller
+	// would have promoted the CR after a Create.
+	prestaged := &seiv1alpha1.SeiNodeDeployment{}
+	if err := loadAndDecorate(specPath, &Params{
+		Role:     testRole,
+		Name:     "validator",
+		ChainID:  testChainID,
+		Image:    testImage,
+		Workflow: w,
+	}, prestaged); err != nil {
+		t.Fatal(err)
+	}
+	prestaged.Status.Phase = seiv1alpha1.GroupPhaseReady
+	prestaged.Status.Endpoints = &seiv1alpha1.Endpoints{
+		TendermintRpc:  "http://tm.svc:26657",
+		TendermintRest: "http://rest.svc:1317",
+		Nodes:          []seiv1alpha1.NodeEndpoint{{Name: "validator-0", EvmJsonRpc: "http://evm.svc:8545"}},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(prestaged).
+		WithStatusSubresource(&seiv1alpha1.SeiNodeDeployment{}).
+		Build()
+
+	srv := fakeStatusServer(t, "42")
+	defer srv.Close()
+	// Rewrite the prestaged SND's TM RPC to the fake server so the
+	// first-block poll points at something live.
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: "validator"}, prestaged); err != nil {
+		t.Fatal(err)
+	}
+	prestaged.Status.Endpoints.TendermintRpc = srv.URL
+	if err := c.Status().Update(context.Background(), prestaged); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Run(context.Background(), c, Params{
+		Role:              testRole,
+		Name:              "validator",
+		SpecFile:          specPath,
+		ChainID:           testChainID,
+		Image:             testImage,
+		ReadyTimeout:      2 * time.Second,
+		FirstBlockTimeout: 2 * time.Second,
+		PollInterval:      10 * time.Millisecond,
+		HTTPClient:        srv.Client(),
+		Workflow:          w,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Name != "validator" || res.ChainID != testChainID {
+		t.Fatalf("Result: %+v", res)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: testWorkflowVarsCM}, cm); err != nil {
+		t.Fatalf("get CM: %v", err)
+	}
+	if got := cm.Data["VALIDATOR_CHAIN_ID"]; got != testChainID {
+		t.Fatalf("VALIDATOR_CHAIN_ID = %q", got)
+	}
+	if cm.Data["VALIDATOR_TM_RPC"] == "" {
+		t.Fatalf("VALIDATOR_TM_RPC empty")
+	}
+	if cm.Data["VALIDATOR_EVM_RPC"] != "http://evm.svc:8545" {
+		t.Fatalf("VALIDATOR_EVM_RPC = %q", cm.Data["VALIDATOR_EVM_RPC"])
+	}
+}
+
+// fakeStatusServer returns a /status endpoint that reports the given height.
+// Tests the JSON-RPC-envelope-or-bare tolerance: server emits the bare
+// `{"sync_info": ...}` shape (Sei CometBFT's default).
+func fakeStatusServer(t *testing.T, height string) *httptest.Server {
+	t.Helper()
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"sync_info": map[string]any{
+				"latest_block_height": height,
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// loadAndDecorate is the test-side mirror of the production loadSpec +
+// applyOverrides + stampMetadata pipeline. Used to materialize the
+// pre-staged SND the fake client serves.
+func loadAndDecorate(specPath string, p *Params, into *seiv1alpha1.SeiNodeDeployment) error {
+	parsed, err := loadSpec(specPath)
+	if err != nil {
+		return err
+	}
+	applyOverrides(parsed, *p)
+	stampMetadata(parsed, *p)
+	*into = *parsed
+	return nil
+}
+
+func TestTendermintStatusResponse_LatestHeight(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"jsonrpc envelope", `{"result":{"sync_info":{"latest_block_height":"42"}}}`, "42"},
+		{"bare", `{"sync_info":{"latest_block_height":"7"}}`, "7"},
+		{"empty", `{}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var r tendermintStatusResponse
+			if err := json.Unmarshal([]byte(tc.body), &r); err != nil {
+				t.Fatal(err)
+			}
+			if got := r.latestHeight(); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/taskruntime/vars.go
+++ b/internal/taskruntime/vars.go
@@ -1,5 +1,7 @@
 package taskruntime
 
+import "strings"
+
 // VarKey is a typed key for the workflow-vars ConfigMap. Producers and
 // consumers reference these constants so renames are compile errors. Schema +
 // stability discipline: docs/design/test-harness-lld.md.
@@ -47,4 +49,11 @@ func ExitReasonFor(err error) ExitReason {
 	default:
 		return ExitReasonTaskFail
 	}
+}
+
+// RoleScoped prefixes a key with an upper-cased role tag so scenarios with
+// multiple SNDs (validator + rpc) write disjoint workflow-vars keys.
+// RoleScoped("validator", KeyTendermintRPC) → "VALIDATOR_TM_RPC".
+func RoleScoped(role string, key VarKey) VarKey {
+	return VarKey(strings.ToUpper(role) + "_" + string(key))
 }

--- a/internal/taskruntime/vars_test.go
+++ b/internal/taskruntime/vars_test.go
@@ -5,6 +5,25 @@ import (
 	"testing"
 )
 
+func TestRoleScoped(t *testing.T) {
+	cases := []struct {
+		role string
+		key  VarKey
+		want VarKey
+	}{
+		{"validator", KeyTendermintRPC, "VALIDATOR_TM_RPC"},
+		{"rpc", KeyEVMJSONRPC, "RPC_EVM_RPC"},
+		{"Validator", KeyChainID, "VALIDATOR_CHAIN_ID"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.want), func(t *testing.T) {
+			if got := RoleScoped(tc.role, tc.key); got != tc.want {
+				t.Fatalf("RoleScoped(%q, %q) = %q, want %q", tc.role, tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestExitReasonFor(t *testing.T) {
 	plain := errors.New("plain")
 	cases := []struct {


### PR DESCRIPTION
Phase 1 follow-up to #309. Adds the `provision-snd` subcommand: apply a SeiNodeDeployment from a YAML spec mounted via ConfigMap, wait for `status.phase=Ready`, poll the chain RPC for first block, then publish role-scoped endpoints (`VALIDATOR_TM_RPC`, `RPC_EVM_RPC`, etc.) to the per-run workflow-vars ConfigMap.

## What lands
- **`internal/seitask/provisionsnd/`** — typed `Params`, YAML spec loader, CLI-flag overrides for per-run values (`--chain-id`, `--image`, `--replicas`, `--name`), ownerRef stamping, Create-or-AlreadyExists idempotent apply, `client.Get` polling for Ready phase, HTTP polling for first block with envelope-or-bare JSON tolerance for Sei's CometBFT `/status`.
- **`cmd/seitask/provision_snd.go`** — urfave/cli wiring with env-var sources for K8s-injected values.
- **`internal/taskruntime/RoleScoped(role, key)`** — helper so concurrent SND provisioners (validator + rpc) write disjoint workflow-vars keys.

## Design
The YAML spec is the source of truth for SND *shape* (preset baseline, overrides, genesis config); CLI flags carry the per-run values (chain-id, image, replicas, name) so the same YAML is reusable across nightly invocations. No envsubst/templating at runtime — the unmarshal-then-override-then-stamp pipeline does it in typed Go.

## Test coverage
- `provision_test.go` — YAML load + override + ownerRef stamping; param validation; end-to-end run against a fake client + httptest server (verifies the full Create → Ready → first-block → publish-endpoints pipeline including `VALIDATOR_TM_RPC` / `VALIDATOR_EVM_RPC` workflow-vars writes); envelope-or-bare JSON shape tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)