### PR TITLE
feat(noderesource): wait-on-:9090 bash wrapper for cosmos-exporter

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -51,6 +51,8 @@ const (
 	// seidStartSubcommand is the seid subcommand that boots the node.
 	seidStartSubcommand = "start"
 
+	shellBash = "/bin/bash"
+
 	// Pod-spec container names. Used as both the .Name on built containers
 	// and the lookup key for the operator-keyring containment guard.
 	containerNameSeid                 = "seid"
@@ -492,7 +494,7 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) (corev1.PodSp
 		buildSidecarContainer(node, p),
 		buildRBACProxyContainer(node, p),
 	}
-	ceContainer, err := buildCosmosExporterContainer(node, p)
+	ceContainer, err := buildCosmosExporterContainer(p)
 	if err != nil {
 		return corev1.PodSpec{}, err
 	}
@@ -609,47 +611,75 @@ func defaultCosmosExporterResources() corev1.ResourceRequirements {
 	}
 }
 
-// cosmosExporterReadinessProbePort: validators probe Tendermint RPC (gRPC
-// is disabled), other modes probe seid's gRPC.
-func cosmosExporterReadinessProbePort(node *seiv1alpha1.SeiNode) int32 {
-	if node.Spec.Validator != nil {
-		return seiconfig.PortRPC
+// cosmosExporterWaitCommand renders bash that waits for seid's gRPC port,
+// then exec's cosmos-exporter. Container.Command overrides ENTRYPOINT, so
+// the binary path is spelled out.
+func cosmosExporterWaitCommand() (command []string, args []string) {
+	exporter := "/usr/local/bin/sei-cosmos-exporter"
+	exporterArgs := []string{
+		"--denom", "usei",
+		"--denom-coefficient", "1000000",
+		"--bech-prefix", "sei",
+		"--listen-address", fmt.Sprintf(":%d", defaultCosmosExporterPort),
 	}
-	return seiconfig.PortGRPC
+
+	var b strings.Builder
+	b.WriteString(exporter)
+	for _, a := range exporterArgs {
+		fmt.Fprintf(&b, " %q", a)
+	}
+
+	script := fmt.Sprintf(
+		`echo "waiting for gRPC :%d to be available..."; `+
+			`until (exec 3<>/dev/tcp/localhost/%d) 2>/dev/null; do `+
+			`sleep 5; done; `+
+			`echo "gRPC available, starting cosmos-exporter"; `+
+			`exec %s`,
+		seiconfig.PortGRPC, seiconfig.PortGRPC, b.String(),
+	)
+
+	return []string{shellBash, "-c"}, []string{script}
 }
 
 // buildCosmosExporterContainer renders the cosmos-exporter sidecar.
-func buildCosmosExporterContainer(node *seiv1alpha1.SeiNode, p PlatformConfig) (corev1.Container, error) {
+func buildCosmosExporterContainer(p PlatformConfig) (corev1.Container, error) {
 	if p.CosmosExporterImage == "" {
 		return corev1.Container{}, fmt.Errorf("SEI_COSMOS_EXPORTER_IMAGE is required on the operator Deployment")
 	}
+	command, args := cosmosExporterWaitCommand()
 	return corev1.Container{
-		Name:  containerNameCosmosExporter,
-		Image: p.CosmosExporterImage,
-		Args: []string{
-			"--denom", "usei",
-			"--denom-coefficient", "1000000",
-			"--bech-prefix", "sei",
-			"--listen-address", fmt.Sprintf(":%d", defaultCosmosExporterPort),
-			// --node and --tendermint-rpc default to localhost; the
-			// exporter shares the pod's net ns with seid.
-		},
+		Name:    containerNameCosmosExporter,
+		Image:   p.CosmosExporterImage,
+		Command: command,
+		Args:    args,
 		Ports: []corev1.ContainerPort{
 			{Name: "cosmos-metrics", ContainerPort: defaultCosmosExporterPort, Protocol: corev1.ProtocolTCP},
 		},
 		SecurityContext: sidecarSecurityContext(),
 		Resources:       defaultCosmosExporterResources(),
-		// /tmp: distroless + ReadOnlyRootFilesystem EROFS insurance.
+		// /tmp: ReadOnlyRootFilesystem EROFS insurance.
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: sidecarTmpVolumeName, MountPath: sidecarTmpMountPath},
 		},
+		// Generous failureThreshold so Prometheus targets don't flap while
+		// the wait loop holds :9300 off during cold start.
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt32(cosmosExporterReadinessProbePort(node)),
+					Port: intstr.FromInt32(defaultCosmosExporterPort),
 				},
 			},
-			InitialDelaySeconds: 5,
+			PeriodSeconds:    10,
+			FailureThreshold: 6,
+		},
+		// InitialDelaySeconds: 600 gives the wait loop room before kubelet probes.
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt32(defaultCosmosExporterPort),
+				},
+			},
+			InitialDelaySeconds: 600,
 			PeriodSeconds:       10,
 			FailureThreshold:    3,
 		},
@@ -680,7 +710,7 @@ func sidecarWaitCommand(node *seiv1alpha1.SeiNode) (command []string, args []str
 		SidecarPort(node), b.String(),
 	)
 
-	return []string{"/bin/bash", "-c"}, []string{script}
+	return []string{shellBash, "-c"}, []string{script}
 }
 
 func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -1352,34 +1352,47 @@ func TestCosmosExporter_ErrorWhenImageUnset(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("SEI_COSMOS_EXPORTER_IMAGE is required"))
 }
 
-func TestCosmosExporter_ReadinessProbe_FullNodeTargetsGRPC(t *testing.T) {
-	g := NewWithT(t)
-	node := newSnapshotNode("ce-fn-0", "default")
+func TestCosmosExporter_ReadinessProbe_TargetsExporterListener(t *testing.T) {
+	for _, name := range []string{"full", roleValidator} {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			var node *seiv1alpha1.SeiNode
+			if name == roleValidator {
+				node = newGenesisNode("ce-val-0", "default")
+			} else {
+				node = newSnapshotNode("ce-fn-0", "default")
+			}
 
-	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
-	ce := findContainer(sts.Spec.Template.Spec.Containers, containerNameCosmosExporter)
+			sts := mustGenerateStatefulSet(t, node, platformtest.Config())
+			ce := findContainer(sts.Spec.Template.Spec.Containers, containerNameCosmosExporter)
 
-	g.Expect(ce.StartupProbe).To(BeNil())
-	g.Expect(ce.ReadinessProbe).NotTo(BeNil())
-	g.Expect(ce.ReadinessProbe.TCPSocket).NotTo(BeNil())
-	g.Expect(ce.ReadinessProbe.TCPSocket.Port.IntVal).To(Equal(int32(9090)))
-	g.Expect(ce.ReadinessProbe.PeriodSeconds).To(Equal(int32(10)))
-	g.Expect(ce.ReadinessProbe.FailureThreshold).To(Equal(int32(3)))
+			g.Expect(ce.StartupProbe).To(BeNil())
+			g.Expect(ce.ReadinessProbe).NotTo(BeNil())
+			g.Expect(ce.ReadinessProbe.TCPSocket).NotTo(BeNil())
+			g.Expect(ce.ReadinessProbe.TCPSocket.Port.IntVal).To(Equal(int32(9300)))
+			g.Expect(ce.ReadinessProbe.PeriodSeconds).To(Equal(int32(10)))
+			g.Expect(ce.ReadinessProbe.FailureThreshold).To(Equal(int32(6)))
+
+			g.Expect(ce.LivenessProbe).NotTo(BeNil())
+			g.Expect(ce.LivenessProbe.TCPSocket).NotTo(BeNil())
+			g.Expect(ce.LivenessProbe.TCPSocket.Port.IntVal).To(Equal(int32(9300)))
+			g.Expect(ce.LivenessProbe.InitialDelaySeconds).To(Equal(int32(600)))
+			g.Expect(ce.LivenessProbe.FailureThreshold).To(Equal(int32(3)))
+		})
+	}
 }
 
-func TestCosmosExporter_ReadinessProbe_ValidatorTargetsTendermintRPC(t *testing.T) {
+func TestCosmosExporter_CommandIsBashWaitWrapper(t *testing.T) {
 	g := NewWithT(t)
-	node := newGenesisNode("ce-val-0", "default")
+	node := newSnapshotNode("ce-0", "default")
 
 	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
 	ce := findContainer(sts.Spec.Template.Spec.Containers, containerNameCosmosExporter)
 
-	g.Expect(ce.StartupProbe).To(BeNil())
-	g.Expect(ce.ReadinessProbe).NotTo(BeNil())
-	g.Expect(ce.ReadinessProbe.TCPSocket).NotTo(BeNil())
-	g.Expect(ce.ReadinessProbe.TCPSocket.Port.IntVal).To(Equal(int32(26657)))
-	g.Expect(ce.ReadinessProbe.PeriodSeconds).To(Equal(int32(10)))
-	g.Expect(ce.ReadinessProbe.FailureThreshold).To(Equal(int32(3)))
+	g.Expect(ce.Command).To(Equal([]string{"/bin/bash", "-c"}))
+	g.Expect(ce.Args).To(HaveLen(1))
+	g.Expect(ce.Args[0]).To(ContainSubstring("/dev/tcp/localhost/9090"))
+	g.Expect(ce.Args[0]).To(ContainSubstring("exec /usr/local/bin/sei-cosmos-exporter"))
 }
 
 func TestCosmosExporter_MountsTmpEmptyDir(t *testing.T) {
@@ -1406,11 +1419,10 @@ func TestCosmosExporter_SeiArgs(t *testing.T) {
 	sts := mustGenerateStatefulSet(t, node, platformtest.Config())
 	ce := findContainer(sts.Spec.Template.Spec.Containers, containerNameCosmosExporter)
 
-	g.Expect(ce.Args).To(ContainElements(
-		"--denom", "usei",
-		"--denom-coefficient", "1000000",
-		"--bech-prefix", "sei",
-	))
+	g.Expect(ce.Args).To(HaveLen(1))
+	g.Expect(ce.Args[0]).To(ContainSubstring(`"--denom" "usei"`))
+	g.Expect(ce.Args[0]).To(ContainSubstring(`"--denom-coefficient" "1000000"`))
+	g.Expect(ce.Args[0]).To(ContainSubstring(`"--bech-prefix" "sei"`))
 }
 
 func TestCosmosExporter_DefaultResources(t *testing.T) {


### PR DESCRIPTION
## Summary

Replaces cosmos-exporter's direct entrypoint with a bash wait-then-exec wrapper modeled on `sidecarWaitCommand`. Eliminates the 5-min metric gap caused by cosmos-exporter's `log.Fatal()` on initial gRPC dial when seid isn't yet up.

## Behavior change

| State | Before | After |
|---|---|---|
| seid down at startup | `Fatal()` → CrashLoopBackOff → kubelet backoff up to 5min | Container Running in wait loop |
| seid binds :9090 | Up to 5min before next restart succeeds | Wait loop exits → exec cosmos-exporter → Ready within one probe period |
| Validators (gRPC disabled pre sei-config #19) | Permanent CrashLoopBackOff | Permanent Running + NotReady (clean signal, no churn) |

## Probe shape (per kubernetes-specialist cross-review)

- **Readiness**: TCPSocket `:9300` (exporter's own listener — Ready iff exporter has actually bound its port). `PeriodSeconds=10`, `FailureThreshold=6`.
- **Liveness** (new): TCPSocket `:9300`, `InitialDelaySeconds=600`. Catches post-bind wedges.

Drops the mode-conditional `cosmosExporterReadinessProbePort` helper — uniform `:9300` across all node modes. Closes #312 once propagation completes.

## Cross-review

Direction reviewed by platform-engineer + kubernetes-specialist (both proceed-with-conditions). Conditions applied in this diff.

## Sequencing dependency

**MUST NOT MERGE** before \`SEI_COSMOS_EXPORTER_IMAGE\` is bumped to a build of sei-protocol/sei-cosmos-exporter@b76f8f9 or later. Current distroless image has no \`/bin/bash\`. New digest available: \`sha256:d7e7a6b0eeb5c969730fe8a56c670be20e2b6b3ce4061e970c9ec867bd7e54a1\`.

Per platform-engineer's harbor-first canary: bump harbor overlay → verify → bump dev + prod → merge this PR.

## Test plan

- [x] \`go test ./...\` passes
- [x] \`golangci-lint --new-from-rev origin/main\` clean
- [x] Harbor verification: cosmos-exporter Ready under new ubuntu base
- [x] Validator verification: Ready post sei-config v0.0.15 propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)