### PR TITLE
docs(CLAUDE.md): codify the conditions convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,43 @@ if err := r.Status().Patch(ctx, obj, patch); err != nil { ... }
 
 The single-patch reconcile model means each reconcile snapshots `obj.DeepCopy()` once, accumulates mutations in-memory, and flushes one optimistic-lock-protected `Status().Patch` at the end. Code-review checklist item: every `r.Status().Patch` call site must use a base built with `MergeFromWithOptimisticLock{}`.
 
+### Conditions
+
+Every `metav1.Condition` on `SeiNodeDeployment`, `SeiNode`, or `SeiNodeTask` follows the Kubernetes upstream pattern: **once a controller sets a condition, it stays present on the reconciled object**, transitioning between `True` / `False` / `Unknown` with a stable `Reason` and a `lastTransitionTime`. This is the default — "School 1." It matches Pod (`Ready`, `Initialized`, `ContainersReady`, `PodScheduled` — stably present once the kubelet has begun processing the pod), Deployment (`Available`, `Progressing` — stably present once the Deployment reconciles), Gateway-API HTTPRoute (`Accepted`, `ResolvedRefs` — stably present per ParentRef once the implementation reconciles it), and CAPI Cluster/Machine (`Ready`, `InfrastructureReady` — stably present after first reconcile). Even "feature off" or "feature broken" states are expressed as `Status=False, Reason=<stable enum value>` — never as absence.
+
+**Use:**
+
+```go
+setCondition(obj, ConditionNetworkingReady, metav1.ConditionFalse,
+    "NetworkingDisabled", "spec.networking is unset; no HTTPRoutes published")
+```
+
+**Do not use** for steady-state transitions:
+
+- `removeCondition(obj, ...)` to express "feature is off." Use `setCondition(False, <reason>)` instead. Removal is indistinguishable in `kubectl describe` from "controller never reached this code path" and forces PromQL consumers into brittle `absent()` queries.
+
+The narrow exceptions to the always-present rule are **School 2**:
+
+- **`*Needed`-style conditions** where `True` is the exception and `False` would be tautological. `GenesisCeremonyNeeded` is the canonical sei example — its `False` value is redundant with the absence of the feature.
+- **`kubectl wait` consumer conditions** where present-vs-absent semantics are explicitly load-bearing. `SeiNodeTask.Status.Conditions[Ready|Failed]` is documented as latch-on-terminal-state because the seitask-runner depends on `kubectl wait --for=condition=Ready=true` (which matches `True` only) and `--for=condition=Failed=true` as the dual exit signal. The Ready+Failed pair is the documented exception to the "no mixed polarities for the same subject" rule below — both latch independently on terminal state.
+
+Any new condition that doesn't fit one of these exceptions defaults to School 1.
+
+**Naming:**
+
+- **`<Subject>Ready`** — `True` is the desired steady state. School 1. Use `False/<reason>` for both "not yet ready" and "not configured."
+- **`<Subject>InProgress`** — `True` is the exception, `False` is steady state. School 1. Always seed `False` on first reconcile.
+- **`<Subject>Complete`** — latch-True. School 1. Seed `False/NotStarted` for discoverability.
+- **`<Subject>Needed`** — School 2 acceptable.
+
+Don't mix polarities for the same subject (no `RouteReady` + `RouteFailed` — pick one and use reasons). The SeiNodeTask `Ready`/`Failed` pair is the documented exception, justified by the `kubectl wait` consumer contract.
+
+**Spec-shape changes don't remove conditions.** If a SeiNode transitions from validator to non-validator (or any condition's preconditions become structurally inapplicable), set the condition to `False/NotApplicable` rather than removing it. Removal forces consumers to treat absence as ambiguous; an explicit `NotApplicable` reason carries the intent.
+
+**Reasons are a stable enum.** Treat `Reason` as the public API for runbooks and alerting. Use `CamelCase` value strings. Don't put dynamic data in the reason — that goes in the message. PromQL keyed on `kube_..._status_condition{type="X", reason="Y", status="..."}` should yield a small, finite set of label combinations.
+
+**`ObservedGeneration` discipline.** Every `setCondition` call site must populate `condition.ObservedGeneration = obj.Generation` so consumers can tell whether a condition reflects the current spec. The `setCondition` helpers in each controller's `status.go` do this automatically; direct `apimeta.SetStatusCondition` calls must set it explicitly. The four direct calls in `internal/controller/nodetask/controller.go` are a known divergence; harmonize on first edit through that file.
+
 ### Testing
 - Tests use `testing` + `gomega` for assertions.
 - Test fixtures for platform config live in `internal/platform/platformtest/`.


### PR DESCRIPTION
## Summary

Adds a `### Conditions` section to `CLAUDE.md` next to `### Status patches`. Codifies the working convention for `metav1.Condition` lifecycle across all three controllers (`SeiNodeDeployment`, `SeiNode`, `SeiNodeTask`).

**Net: 1 file, +37 / 0.**

## Why now

Today the codebase mixes two patterns:

- **School 1 (always-present, transition with reason)** — `NodesReady`, `GenesisCeremonyComplete`, `PlanInProgress`, `RolloutInProgress`, `TargetReady`
- **School 2 (absent-when-not-applicable)** — `RouteReady`, `GenesisCeremonyNeeded`, `ImportPVCReady`, `SigningKeyReady`, `NodeKeyReady`, `OperatorKeyringReady`, SeiNodeTask `Ready`/`Failed`

`RouteReady` was originally surfaced by the SRE Coral review on the envtest Phase 5 orphan-cleanup PR: the condition is *removed* when `spec.networking` is unset, which is indistinguishable in `kubectl describe` from "controller hasn't reconciled yet." Before fixing one site, we want the doctrine.

Coral cross-review (kubernetes-specialist + sre-engineer) converged unambiguously:

- **K8s upstream lean is unambiguously School 1.** Pod, Deployment, Gateway-API HTTPRoute, CAPI Cluster/Machine all use always-present-with-reason. Even broken states (`BackendNotFound`) are expressed as `Status=False, Reason=BackendNotFound`, never as absence. Deployment's `ReplicaFailure` is the rare canonical School 2 (transient exception condition).
- **SRE would block the forthcoming `Paused` PR specifically** to insist it ships School 1, because PromQL keyed on `kube_..._status_condition{type="Paused"}` becomes brittle if the condition disappears when not paused (`absent()` gymnastics, false-positive scrape-down alarms on Grafana panels).
- **Don't retroactively flip every condition.** The doctrine is the precedent; `RouteReady` → `NetworkingReady` is the first conversion (PR B); the rest harmonize on first edit through their respective controller files.

## What the doctrine says

1. **School 1 is the default.** Once set, a condition stays present on the reconciled object. Transitions express state via `Status` + `Reason` + `lastTransitionTime`.
2. **School 2 has two narrow allowances:** `*Needed`-style (where `False` would be tautological) and `kubectl wait` consumers where present-vs-absent semantics are load-bearing (SeiNodeTask).
3. **Naming**: `*Ready` / `*InProgress` / `*Complete` → School 1; `*Needed` → School 2. No mixed polarities for the same subject (the SeiNodeTask `Ready`/`Failed` pair is the documented exception, justified by `kubectl wait --for=condition=Ready=true` + `--for=condition=Failed=true` dual-exit signaling).
4. **Spec-shape changes don't remove conditions.** Set `False/NotApplicable` instead.
5. **Reasons are a stable enum.** `CamelCase`, finite set per condition type. Dynamic data goes in the message.
6. **`ObservedGeneration` discipline.** Every `setCondition` site populates it. The four direct `apimeta.SetStatusCondition` calls in `internal/controller/nodetask/controller.go` are a known divergence to harmonize on first edit through that file.

## Coral cross-review on this PR

K8s-specialist flagged:
- **Pod conditions aren't literally "always-present from t=0"** — softened to "stably present once the kubelet has begun processing the pod." Same softening applied to Deployment and CAPI claims.
- **HTTPRoute conditions are per-ParentRef** — parenthetical added.
- **`*Pending` vs `*InProgress`** were lumped together; dropped `*Pending` since `*InProgress` covers both for sei's domain.
- **`kubectl wait --for=condition=Failed`** is the dual exit signal — explained why the SeiNodeTask `Ready`+`Failed` mixed-polarity pair is the documented exception.
- **`ObservedGeneration` known divergence** — call out the specific nodetask call sites needing harmonization.
- **Spec-shape changes** — added explicit `False/NotApplicable` guidance for the transition-to-inapplicable case.

All incorporated.

## Test plan

- [x] Doc-only PR; no code change; existing tests + build remain unaffected
- [x] Convention is referenced explicitly by the next two PRs (RouteReady rename + orphan-cleanup envtest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)