### PR TITLE
test(networking): TypeMeta + BackendRef-defaults invariants for HTTPRoute

### DIFF
--- a/internal/controller/nodedeployment/networking_test.go
+++ b/internal/controller/nodedeployment/networking_test.go
@@ -193,6 +193,53 @@ func TestGenerateHTTPRoute_ManagedByAnnotation(t *testing.T) {
 	g.Expect(route.Annotations).To(HaveKeyWithValue("sei.io/managed-by", "seinodedeployment"))
 }
 
+// TestGenerateHTTPRoute_TypeMeta locks down the apiVersion/kind on the
+// constructed object. The typed builder must populate TypeMeta so the SSA
+// apply path serializes the same top-level keys the unstructured builder
+// did pre-#316; an empty TypeMeta would silently break server-side apply.
+func TestGenerateHTTPRoute_TypeMeta(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("pacific-1-wave", "pacific-1")
+	group.Spec.Networking = &seiv1alpha1.NetworkingConfig{}
+
+	routes := resolveEffectiveRoutes(group, "prod.platform.sei.io", "platform.sei.io")
+	route := generateHTTPRoute(group, routes[0], "sei-gateway", "gateway")
+
+	g.Expect(route.APIVersion).To(Equal("gateway.networking.k8s.io/v1"))
+	g.Expect(route.Kind).To(Equal("HTTPRoute"))
+}
+
+// TestGenerateHTTPRoute_BackendRefDefaultsServerSide is the load-bearing
+// guard against accidental SSA field-ownership creep. The controller must
+// leave BackendObjectReference.{Group,Kind} unset (nil) so the apiserver
+// applies the documented defaults (core/Service) on its side. Setting
+// them explicitly would cause field-manager "seinode-controller" to claim
+// those paths, fighting any future operator who tries to retarget a
+// backend via kubectl edit.
+func TestGenerateHTTPRoute_BackendRefDefaultsServerSide(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("pacific-1-wave", "pacific-1")
+	group.Spec.Networking = &seiv1alpha1.NetworkingConfig{}
+
+	routes := resolveEffectiveRoutes(group, "prod.platform.sei.io", "platform.sei.io")
+	g.Expect(routes).NotTo(BeEmpty())
+
+	for _, er := range routes {
+		route := generateHTTPRoute(group, er, "sei-gateway", "gateway")
+		g.Expect(route.Spec.Rules).NotTo(BeEmpty())
+		for ri, rule := range route.Spec.Rules {
+			for bi, b := range rule.BackendRefs {
+				g.Expect(b.Group).To(BeNil(),
+					"route %s rule[%d] backend[%d]: BackendRef.Group must be nil (server-defaulted to core)",
+					er.Name, ri, bi)
+				g.Expect(b.Kind).To(BeNil(),
+					"route %s rule[%d] backend[%d]: BackendRef.Kind must be nil (server-defaulted to Service)",
+					er.Name, ri, bi)
+			}
+		}
+	}
+}
+
 func TestGenerateHTTPRoute_BackendRef(t *testing.T) {
 	g := NewWithT(t)
 	group := newTestGroup("pacific-1-wave", "pacific-1")


### PR DESCRIPTION
## Summary

Follow-up to #316. Adds two regression-armor tests the Coral review surfaced as load-bearing but didn't make it into the original PR (my fault — was teed up for bundling, then got lost in the merge sequence).

Test-only change, no production code touched. **Net: 1 file, +52 / -0.**

## What's added

| Test | What it locks down |
|---|---|
| `TestGenerateHTTPRoute_TypeMeta` | `route.APIVersion == "gateway.networking.k8s.io/v1"` + `route.Kind == "HTTPRoute"`. The SSA apply path relies on these top-level keys matching what the unstructured builder produced pre-#316; empty `TypeMeta` would silently break server-side apply with no compile-time signal. |
| `TestGenerateHTTPRoute_BackendRefDefaultsServerSide` | Every `BackendObjectReference.{Group,Kind}` is `nil`. Setting them explicitly would cause field-manager `seinode-controller` to claim those paths via SSA, fighting any future operator who tries to retarget a backend. Locks down the no-server-default-claim invariant Coral k8s-specialist flagged. |

## Test plan

- [x] `go test ./internal/controller/nodedeployment/ -run 'TestGenerateHTTPRoute_(TypeMeta\|BackendRefDefaultsServerSide)' -v` — both pass
- [x] `go test ./...` exits 0
- [x] No new lint issues from these test additions (CI uses `only-new-issues: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)