### PR TITLE
refactor(snd): rename RouteReady → NetworkingReady, migrate to always-present

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,34 +47,34 @@ The single-patch reconcile model means each reconcile snapshots `obj.DeepCopy()`
 
 ### Conditions
 
-Every `metav1.Condition` on `SeiNodeDeployment`, `SeiNode`, or `SeiNodeTask` follows the Kubernetes upstream pattern: **once a controller sets a condition, it stays present on the reconciled object**, transitioning between `True` / `False` / `Unknown` with a stable `Reason` and a `lastTransitionTime`. This is the default — "School 1." It matches Pod (`Ready`, `Initialized`, `ContainersReady`, `PodScheduled` — stably present once the kubelet has begun processing the pod), Deployment (`Available`, `Progressing` — stably present once the Deployment reconciles), Gateway-API HTTPRoute (`Accepted`, `ResolvedRefs` — stably present per ParentRef once the implementation reconciles it), and CAPI Cluster/Machine (`Ready`, `InfrastructureReady` — stably present after first reconcile). Even "feature off" or "feature broken" states are expressed as `Status=False, Reason=<stable enum value>` — never as absence.
+Every `metav1.Condition` on `SeiNodeDeployment`, `SeiNode`, or `SeiNodeTask` follows the Kubernetes upstream pattern: **once a controller sets a condition, it stays present on the reconciled object**, transitioning between `True` / `False` / `Unknown` with a stable `Reason` and a `lastTransitionTime`. This is the default. It matches Pod (`Ready`, `Initialized`, `ContainersReady`, `PodScheduled` — stably present once the kubelet has begun processing the pod), Deployment (`Available`, `Progressing` — stably present once the Deployment reconciles), Gateway-API HTTPRoute (`Accepted`, `ResolvedRefs` — stably present per ParentRef once the implementation reconciles it), and CAPI Cluster/Machine (`Ready`, `InfrastructureReady` — stably present after first reconcile). Even "feature off" or "feature broken" states are expressed as `Status=False, Reason=<stable enum value>` — never as absence.
 
 **Use:**
 
 ```go
 setCondition(obj, ConditionNetworkingReady, metav1.ConditionFalse,
-    "NetworkingDisabled", "spec.networking is unset; no HTTPRoutes published")
+    "NetworkingDisabled", "spec.networking is unset")
 ```
 
 **Do not use** for steady-state transitions:
 
 - `removeCondition(obj, ...)` to express "feature is off." Use `setCondition(False, <reason>)` instead. Removal is indistinguishable in `kubectl describe` from "controller never reached this code path" and forces PromQL consumers into brittle `absent()` queries.
 
-The narrow exceptions to the always-present rule are **School 2**:
+The narrow exceptions to the always-present rule:
 
 - **`*Needed`-style conditions** where `True` is the exception and `False` would be tautological. `GenesisCeremonyNeeded` is the canonical sei example — its `False` value is redundant with the absence of the feature.
 - **`kubectl wait` consumer conditions** where present-vs-absent semantics are explicitly load-bearing. `SeiNodeTask.Status.Conditions[Ready|Failed]` is documented as latch-on-terminal-state because the seitask-runner depends on `kubectl wait --for=condition=Ready=true` (which matches `True` only) and `--for=condition=Failed=true` as the dual exit signal. The Ready+Failed pair is the documented exception to the "no mixed polarities for the same subject" rule below — both latch independently on terminal state.
 
-Any new condition that doesn't fit one of these exceptions defaults to School 1.
+Any new condition that doesn't fit one of these exceptions defaults to always-present.
 
 **Naming:**
 
-- **`<Subject>Ready`** — `True` is the desired steady state. School 1. Use `False/<reason>` for both "not yet ready" and "not configured."
-- **`<Subject>InProgress`** — `True` is the exception, `False` is steady state. School 1. Always seed `False` on first reconcile.
-- **`<Subject>Complete`** — latch-True. School 1. Seed `False/NotStarted` for discoverability.
-- **`<Subject>Needed`** — School 2 acceptable.
+- **`<Subject>Ready`** — `True` is the desired steady state. Always-present. Use `False/<reason>` for both "not yet ready" and "not configured."
+- **`<Subject>InProgress`** — `True` is the exception, `False` is steady state. Always-present. Seed `False` on first reconcile.
+- **`<Subject>Complete`** — latch-True. Always-present. Seed `False/NotStarted` for discoverability.
+- **`<Subject>Needed`** — absent-when-not-applicable acceptable.
 
-Don't mix polarities for the same subject (no `RouteReady` + `RouteFailed` — pick one and use reasons). The SeiNodeTask `Ready`/`Failed` pair is the documented exception, justified by the `kubectl wait` consumer contract.
+Don't mix polarities for the same subject (no `XReady` + `XFailed` — pick one and use reasons). The SeiNodeTask `Ready`/`Failed` pair is the documented exception, justified by the `kubectl wait` consumer contract.
 
 **Spec-shape changes don't remove conditions.** If a SeiNode transitions from validator to non-validator (or any condition's preconditions become structurally inapplicable), set the condition to `False/NotApplicable` rather than removing it. Removal forces consumers to treat absence as ambiguous; an explicit `NotApplicable` reason carries the intent.
 

--- a/api/v1alpha1/seinodedeployment_types.go
+++ b/api/v1alpha1/seinodedeployment_types.go
@@ -361,7 +361,7 @@ type RolloutStatus struct {
 // Status condition types for SeiNodeDeployment.
 const (
 	ConditionNodesReady              = "NodesReady"
-	ConditionRouteReady              = "RouteReady"
+	ConditionNetworkingReady         = "NetworkingReady"
 	ConditionGenesisCeremonyComplete = "GenesisCeremonyComplete"
 	ConditionPlanInProgress          = "PlanInProgress"
 	ConditionGenesisCeremonyNeeded   = "GenesisCeremonyNeeded"

--- a/docs/design-networking-monitoring.md
+++ b/docs/design-networking-monitoring.md
@@ -384,7 +384,7 @@ type ServiceMonitorConfig struct {
 const (
     ConditionNodesReady            = "NodesReady"
     ConditionExternalServiceReady  = "ExternalServiceReady"
-    ConditionRouteReady            = "RouteReady"          // HTTPRoute
+    ConditionNetworkingReady       = "NetworkingReady"     // HTTPRoute
     ConditionIsolationReady        = "IsolationReady"      // AuthorizationPolicy
     ConditionServiceMonitorReady   = "ServiceMonitorReady"
 )
@@ -568,7 +568,7 @@ func (r *SeiNodeDeploymentReconciler) reconcileNetworking(ctx, group) error {
 **HTTPRoute:**
 - Generated as `unstructured.Unstructured` (avoids importing Gateway API Go modules)
 - Backend targets `{group}-external` Service
-- If CRD not installed (no Gateway API), sets `RouteReady` condition to False
+- If CRD not installed (no Gateway API), sets `NetworkingReady` condition to False/CRDNotInstalled
 
 **AuthorizationPolicy:**
 - Generated as `unstructured.Unstructured` (avoids importing Istio Go modules)

--- a/docs/design-rpc-migration-istio.md
+++ b/docs/design-rpc-migration-istio.md
@@ -100,7 +100,7 @@ Mirroring write endpoints would double-broadcast transactions. Mempool dedup han
 | Performance | RPC latency p99 | Within 20% of EC2 |
 | Operations | Automated pod recovery | Recovers in < 5 min |
 | Operations | Blue-green deployment | Works without manual steps |
-| Data plane | Gateway healthy | ConditionRouteReady == True |
+| Data plane | Gateway healthy | ConditionNetworkingReady == True |
 
 ## Prerequisites Checklist
 

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -91,8 +91,8 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	if !r.routeHostnameResolvable(ctx, group) {
-		setCondition(group, seiv1alpha1.ConditionRouteReady, metav1.ConditionFalse,
-			"DNSPending", "Waiting for route hostname to resolve in DNS")
+		setCondition(group, seiv1alpha1.ConditionNetworkingReady, metav1.ConditionFalse,
+			"DNSPending", "waiting for route hostname to resolve in DNS")
 		if err := r.updateStatus(ctx, group, statusBase); err != nil {
 			return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
 		}

--- a/internal/controller/nodedeployment/envtest/networking_test.go
+++ b/internal/controller/nodedeployment/envtest/networking_test.go
@@ -147,17 +147,17 @@ func TestNetworking_FullNode_PublishesHTTPRoutes(t *testing.T) {
 	g.Expect(*wsHeader.Type).To(Equal(gatewayv1.HeaderMatchExact), "EVM WS match type=Exact")
 	g.Expect(*wsRule.BackendRefs[0].Port).To(Equal(gatewayv1.PortNumber(8546)), "EVM WS rule routes to 8546")
 
-	// 5. ConditionRouteReady lands at False with reason DNSPending: the
-	//    controller publishes HTTPRoutes via SSA, then gates the
+	// 5. ConditionNetworkingReady lands at False with reason DNSPending:
+	//    the controller publishes HTTPRoutes via SSA, then gates the
 	//    operator-visible "ready" signal on the external-DNS pipeline
-	//    having resolved the route's hostname. envtest has no DNS
-	//    publisher, so test.local never resolves and the gate stays
-	//    pending — that's the signal an operator sees when external-DNS
-	//    is lagging in a real cluster.
+	//    resolving the route's hostname. envtest has no DNS publisher,
+	//    so test.local never resolves and the gate stays pending —
+	//    the same signal an operator sees when external-DNS is lagging
+	//    in a real cluster.
 	waitForStatus(t, client.ObjectKeyFromObject(snd), func(latest *seiv1alpha1.SeiNodeDeployment) bool {
-		c := apimeta.FindStatusCondition(latest.Status.Conditions, seiv1alpha1.ConditionRouteReady)
+		c := apimeta.FindStatusCondition(latest.Status.Conditions, seiv1alpha1.ConditionNetworkingReady)
 		return c != nil && c.Status == metav1.ConditionFalse && c.Reason == "DNSPending"
-	}, "ConditionRouteReady=False/DNSPending after HTTPRoute publication")
+	}, "ConditionNetworkingReady=False/DNSPending after HTTPRoute publication")
 }
 
 // TestNetworking_Validator_NoHTTPRoutes asserts the negative case: when
@@ -196,13 +196,16 @@ func TestNetworking_Validator_NoHTTPRoutes(t *testing.T) {
 	}, "2s", "200ms").Should(Equal(0),
 		"validator-mode SND with networking must publish zero HTTPRoutes")
 
-	// Belt-and-suspenders: the controller should NOT have set
-	// ConditionRouteReady=True. With zero effective routes the
-	// controller's reconcileRoute calls removeCondition explicitly, so
-	// either the condition is absent or it's anything-but-True.
+	// The controller surfaces a False condition with a stable reason
+	// rather than removing it. Validator mode declares no
+	// externally-routable protocols, so the reason is NoEffectiveRoutes.
 	latest := getSND(t, client.ObjectKeyFromObject(snd))
-	g.Expect(condTrue(latest, seiv1alpha1.ConditionRouteReady)).To(BeFalse(),
-		"ConditionRouteReady must not be True for validator-mode SND")
+	cond := apimeta.FindStatusCondition(latest.Status.Conditions, seiv1alpha1.ConditionNetworkingReady)
+	g.Expect(cond).NotTo(BeNil(), "ConditionNetworkingReady must be set for validator-mode SND")
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse),
+		"ConditionNetworkingReady must be False for validator-mode SND")
+	g.Expect(cond.Reason).To(Equal("NoEffectiveRoutes"),
+		"reason surfaces the no-routable-protocols intent")
 
 	// Sanity: deleting the SND cleans up the external Service so the
 	// next test on a fresh namespace doesn't see a leak across the

--- a/internal/controller/nodedeployment/networking.go
+++ b/internal/controller/nodedeployment/networking.go
@@ -60,7 +60,8 @@ func (r *SeiNodeDeploymentReconciler) routeHostnameResolvable(ctx context.Contex
 
 func (r *SeiNodeDeploymentReconciler) reconcileNetworking(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
 	if group.Spec.Networking == nil {
-		removeCondition(group, seiv1alpha1.ConditionRouteReady)
+		setCondition(group, seiv1alpha1.ConditionNetworkingReady, metav1.ConditionFalse,
+			"NetworkingDisabled", "spec.networking is unset")
 		return r.deleteNetworkingResources(ctx, group)
 	}
 
@@ -151,7 +152,8 @@ func portsForMode(mode seiconfig.NodeMode) []corev1.ServicePort {
 func (r *SeiNodeDeploymentReconciler) reconcileRoute(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
 	routes := resolveEffectiveRoutes(group, r.GatewayDomain, r.GatewayPublicDomain)
 	if len(routes) == 0 {
-		removeCondition(group, seiv1alpha1.ConditionRouteReady)
+		setCondition(group, seiv1alpha1.ConditionNetworkingReady, metav1.ConditionFalse,
+			"NoEffectiveRoutes", "node mode declares no externally-routable protocols")
 		return r.deleteHTTPRoutesByLabel(ctx, group)
 	}
 	return r.reconcileHTTPRoutes(ctx, group, routes)
@@ -232,10 +234,10 @@ func (r *SeiNodeDeploymentReconciler) reconcileHTTPRoutes(ctx context.Context, g
 		//nolint:staticcheck // typed ApplyConfiguration migration is a separate effort
 		err := r.Patch(ctx, desired, client.Apply, fieldOwner, client.ForceOwnership)
 		if meta.IsNoMatchError(err) {
-			if !hasConditionReason(group, seiv1alpha1.ConditionRouteReady, "CRDNotInstalled") {
+			if !hasConditionReason(group, seiv1alpha1.ConditionNetworkingReady, "CRDNotInstalled") {
 				r.Recorder.Event(group, corev1.EventTypeWarning, "CRDNotInstalled", "Gateway API CRD (HTTPRoute) is not installed; HTTPRoute will not be created")
 			}
-			setCondition(group, seiv1alpha1.ConditionRouteReady, metav1.ConditionFalse,
+			setCondition(group, seiv1alpha1.ConditionNetworkingReady, metav1.ConditionFalse,
 				"CRDNotInstalled", "Gateway API CRD (HTTPRoute) is not installed")
 			return nil
 		}
@@ -248,11 +250,11 @@ func (r *SeiNodeDeploymentReconciler) reconcileHTTPRoutes(ctx context.Context, g
 		return fmt.Errorf("cleaning up orphaned HTTPRoutes: %w", err)
 	}
 
-	if !hasConditionReason(group, seiv1alpha1.ConditionRouteReady, "HTTPRouteReady") {
-		r.Recorder.Event(group, corev1.EventTypeNormal, "HTTPRouteReady", "HTTPRoute reconciled successfully")
+	if !hasConditionReason(group, seiv1alpha1.ConditionNetworkingReady, "HTTPRoutesPublished") {
+		r.Recorder.Event(group, corev1.EventTypeNormal, "HTTPRoutesPublished", "HTTPRoutes reconciled successfully")
 	}
-	setCondition(group, seiv1alpha1.ConditionRouteReady, metav1.ConditionTrue,
-		"HTTPRouteReady", fmt.Sprintf("%d HTTPRoute(s) reconciled successfully", len(routes)))
+	setCondition(group, seiv1alpha1.ConditionNetworkingReady, metav1.ConditionTrue,
+		"HTTPRoutesPublished", fmt.Sprintf("%d HTTPRoute(s) reconciled successfully", len(routes)))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Implements the conditions doctrine merged in #329: `ConditionNetworkingReady` stays present on every reconciled SND, transitioning between True / False / Unknown with stable reasons rather than disappearing when networking is off. First conversion site under the new convention.

**Net: 7 files, +42 / -37.**

## Why this rename

`RouteReady` semantically only makes sense when networking is configured — "routes are ready" is incoherent for a validator-mode SND that publishes no externally-routable protocols. `NetworkingReady` reads coherent across every SND shape (full-node with routes, validator with none, networking disabled entirely, etc.).

## Reason enum (post-rename)

| Status | Reason | Meaning |
|---|---|---|
| True | `HTTPRoutesPublished` | HTTPRoutes reconciled and the controller has nothing in-flight |
| False | `NetworkingDisabled` | `spec.networking == nil` |
| False | `NoEffectiveRoutes` | node mode declares no externally-routable protocols (validator mode etc.) |
| False | `CRDNotInstalled` | gateway-api CRD missing |
| False | `DNSPending` | external-DNS hasn't yet resolved the route's hostname |

## Operational rollout (legacy condition cleanup)

Existing SNDs carry a stale `Status.Conditions[Type="RouteReady"]` entry from the previous controller. `apimeta.SetStatusCondition` keys by `Type`, so the new `NetworkingReady` entry gets added alongside — both entries coexist indefinitely until manually cleaned.

**These stale entries are functionally harmless** — controller doesn't read them, API server stores them, kube-state-metrics exports them as PromQL series that nothing queries (zero `RouteReady`-keyed alerts in `platform/clusters/*/monitoring/`). The cost is one extra row in `kubectl describe snd` and a few hundred bytes per SND in etcd.

**Cleanup is operator-side**, not controller-carried. Run once after deploying the new image:

```bash
kubectl get snd -A -o json \
  | jq -r '.items[] | select(.status.conditions[]?.type == "RouteReady") | "\(.metadata.namespace) \(.metadata.name)"' \
  | while read ns name; do
      kubectl patch snd -n "$ns" "$name" --subresource=status --type=json \
        -p="[{\"op\": \"replace\", \"path\": \"/status/conditions\", \"value\": $(kubectl get snd -n "$ns" "$name" -o json | jq '[.status.conditions[] | select(.type != "RouteReady")]')}]"
    done
```

Carrying a one-shot migration in the controller would be permanent code paying for a transient situation. We accept the dual-condition state briefly and clean it up out-of-band.

## Coral cross-review applied (k8s + sre)

**Incorporated:**
- `Disabled` → `NetworkingDisabled` (both reviewers: bare "Disabled" gets ambiguous in PromQL as other features harmonize to the same enum shape)
- `Published` → `HTTPRoutesPublished` (k8s: "what's published?" reads weakly at-a-glance)
- Stale `ConditionRouteReady` references in `docs/design-networking-monitoring.md` + `docs/design-rpc-migration-istio.md` (sre: runbook drift)
- CLAUDE.md jargon cleanup (user feedback during review): dropped the "School 1/2" shorthand from the doctrine; describes behavior directly

**Initially blocked on, then dropped** (your call):
- Both reviewers initially flagged the stale `RouteReady` entry as a blocker requiring an in-controller migration step. After discussion, dropped that approach. The stale entries are operationally harmless (no PromQL keys on them, no controller logic reads them), so paying permanent controller code for a transient cleanup wasn't worth it. Manual kubectl cleanup (above) handles it.

**Deferred to follow-ups:**
- `GenesisCeremonyNeeded` as next harmonization candidate — the doctrine's `*Needed` exception is the weakest seam; "no ceremony spec" and "never reconciled" look identical today.
- Coupling event reasons to condition reasons — both now share `HTTPRoutesPublished` / `CRDNotInstalled`. Works for this controller's size; revisit if a future event needs a vocabulary the condition wouldn't carry.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean
- [x] `make test-integration` — 46.6s, all 4 envtest tests pass (Phase 1 InPlace, Phase 2 Supersession, Phase 3 Networking, Phase 4 Stuck). The Phase 3 networking test asserts the new condition shape: `NetworkingReady=False/DNSPending` for the full-node create-path, `NetworkingReady=False/NoEffectiveRoutes` for validator mode.
- [x] `make verify-generated` clean (condition types are free-form strings; no CRD regen needed).

## What an on-call sees the morning after merge

`kubectl describe snd <name>` shows `NetworkingReady` (the new condition) alongside the legacy `RouteReady` entry until the manual cleanup script runs. The active condition is `NetworkingReady`; the stale `RouteReady` carries whatever value the old controller last wrote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)