### PR TITLE
feat(uploadreport): default --region to eu-central-1

### DIFF
--- a/cmd/seitask/upload_report.go
+++ b/cmd/seitask/upload_report.go
@@ -36,7 +36,7 @@ func newUploadReportCommand() *cli.Command {
 				Name:    "region",
 				Usage:   "AWS region",
 				Sources: cli.EnvVars("AWS_REGION"),
-				Value:   "us-east-2",
+				Value:   "eu-central-1",
 			},
 		},
 		Action: runUploadReport,


### PR DESCRIPTION
## Summary

- `harbor-validation-results` lives in **eu-central-1** (the harbor EKS cluster region), not us-east-2.
- Defaulting to us-east-2 meant every scenario YAML had to set `AWS_REGION=eu-central-1` or the SDK signed PutObject for the wrong region.
- Move the default to where the bucket actually is; other-region uses can still override via `--region` or `AWS_REGION`.

Paired with the IAM grant in sei-protocol/platform#625 that binds Pod Identity for `nightly/default` to `s3:PutObject` on the same bucket.

## Test plan

- [x] `go build ./...` passes
- [x] Unit tests pass (`go test ./internal/seitask/uploadreport/...`)
- [x] End-to-end nightly scenario writes to `s3://harbor-validation-results/nightly/...` after #625 applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)