### PR TITLE
chore(config): bump manager image to 7caf9ba (post-#318)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:80f148fec0bf6915d1fc0a82225f19720765ac07
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:7caf9ba01f7a492ffdb567fd70871e7f1cd202f3
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Picks up the cosmos-exporter bash wait wrapper landed in #318.

Image: \`189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:7caf9ba01f7a492ffdb567fd70871e7f1cd202f3\`
Digest: \`sha256:871f9190999f3a1c482b1b5265c5fb03b5ef243297c059753f270cd7149f75e4\`

## Sequencing dependency

The new controller renders \`Command: ["/bin/bash", "-c"]\` on the cosmos-exporter sidecar. This requires the cosmos-exporter image to provide \`/bin/bash\`. Platform overlay needs to bump \`SEI_COSMOS_EXPORTER_IMAGE\` to a build of sei-protocol/sei-cosmos-exporter@b76f8f9 or later (digest \`sha256:d7e7a6b0...\`) before any pod cycle. Harbor-first canary recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)