### PR TITLE
refactor(snd): fold GenesisCeremonyNeeded into GenesisCeremonyComplete; make spec.genesis immutable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ setCondition(obj, ConditionNetworkingReady, metav1.ConditionFalse,
 
 The narrow exceptions to the always-present rule are **School 2**:
 
-- **`*Needed`-style conditions** where `True` is the exception and `False` would be tautological. `GenesisCeremonyNeeded` is the canonical sei example — its `False` value is redundant with the absence of the feature.
+- **`*Needed`-style conditions** where `True` is the exception and `False` would be tautological — its `False` value would be redundant with the absence of the feature. There are no current instances in this codebase; the exception is retained in the doctrine for future conditions where it genuinely fits.
 - **`kubectl wait` consumer conditions** where present-vs-absent semantics are explicitly load-bearing. `SeiNodeTask.Status.Conditions[Ready|Failed]` is documented as latch-on-terminal-state because the seitask-runner depends on `kubectl wait --for=condition=Ready=true` (which matches `True` only) and `--for=condition=Failed=true` as the dual exit signal. The Ready+Failed pair is the documented exception to the "no mixed polarities for the same subject" rule below — both latch independently on terminal state.
 
 Any new condition that doesn't fit one of these exceptions defaults to School 1.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ setCondition(obj, ConditionNetworkingReady, metav1.ConditionFalse,
 
 The narrow exceptions to the always-present rule are **School 2**:
 
-- **`*Needed`-style conditions** where `True` is the exception and `False` would be tautological — its `False` value would be redundant with the absence of the feature. There are no current instances in this codebase; the exception is retained in the doctrine for future conditions where it genuinely fits.
+- **`*Needed`-style conditions** where `True` is the exception and `False` would be tautological with the absence of the feature. No current instances in this codebase; the exception is retained for future conditions where it genuinely fits.
 - **`kubectl wait` consumer conditions** where present-vs-absent semantics are explicitly load-bearing. `SeiNodeTask.Status.Conditions[Ready|Failed]` is documented as latch-on-terminal-state because the seitask-runner depends on `kubectl wait --for=condition=Ready=true` (which matches `True` only) and `--for=condition=Failed=true` as the dual exit signal. The Ready+Failed pair is the documented exception to the "no mixed polarities for the same subject" rule below — both latch independently on terminal state.
 
 Any new condition that doesn't fit one of these exceptions defaults to School 1.

--- a/api/v1alpha1/seinodedeployment_types.go
+++ b/api/v1alpha1/seinodedeployment_types.go
@@ -8,6 +8,7 @@ import (
 // SeiNodeDeploymentSpec defines the desired state of a SeiNodeDeployment.
 //
 // +kubebuilder:validation:XValidation:rule="!has(self.genesis) || has(self.template.spec.validator)",message="genesis is meaningful only for validator-role deployments (full nodes inherit genesis from the validator ceremony's S3 artifact); remove spec.genesis or set template.spec.validator: {}"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.genesis) || (has(self.genesis) && self.genesis == oldSelf.genesis)",message="spec.genesis is immutable once set; the ceremony's outputs (chain ID, validator gentxs, account balances) are baked into chain state and cannot be retroactively rewritten by editing the spec"
 type SeiNodeDeploymentSpec struct {
 	// Replicas is the number of SeiNode instances to create.
 	// +kubebuilder:validation:Minimum=1
@@ -30,8 +31,8 @@ type SeiNodeDeploymentSpec struct {
 	// Genesis configures genesis ceremony orchestration for this group.
 	// When set, the controller generates GenesisCeremonyNodeConfig for each
 	// child SeiNode and coordinates assembly of the final genesis.json.
+	// Immutable once set (enforced at the spec level via CEL).
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.genesis is immutable after creation"
 	Genesis *GenesisCeremonyConfig `json:"genesis,omitempty"`
 
 	// Networking enables public networking for the deployment.
@@ -364,7 +365,6 @@ const (
 	ConditionRouteReady              = "RouteReady"
 	ConditionGenesisCeremonyComplete = "GenesisCeremonyComplete"
 	ConditionPlanInProgress          = "PlanInProgress"
-	ConditionGenesisCeremonyNeeded   = "GenesisCeremonyNeeded"
 	ConditionRolloutInProgress       = "RolloutInProgress"
 )
 

--- a/api/v1alpha1/seinodedeployment_types.go
+++ b/api/v1alpha1/seinodedeployment_types.go
@@ -31,7 +31,7 @@ type SeiNodeDeploymentSpec struct {
 	// Genesis configures genesis ceremony orchestration for this group.
 	// When set, the controller generates GenesisCeremonyNodeConfig for each
 	// child SeiNode and coordinates assembly of the final genesis.json.
-	// Immutable once set (enforced at the spec level via CEL).
+	// Immutable once set; enforced by spec-level CEL.
 	// +optional
 	Genesis *GenesisCeremonyConfig `json:"genesis,omitempty"`
 

--- a/config/crd/sei.io_seinodedeployments.yaml
+++ b/config/crd/sei.io_seinodedeployments.yaml
@@ -74,7 +74,7 @@ spec:
                   Genesis configures genesis ceremony orchestration for this group.
                   When set, the controller generates GenesisCeremonyNodeConfig for each
                   child SeiNode and coordinates assembly of the final genesis.json.
-                  Immutable once set (enforced at the spec level via CEL).
+                  Immutable once set; enforced by spec-level CEL.
                 properties:
                   accountBalance:
                     default: 1000000000000000000000usei,1000000000000000000000uusdc,1000000000000000000000uatom

--- a/config/crd/sei.io_seinodedeployments.yaml
+++ b/config/crd/sei.io_seinodedeployments.yaml
@@ -74,6 +74,7 @@ spec:
                   Genesis configures genesis ceremony orchestration for this group.
                   When set, the controller generates GenesisCeremonyNodeConfig for each
                   child SeiNode and coordinates assembly of the final genesis.json.
+                  Immutable once set (enforced at the spec level via CEL).
                 properties:
                   accountBalance:
                     default: 1000000000000000000000usei,1000000000000000000000uusdc,1000000000000000000000uatom
@@ -130,9 +131,6 @@ spec:
                 required:
                 - chainId
                 type: object
-                x-kubernetes-validations:
-                - message: spec.genesis is immutable after creation
-                  rule: self == oldSelf
               networking:
                 description: |-
                   Networking enables public networking for the deployment.
@@ -876,6 +874,11 @@ spec:
                 (full nodes inherit genesis from the validator ceremony''s S3 artifact);
                 remove spec.genesis or set template.spec.validator: {}'
               rule: '!has(self.genesis) || has(self.template.spec.validator)'
+            - message: spec.genesis is immutable once set; the ceremony's outputs
+                (chain ID, validator gentxs, account balances) are baked into chain
+                state and cannot be retroactively rewritten by editing the spec
+              rule: '!has(oldSelf.genesis) || (has(self.genesis) && self.genesis ==
+                oldSelf.genesis)'
           status:
             description: SeiNodeDeploymentStatus defines the observed state of a SeiNodeDeployment.
             properties:

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -80,6 +80,10 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	statusBase := client.MergeFromWithOptions(group.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	ns, name := group.Namespace, group.Name
 
+	// Seed always-present conditions before any early-return path so they
+	// are visible on every reconcile (see CLAUDE.md `### Conditions`).
+	r.setGenesisCeremonyCondition(group)
+
 	if err := r.reconcileInternalService(ctx, group); err != nil {
 		logger.Error(err, "reconciling internal RPC service")
 		return ctrl.Result{}, fmt.Errorf("reconciling internal RPC service: %w", err)

--- a/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
+++ b/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
@@ -5,16 +5,47 @@ package envtest_test
 import (
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
 )
+
+// updateSNDWithRetry re-fetches and re-applies mutate on resourceVersion
+// conflict — necessary because the controller patches status concurrently
+// (now that GenesisCeremonyComplete is hoisted to fire on every reconcile),
+// and the test's Get→mutate→Update would otherwise lose the 409 race
+// before CEL validation can fire. Returns the first non-conflict error
+// (or nil on success), so assertions see the CEL rejection itself rather
+// than the optimistic-concurrency conflict.
+func updateSNDWithRetry(t *testing.T, key client.ObjectKey, mutate func(*seiv1alpha1.SeiNodeDeployment)) error {
+	t.Helper()
+	var lastErr error
+	for i := 0; i < 10; i++ {
+		cur := &seiv1alpha1.SeiNodeDeployment{}
+		if err := testCli.Get(testCtx, key, cur); err != nil {
+			return err
+		}
+		mutate(cur)
+		err := testCli.Update(testCtx, cur)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return err
+		}
+		lastErr = err
+		time.Sleep(50 * time.Millisecond)
+	}
+	return lastErr
+}
 
 // TestGenesis_ImmutabilityGate asserts the spec-level CEL rule rejects
 // post-creation mutation of spec.genesis. The ceremony's outputs are
@@ -34,12 +65,13 @@ func TestGenesis_ImmutabilityGate(t *testing.T) {
 	}
 	g.Expect(testCli.Create(testCtx, snd)).To(Succeed(), "creating SND with genesis must succeed")
 
+	key := client.ObjectKeyFromObject(snd)
+
 	t.Run("clearing spec.genesis is rejected", func(t *testing.T) {
 		g := NewWithT(t)
-		cur := &seiv1alpha1.SeiNodeDeployment{}
-		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
-		cur.Spec.Genesis = nil
-		err := testCli.Update(testCtx, cur)
+		err := updateSNDWithRetry(t, key, func(cur *seiv1alpha1.SeiNodeDeployment) {
+			cur.Spec.Genesis = nil
+		})
 		g.Expect(err).To(HaveOccurred(), "clearing spec.genesis must be rejected")
 		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"),
 			"rejection must carry the CEL rule's immutability message; got: %s", err.Error())
@@ -47,59 +79,56 @@ func TestGenesis_ImmutabilityGate(t *testing.T) {
 
 	t.Run("mutating chainId is rejected", func(t *testing.T) {
 		g := NewWithT(t)
-		cur := &seiv1alpha1.SeiNodeDeployment{}
-		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
-		cur.Spec.Genesis.ChainID = "atlantic-2"
-		err := testCli.Update(testCtx, cur)
+		err := updateSNDWithRetry(t, key, func(cur *seiv1alpha1.SeiNodeDeployment) {
+			cur.Spec.Genesis.ChainID = "atlantic-2"
+		})
 		g.Expect(err).To(HaveOccurred(), "mutating spec.genesis.chainId must be rejected")
 		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"))
 	})
 
 	t.Run("mutating stakingAmount is rejected", func(t *testing.T) {
 		g := NewWithT(t)
-		cur := &seiv1alpha1.SeiNodeDeployment{}
-		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
-		cur.Spec.Genesis.StakingAmount = "99999999usei"
-		err := testCli.Update(testCtx, cur)
+		err := updateSNDWithRetry(t, key, func(cur *seiv1alpha1.SeiNodeDeployment) {
+			cur.Spec.Genesis.StakingAmount = "99999999usei"
+		})
 		g.Expect(err).To(HaveOccurred(), "mutating spec.genesis.stakingAmount must be rejected")
 		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"))
 	})
 
 	t.Run("appending to accounts list is rejected", func(t *testing.T) {
 		g := NewWithT(t)
-		cur := &seiv1alpha1.SeiNodeDeployment{}
-		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
-		cur.Spec.Genesis.Accounts = append(cur.Spec.Genesis.Accounts, seiv1alpha1.GenesisAccount{
-			Address: "sei1example0000000000000000000000000000000",
-			Balance: "1000usei",
+		err := updateSNDWithRetry(t, key, func(cur *seiv1alpha1.SeiNodeDeployment) {
+			cur.Spec.Genesis.Accounts = append(cur.Spec.Genesis.Accounts, seiv1alpha1.GenesisAccount{
+				Address: "sei1example0000000000000000000000000000000",
+				Balance: "1000usei",
+			})
 		})
-		err := testCli.Update(testCtx, cur)
 		g.Expect(err).To(HaveOccurred(), "appending to spec.genesis.accounts must be rejected")
 		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"))
 	})
 
 	t.Run("adding an overrides entry is rejected", func(t *testing.T) {
 		g := NewWithT(t)
-		cur := &seiv1alpha1.SeiNodeDeployment{}
-		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
-		if cur.Spec.Genesis.Overrides == nil {
-			cur.Spec.Genesis.Overrides = map[string]apiextensionsv1.JSON{}
-		}
-		cur.Spec.Genesis.Overrides["staking.params.unbonding_time"] = apiextensionsv1.JSON{
-			Raw: []byte(`"1814400s"`),
-		}
-		err := testCli.Update(testCtx, cur)
+		err := updateSNDWithRetry(t, key, func(cur *seiv1alpha1.SeiNodeDeployment) {
+			if cur.Spec.Genesis.Overrides == nil {
+				cur.Spec.Genesis.Overrides = map[string]apiextensionsv1.JSON{}
+			}
+			cur.Spec.Genesis.Overrides["staking.params.unbonding_time"] = apiextensionsv1.JSON{
+				Raw: []byte(`"1814400s"`),
+			}
+		})
 		g.Expect(err).To(HaveOccurred(), "adding spec.genesis.overrides entry must be rejected")
 		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"))
 	})
 
 	t.Run("same-content update is allowed", func(t *testing.T) {
 		g := NewWithT(t)
-		cur := &seiv1alpha1.SeiNodeDeployment{}
-		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
-		// Touch an unrelated field to force a write through the same path.
-		cur.Spec.Replicas = 2
-		g.Expect(testCli.Update(testCtx, cur)).To(Succeed(),
+		// Touching an unrelated field forces a write while genesis stays
+		// the same — confirms the CEL rule passes value-equality checks.
+		err := updateSNDWithRetry(t, key, func(cur *seiv1alpha1.SeiNodeDeployment) {
+			cur.Spec.Replicas = 2
+		})
+		g.Expect(err).NotTo(HaveOccurred(),
 			"editing non-genesis fields must still succeed while genesis is unchanged")
 	})
 }
@@ -116,10 +145,9 @@ func TestGenesis_CreationWithoutGenesisAllowsLaterAddition(t *testing.T) {
 	)
 	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
 
-	cur := &seiv1alpha1.SeiNodeDeployment{}
-	g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
-	cur.Spec.Genesis = &seiv1alpha1.GenesisCeremonyConfig{ChainID: "pacific-1"}
-	err := testCli.Update(testCtx, cur)
+	err := updateSNDWithRetry(t, client.ObjectKeyFromObject(snd), func(cur *seiv1alpha1.SeiNodeDeployment) {
+		cur.Spec.Genesis = &seiv1alpha1.GenesisCeremonyConfig{ChainID: "pacific-1"}
+	})
 	g.Expect(err).NotTo(HaveOccurred(),
 		"adding spec.genesis to an SND that didn't have it must be permitted (got: %s)",
 		errString(err))

--- a/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
+++ b/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
@@ -8,22 +8,18 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
 )
 
-// TestGenesis_ImmutabilityGate asserts the CRD-level CEL rule rejects
-// post-creation mutation of spec.genesis. The ceremony's outputs (chain
-// ID, validator gentxs, account balances) are baked into chain state at
-// bootstrap; later spec edits would silently diverge from on-chain truth.
-// The gate also keeps the GenesisCeremonyComplete condition's latched-
-// True semantics honest — clearing spec.genesis mid-flight would let a
-// completed ceremony be downgraded to False/NotApplicable.
-//
-// The test runs without the controller reconciling because CEL validation
-// fires at admission time before any controller sees the object.
+// TestGenesis_ImmutabilityGate asserts the spec-level CEL rule rejects
+// post-creation mutation of spec.genesis. The ceremony's outputs are
+// baked into chain state; later edits would diverge from on-chain truth
+// and could defeat the GenesisCeremonyComplete latch.
 func TestGenesis_ImmutabilityGate(t *testing.T) {
 	g := NewWithT(t)
 	ns := makeNamespace(t)
@@ -69,6 +65,34 @@ func TestGenesis_ImmutabilityGate(t *testing.T) {
 		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"))
 	})
 
+	t.Run("appending to accounts list is rejected", func(t *testing.T) {
+		g := NewWithT(t)
+		cur := &seiv1alpha1.SeiNodeDeployment{}
+		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
+		cur.Spec.Genesis.Accounts = append(cur.Spec.Genesis.Accounts, seiv1alpha1.GenesisAccount{
+			Address: "sei1example0000000000000000000000000000000",
+			Balance: "1000usei",
+		})
+		err := testCli.Update(testCtx, cur)
+		g.Expect(err).To(HaveOccurred(), "appending to spec.genesis.accounts must be rejected")
+		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"))
+	})
+
+	t.Run("adding an overrides entry is rejected", func(t *testing.T) {
+		g := NewWithT(t)
+		cur := &seiv1alpha1.SeiNodeDeployment{}
+		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
+		if cur.Spec.Genesis.Overrides == nil {
+			cur.Spec.Genesis.Overrides = map[string]apiextensionsv1.JSON{}
+		}
+		cur.Spec.Genesis.Overrides["staking.params.unbonding_time"] = apiextensionsv1.JSON{
+			Raw: []byte(`"1814400s"`),
+		}
+		err := testCli.Update(testCtx, cur)
+		g.Expect(err).To(HaveOccurred(), "adding spec.genesis.overrides entry must be rejected")
+		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"))
+	})
+
 	t.Run("same-content update is allowed", func(t *testing.T) {
 		g := NewWithT(t)
 		cur := &seiv1alpha1.SeiNodeDeployment{}
@@ -80,10 +104,9 @@ func TestGenesis_ImmutabilityGate(t *testing.T) {
 	})
 }
 
-// TestGenesis_CreationWithoutGenesisAllowsLaterAddition guards the CEL
-// rule's `!has(oldSelf.genesis)` short-circuit: an SND created without
-// genesis can have it added later. Only mutation of a previously-set
-// genesis block is forbidden.
+// TestGenesis_CreationWithoutGenesisAllowsLaterAddition guards the
+// `!has(oldSelf.genesis)` short-circuit: nil → set is permitted; only
+// mutation of a previously-set genesis block is forbidden.
 func TestGenesis_CreationWithoutGenesisAllowsLaterAddition(t *testing.T) {
 	g := NewWithT(t)
 	ns := makeNamespace(t)
@@ -107,4 +130,23 @@ func errString(err error) string {
 		return "<nil>"
 	}
 	return strings.TrimSpace(err.Error())
+}
+
+// TestGenesis_ConditionSeededOnEveryReconcile guards the hoist in
+// controller.go: setGenesisCeremonyCondition runs before any path
+// that may early-return, so the condition is visible immediately
+// once the controller has reconciled the SND.
+func TestGenesis_ConditionSeededOnEveryReconcile(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	snd := fixtures.NewSND(ns, "genesis-seeded",
+		fixtures.WithValidator(),
+	)
+	snd.Spec.Genesis = &seiv1alpha1.GenesisCeremonyConfig{ChainID: "pacific-1"}
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	waitForStatus(t, client.ObjectKeyFromObject(snd), func(s *seiv1alpha1.SeiNodeDeployment) bool {
+		return apimeta.FindStatusCondition(s.Status.Conditions, seiv1alpha1.ConditionGenesisCeremonyComplete) != nil
+	}, "GenesisCeremonyComplete must be present after first reconcile")
 }

--- a/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
+++ b/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
@@ -19,12 +19,11 @@ import (
 )
 
 // updateSNDWithRetry re-fetches and re-applies mutate on resourceVersion
-// conflict — necessary because the controller patches status concurrently
-// (now that GenesisCeremonyComplete is hoisted to fire on every reconcile),
-// and the test's Get→mutate→Update would otherwise lose the 409 race
-// before CEL validation can fire. Returns the first non-conflict error
-// (or nil on success), so assertions see the CEL rejection itself rather
-// than the optimistic-concurrency conflict.
+// conflict. The controller patches status concurrently, so a single
+// Get → mutate → Update can lose the 409 race before CEL validation
+// fires. Returns the first non-conflict error (or nil on success) so
+// assertions land on the CEL rejection itself, not on the optimistic-
+// concurrency conflict.
 func updateSNDWithRetry(t *testing.T, key client.ObjectKey, mutate func(*seiv1alpha1.SeiNodeDeployment)) error {
 	t.Helper()
 	var lastErr error
@@ -135,7 +134,7 @@ func TestGenesis_ImmutabilityGate(t *testing.T) {
 
 // TestGenesis_CreationWithoutGenesisAllowsLaterAddition guards the
 // `!has(oldSelf.genesis)` short-circuit: nil → set is permitted; only
-// mutation of a previously-set genesis block is forbidden.
+// mutation of an existing genesis block is forbidden.
 func TestGenesis_CreationWithoutGenesisAllowsLaterAddition(t *testing.T) {
 	g := NewWithT(t)
 	ns := makeNamespace(t)

--- a/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
+++ b/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
@@ -1,0 +1,110 @@
+//go:build envtest
+
+package envtest_test
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
+)
+
+// TestGenesis_ImmutabilityGate asserts the CRD-level CEL rule rejects
+// post-creation mutation of spec.genesis. The ceremony's outputs (chain
+// ID, validator gentxs, account balances) are baked into chain state at
+// bootstrap; later spec edits would silently diverge from on-chain truth.
+// The gate also keeps the GenesisCeremonyComplete condition's latched-
+// True semantics honest — clearing spec.genesis mid-flight would let a
+// completed ceremony be downgraded to False/NotApplicable.
+//
+// The test runs without the controller reconciling because CEL validation
+// fires at admission time before any controller sees the object.
+func TestGenesis_ImmutabilityGate(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	snd := fixtures.NewSND(ns, "genesis-immutable",
+		fixtures.WithValidator(),
+	)
+	snd.Spec.Genesis = &seiv1alpha1.GenesisCeremonyConfig{
+		ChainID:        "pacific-1",
+		StakingAmount:  "10000000usei",
+		AccountBalance: "1000000usei",
+	}
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed(), "creating SND with genesis must succeed")
+
+	t.Run("clearing spec.genesis is rejected", func(t *testing.T) {
+		g := NewWithT(t)
+		cur := &seiv1alpha1.SeiNodeDeployment{}
+		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
+		cur.Spec.Genesis = nil
+		err := testCli.Update(testCtx, cur)
+		g.Expect(err).To(HaveOccurred(), "clearing spec.genesis must be rejected")
+		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"),
+			"rejection must carry the CEL rule's immutability message; got: %s", err.Error())
+	})
+
+	t.Run("mutating chainId is rejected", func(t *testing.T) {
+		g := NewWithT(t)
+		cur := &seiv1alpha1.SeiNodeDeployment{}
+		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
+		cur.Spec.Genesis.ChainID = "atlantic-2"
+		err := testCli.Update(testCtx, cur)
+		g.Expect(err).To(HaveOccurred(), "mutating spec.genesis.chainId must be rejected")
+		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"))
+	})
+
+	t.Run("mutating stakingAmount is rejected", func(t *testing.T) {
+		g := NewWithT(t)
+		cur := &seiv1alpha1.SeiNodeDeployment{}
+		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
+		cur.Spec.Genesis.StakingAmount = "99999999usei"
+		err := testCli.Update(testCtx, cur)
+		g.Expect(err).To(HaveOccurred(), "mutating spec.genesis.stakingAmount must be rejected")
+		g.Expect(err.Error()).To(ContainSubstring("spec.genesis is immutable"))
+	})
+
+	t.Run("same-content update is allowed", func(t *testing.T) {
+		g := NewWithT(t)
+		cur := &seiv1alpha1.SeiNodeDeployment{}
+		g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
+		// Touch an unrelated field to force a write through the same path.
+		cur.Spec.Replicas = 2
+		g.Expect(testCli.Update(testCtx, cur)).To(Succeed(),
+			"editing non-genesis fields must still succeed while genesis is unchanged")
+	})
+}
+
+// TestGenesis_CreationWithoutGenesisAllowsLaterAddition guards the CEL
+// rule's `!has(oldSelf.genesis)` short-circuit: an SND created without
+// genesis can have it added later. Only mutation of a previously-set
+// genesis block is forbidden.
+func TestGenesis_CreationWithoutGenesisAllowsLaterAddition(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	snd := fixtures.NewSND(ns, "genesis-late-add",
+		fixtures.WithValidator(),
+	)
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	cur := &seiv1alpha1.SeiNodeDeployment{}
+	g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
+	cur.Spec.Genesis = &seiv1alpha1.GenesisCeremonyConfig{ChainID: "pacific-1"}
+	err := testCli.Update(testCtx, cur)
+	g.Expect(err).NotTo(HaveOccurred(),
+		"adding spec.genesis to an SND that didn't have it must be permitted (got: %s)",
+		errString(err))
+}
+
+func errString(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return strings.TrimSpace(err.Error())
+}

--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -39,27 +39,41 @@ func (r *SeiNodeDeploymentReconciler) reconcileSeiNodes(ctx context.Context, gro
 	}
 
 	r.detectDeploymentNeeded(group)
-	r.detectGenesisCeremonyNeeded(group)
+	r.setGenesisCeremonyCondition(group)
 	return nil
 }
 
-// detectGenesisCeremonyNeeded sets GenesisCeremonyNeeded when a genesis
-// ceremony is required.
-func (r *SeiNodeDeploymentReconciler) detectGenesisCeremonyNeeded(group *seiv1alpha1.SeiNodeDeployment) {
-	if group.Spec.Genesis == nil {
-		removeCondition(group, seiv1alpha1.ConditionGenesisCeremonyNeeded)
+// setGenesisCeremonyCondition keeps ConditionGenesisCeremonyComplete in
+// sync with the SND's genesis lifecycle. The condition stays present on
+// every reconciled SND and carries the current state via Reason:
+//
+//   - True / Complete         — ceremony finished (latched)
+//   - False / NotApplicable   — spec.genesis is unset
+//   - False / NotStarted      — spec.genesis set, ceremony not yet started
+//   - False / InProgress      — ceremony executing under an active plan
+//
+// The True/Complete state is latched: once a ceremony completes, the
+// condition stays True even if an operator later clears spec.genesis.
+// Clearing the spec doesn't unmake history.
+//
+// The latch check must come first; reordering would cause a completed
+// ceremony to be downgraded to NotApplicable when spec.genesis is cleared.
+func (r *SeiNodeDeploymentReconciler) setGenesisCeremonyCondition(group *seiv1alpha1.SeiNodeDeployment) {
+	if hasConditionTrue(group, seiv1alpha1.ConditionGenesisCeremonyComplete) {
 		return
 	}
-	if hasConditionTrue(group, seiv1alpha1.ConditionGenesisCeremonyComplete) {
-		removeCondition(group, seiv1alpha1.ConditionGenesisCeremonyNeeded)
+	if group.Spec.Genesis == nil {
+		setCondition(group, seiv1alpha1.ConditionGenesisCeremonyComplete, metav1.ConditionFalse,
+			"NotApplicable", "spec.genesis is unset")
 		return
 	}
 	if hasConditionTrue(group, seiv1alpha1.ConditionPlanInProgress) {
+		setCondition(group, seiv1alpha1.ConditionGenesisCeremonyComplete, metav1.ConditionFalse,
+			"InProgress", "genesis ceremony is executing under an active plan")
 		return
 	}
-
-	setCondition(group, seiv1alpha1.ConditionGenesisCeremonyNeeded, metav1.ConditionTrue,
-		"GenesisConfigured", "Genesis ceremony configured")
+	setCondition(group, seiv1alpha1.ConditionGenesisCeremonyComplete, metav1.ConditionFalse,
+		"NotStarted", "genesis ceremony has not yet started")
 }
 
 // detectDeploymentNeeded checks if deployment-worthy fields have changed

--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -39,25 +39,19 @@ func (r *SeiNodeDeploymentReconciler) reconcileSeiNodes(ctx context.Context, gro
 	}
 
 	r.detectDeploymentNeeded(group)
-	r.setGenesisCeremonyCondition(group)
 	return nil
 }
 
-// setGenesisCeremonyCondition keeps ConditionGenesisCeremonyComplete in
-// sync with the SND's genesis lifecycle. The condition stays present on
-// every reconciled SND and carries the current state via Reason:
+// setGenesisCeremonyCondition stamps ConditionGenesisCeremonyComplete
+// with the SND's current genesis lifecycle state:
 //
 //   - True / Complete         — ceremony finished (latched)
 //   - False / NotApplicable   — spec.genesis is unset
 //   - False / NotStarted      — spec.genesis set, ceremony not yet started
 //   - False / InProgress      — ceremony executing under an active plan
 //
-// The True/Complete state is latched: once a ceremony completes, the
-// condition stays True even if an operator later clears spec.genesis.
-// Clearing the spec doesn't unmake history.
-//
-// The latch check must come first; reordering would cause a completed
-// ceremony to be downgraded to NotApplicable when spec.genesis is cleared.
+// The latch check runs first. Reordering it would let a completed
+// ceremony be downgraded to NotApplicable if spec.genesis is cleared.
 func (r *SeiNodeDeploymentReconciler) setGenesisCeremonyCondition(group *seiv1alpha1.SeiNodeDeployment) {
 	if hasConditionTrue(group, seiv1alpha1.ConditionGenesisCeremonyComplete) {
 		return

--- a/internal/controller/nodedeployment/nodes_test.go
+++ b/internal/controller/nodedeployment/nodes_test.go
@@ -314,38 +314,49 @@ func TestGenerateSeiNode_DeepCopiesTemplate(t *testing.T) {
 		"modification to generated SeiNode should not mutate the group template")
 }
 
-func TestDetectGenesisCeremonyNeeded(t *testing.T) {
+func TestSetGenesisCeremonyCondition(t *testing.T) {
 	cases := []struct {
-		name        string
-		mutate      func(*seiv1alpha1.SeiNodeDeployment)
-		wantPresent bool
-		wantStatus  metav1.ConditionStatus
+		name       string
+		mutate     func(*seiv1alpha1.SeiNodeDeployment)
+		wantStatus metav1.ConditionStatus
+		wantReason string
 	}{
 		{
-			name:        "no genesis spec clears condition",
-			mutate:      func(g *seiv1alpha1.SeiNodeDeployment) { g.Spec.Genesis = nil },
-			wantPresent: false,
+			name:       "no genesis spec sets False/NotApplicable",
+			mutate:     func(g *seiv1alpha1.SeiNodeDeployment) { g.Spec.Genesis = nil },
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NotApplicable",
 		},
 		{
-			name: "ceremony complete clears condition",
+			name: "already complete stays True/Complete (latched)",
 			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
-				setCondition(g, seiv1alpha1.ConditionGenesisCeremonyComplete, metav1.ConditionTrue, "Done", "")
-				setCondition(g, seiv1alpha1.ConditionGenesisCeremonyNeeded, metav1.ConditionTrue, "Stale", "")
+				setCondition(g, seiv1alpha1.ConditionGenesisCeremonyComplete, metav1.ConditionTrue, "Complete", "ceremony already done")
 			},
-			wantPresent: false,
+			wantStatus: metav1.ConditionTrue,
+			wantReason: "Complete",
 		},
 		{
-			name: "plan in progress leaves condition untouched",
+			name: "latched True survives operator clearing spec.genesis",
+			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
+				setCondition(g, seiv1alpha1.ConditionGenesisCeremonyComplete, metav1.ConditionTrue, "Complete", "ceremony already done")
+				g.Spec.Genesis = nil
+			},
+			wantStatus: metav1.ConditionTrue,
+			wantReason: "Complete",
+		},
+		{
+			name: "plan in progress sets False/InProgress",
 			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
 				setCondition(g, seiv1alpha1.ConditionPlanInProgress, metav1.ConditionTrue, "Running", "")
 			},
-			wantPresent: false,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "InProgress",
 		},
 		{
-			name:        "genesis configured sets condition true",
-			mutate:      func(g *seiv1alpha1.SeiNodeDeployment) {},
-			wantPresent: true,
-			wantStatus:  metav1.ConditionTrue,
+			name:       "genesis configured but not started sets False/NotStarted",
+			mutate:     func(g *seiv1alpha1.SeiNodeDeployment) {},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NotStarted",
 		},
 	}
 	for _, tc := range cases {
@@ -356,15 +367,12 @@ func TestDetectGenesisCeremonyNeeded(t *testing.T) {
 			tc.mutate(group)
 
 			r := &SeiNodeDeploymentReconciler{Recorder: record.NewFakeRecorder(10)}
-			r.detectGenesisCeremonyNeeded(group)
+			r.setGenesisCeremonyCondition(group)
 
-			cond := apimeta.FindStatusCondition(group.Status.Conditions, seiv1alpha1.ConditionGenesisCeremonyNeeded)
-			if !tc.wantPresent {
-				g.Expect(cond).To(BeNil())
-				return
-			}
-			g.Expect(cond).NotTo(BeNil())
+			cond := apimeta.FindStatusCondition(group.Status.Conditions, seiv1alpha1.ConditionGenesisCeremonyComplete)
+			g.Expect(cond).NotTo(BeNil(), "ConditionGenesisCeremonyComplete must be set on every reconciled SND")
 			g.Expect(cond.Status).To(Equal(tc.wantStatus))
+			g.Expect(cond.Reason).To(Equal(tc.wantReason))
 		})
 	}
 }

--- a/internal/controller/nodedeployment/nodes_test.go
+++ b/internal/controller/nodedeployment/nodes_test.go
@@ -358,6 +358,17 @@ func TestSetGenesisCeremonyCondition(t *testing.T) {
 			wantStatus: metav1.ConditionFalse,
 			wantReason: "NotStarted",
 		},
+		{
+			// Post-failPlan: PlanInProgress=False, no latched Complete.
+			// The next reconcile must drop back to NotStarted so retries
+			// can proceed.
+			name: "plan failed returns to False/NotStarted",
+			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
+				setCondition(g, seiv1alpha1.ConditionPlanInProgress, metav1.ConditionFalse, "PlanFailed", "previous attempt failed")
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NotStarted",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/controller/nodedeployment/plan.go
+++ b/internal/controller/nodedeployment/plan.go
@@ -86,7 +86,7 @@ func (r *SeiNodeDeploymentReconciler) completePlan(ctx context.Context, group *s
 
 	if group.Spec.Genesis != nil && !isDeploymentPlan {
 		setCondition(group, seiv1alpha1.ConditionGenesisCeremonyComplete, metav1.ConditionTrue,
-			"CeremonyComplete", "Genesis ceremony completed")
+			"Complete", "genesis ceremony completed")
 	}
 
 	group.Status.Plan = nil

--- a/internal/planner/group_accounts_test.go
+++ b/internal/planner/group_accounts_test.go
@@ -35,9 +35,6 @@ func groupWithAccounts(accounts []seiv1alpha1.GenesisAccount) *seiv1alpha1.SeiNo
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{testNodeName},
-			Conditions: []metav1.Condition{
-				{Type: seiv1alpha1.ConditionGenesisCeremonyNeeded, Status: metav1.ConditionTrue},
-			},
 		},
 	}
 }

--- a/internal/planner/group_test.go
+++ b/internal/planner/group_test.go
@@ -23,9 +23,10 @@ func TestBuildGroupAssemblyPlan(t *testing.T) {
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{"node-0", "node-1", "node-2"},
-			Conditions: []metav1.Condition{
-				{Type: seiv1alpha1.ConditionGenesisCeremonyNeeded, Status: metav1.ConditionTrue},
-			},
+			// Absence of ConditionGenesisCeremonyComplete=True (the new
+			// signal) means the planner treats the SND as needing a
+			// genesis plan.
+
 		},
 	}
 
@@ -116,9 +117,10 @@ func TestBuildGroupAssemblyPlan_DefaultS3(t *testing.T) {
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{"node-0"},
-			Conditions: []metav1.Condition{
-				{Type: seiv1alpha1.ConditionGenesisCeremonyNeeded, Status: metav1.ConditionTrue},
-			},
+			// Absence of ConditionGenesisCeremonyComplete=True (the new
+			// signal) means the planner treats the SND as needing a
+			// genesis plan.
+
 		},
 	}
 
@@ -163,9 +165,10 @@ func TestBuildGroupAssemblyPlan_PropagatesOverrides(t *testing.T) {
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{testNodeName},
-			Conditions: []metav1.Condition{
-				{Type: seiv1alpha1.ConditionGenesisCeremonyNeeded, Status: metav1.ConditionTrue},
-			},
+			// Absence of ConditionGenesisCeremonyComplete=True (the new
+			// signal) means the planner treats the SND as needing a
+			// genesis plan.
+
 		},
 	}
 
@@ -220,9 +223,10 @@ func TestBuildGroupAssemblyPlan_OmitsOverridesWhenUnset(t *testing.T) {
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{testNodeName},
-			Conditions: []metav1.Condition{
-				{Type: seiv1alpha1.ConditionGenesisCeremonyNeeded, Status: metav1.ConditionTrue},
-			},
+			// Absence of ConditionGenesisCeremonyComplete=True (the new
+			// signal) means the planner treats the SND as needing a
+			// genesis plan.
+
 		},
 	}
 
@@ -262,9 +266,10 @@ func TestBuildGroupAssemblyPlan_UniqueIDsAcrossRebuilds(t *testing.T) {
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{"node-0", "node-1"},
-			Conditions: []metav1.Condition{
-				{Type: seiv1alpha1.ConditionGenesisCeremonyNeeded, Status: metav1.ConditionTrue},
-			},
+			// Absence of ConditionGenesisCeremonyComplete=True (the new
+			// signal) means the planner treats the SND as needing a
+			// genesis plan.
+
 		},
 	}
 

--- a/internal/planner/group_test.go
+++ b/internal/planner/group_test.go
@@ -23,9 +23,8 @@ func TestBuildGroupAssemblyPlan(t *testing.T) {
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{"node-0", "node-1", "node-2"},
-			// Absence of ConditionGenesisCeremonyComplete=True (the new
-			// signal) means the planner treats the SND as needing a
-			// genesis plan.
+			// The planner triggers a genesis plan whenever
+			// ConditionGenesisCeremonyComplete is not True.
 
 		},
 	}
@@ -117,9 +116,8 @@ func TestBuildGroupAssemblyPlan_DefaultS3(t *testing.T) {
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{"node-0"},
-			// Absence of ConditionGenesisCeremonyComplete=True (the new
-			// signal) means the planner treats the SND as needing a
-			// genesis plan.
+			// The planner triggers a genesis plan whenever
+			// ConditionGenesisCeremonyComplete is not True.
 
 		},
 	}
@@ -165,9 +163,8 @@ func TestBuildGroupAssemblyPlan_PropagatesOverrides(t *testing.T) {
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{testNodeName},
-			// Absence of ConditionGenesisCeremonyComplete=True (the new
-			// signal) means the planner treats the SND as needing a
-			// genesis plan.
+			// The planner triggers a genesis plan whenever
+			// ConditionGenesisCeremonyComplete is not True.
 
 		},
 	}
@@ -223,9 +220,8 @@ func TestBuildGroupAssemblyPlan_OmitsOverridesWhenUnset(t *testing.T) {
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{testNodeName},
-			// Absence of ConditionGenesisCeremonyComplete=True (the new
-			// signal) means the planner treats the SND as needing a
-			// genesis plan.
+			// The planner triggers a genesis plan whenever
+			// ConditionGenesisCeremonyComplete is not True.
 
 		},
 	}
@@ -266,9 +262,8 @@ func TestBuildGroupAssemblyPlan_UniqueIDsAcrossRebuilds(t *testing.T) {
 		},
 		Status: seiv1alpha1.SeiNodeDeploymentStatus{
 			IncumbentNodes: []string{"node-0", "node-1"},
-			// Absence of ConditionGenesisCeremonyComplete=True (the new
-			// signal) means the planner treats the SND as needing a
-			// genesis plan.
+			// The planner triggers a genesis plan whenever
+			// ConditionGenesisCeremonyComplete is not True.
 
 		},
 	}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -97,7 +97,7 @@ func needsGenesisPlan(group *seiv1alpha1.SeiNodeDeployment) bool {
 	if group.Status.Plan != nil {
 		return false
 	}
-	if hasCondition(group, seiv1alpha1.ConditionGenesisCeremonyComplete) {
+	if isConditionTrue(group, seiv1alpha1.ConditionGenesisCeremonyComplete) {
 		return false
 	}
 	return allReplicasCreated(group)
@@ -107,7 +107,11 @@ func allReplicasCreated(group *seiv1alpha1.SeiNodeDeployment) bool {
 	return int32(len(group.Status.IncumbentNodes)) >= group.Spec.Replicas
 }
 
-func hasCondition(group *seiv1alpha1.SeiNodeDeployment, condType string) bool {
+// isConditionTrue returns whether the named condition is present with
+// Status=True. The name distinguishes this from a presence check —
+// always-present conditions (per CLAUDE.md `### Conditions`) require
+// callers to assert on Status, not on presence.
+func isConditionTrue(group *seiv1alpha1.SeiNodeDeployment, condType string) bool {
 	for _, c := range group.Status.Conditions {
 		if c.Type == condType && c.Status == metav1.ConditionTrue {
 			return true

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -86,8 +86,10 @@ func ForGroup(group *seiv1alpha1.SeiNodeDeployment) (GroupPlanner, error) {
 	return nil, nil
 }
 
-// needsGenesisPlan returns true when GenesisCeremonyNeeded is set with
-// sufficient nodes.
+// needsGenesisPlan returns true when a genesis ceremony has not yet
+// completed for an SND that requires one. Reads
+// ConditionGenesisCeremonyComplete: any value other than True/Complete
+// means "ceremony still needs to run."
 func needsGenesisPlan(group *seiv1alpha1.SeiNodeDeployment) bool {
 	if group.Spec.Genesis == nil {
 		return false
@@ -95,7 +97,7 @@ func needsGenesisPlan(group *seiv1alpha1.SeiNodeDeployment) bool {
 	if group.Status.Plan != nil {
 		return false
 	}
-	if !hasCondition(group, seiv1alpha1.ConditionGenesisCeremonyNeeded) {
+	if hasCondition(group, seiv1alpha1.ConditionGenesisCeremonyComplete) {
 		return false
 	}
 	return allReplicasCreated(group)

--- a/manifests/sei.io_seinodedeployments.yaml
+++ b/manifests/sei.io_seinodedeployments.yaml
@@ -74,7 +74,7 @@ spec:
                   Genesis configures genesis ceremony orchestration for this group.
                   When set, the controller generates GenesisCeremonyNodeConfig for each
                   child SeiNode and coordinates assembly of the final genesis.json.
-                  Immutable once set (enforced at the spec level via CEL).
+                  Immutable once set; enforced by spec-level CEL.
                 properties:
                   accountBalance:
                     default: 1000000000000000000000usei,1000000000000000000000uusdc,1000000000000000000000uatom

--- a/manifests/sei.io_seinodedeployments.yaml
+++ b/manifests/sei.io_seinodedeployments.yaml
@@ -74,6 +74,7 @@ spec:
                   Genesis configures genesis ceremony orchestration for this group.
                   When set, the controller generates GenesisCeremonyNodeConfig for each
                   child SeiNode and coordinates assembly of the final genesis.json.
+                  Immutable once set (enforced at the spec level via CEL).
                 properties:
                   accountBalance:
                     default: 1000000000000000000000usei,1000000000000000000000uusdc,1000000000000000000000uatom
@@ -130,9 +131,6 @@ spec:
                 required:
                 - chainId
                 type: object
-                x-kubernetes-validations:
-                - message: spec.genesis is immutable after creation
-                  rule: self == oldSelf
               networking:
                 description: |-
                   Networking enables public networking for the deployment.
@@ -876,6 +874,11 @@ spec:
                 (full nodes inherit genesis from the validator ceremony''s S3 artifact);
                 remove spec.genesis or set template.spec.validator: {}'
               rule: '!has(self.genesis) || has(self.template.spec.validator)'
+            - message: spec.genesis is immutable once set; the ceremony's outputs
+                (chain ID, validator gentxs, account balances) are baked into chain
+                state and cannot be retroactively rewritten by editing the spec
+              rule: '!has(oldSelf.genesis) || (has(self.genesis) && self.genesis ==
+                oldSelf.genesis)'
           status:
             description: SeiNodeDeploymentStatus defines the observed state of a SeiNodeDeployment.
             properties:


### PR DESCRIPTION
## Summary

Folds `GenesisCeremonyNeeded` + `GenesisCeremonyComplete` into a single always-present `GenesisCeremonyComplete` condition whose state is carried by a stable reason enum. Removes the last sei `*Needed` (School 2) condition, completing the harmonization to the doctrine codified in #329.

Also makes `spec.genesis` CEL-immutable once set, so the latched-True semantics can't be defeated by post-bootstrap spec edits — and so operators can't silently mutate fields (chainID, staking amounts, gentx outputs) that are already baked into chain state.

## State machine

| Status / Reason          | Meaning                                                  |
|--------------------------|----------------------------------------------------------|
| `True / Complete`        | Ceremony finished — latched, survives spec.genesis edits |
| `False / NotApplicable`  | `spec.genesis` is unset (and ceremony never ran)         |
| `False / NotStarted`     | `spec.genesis` set, ceremony not yet started             |
| `False / InProgress`     | Ceremony executing under an active plan                  |

Latch-check ordering is load-bearing — a completed ceremony's history must not be downgraded to `NotApplicable` by a later spec clear (doc-commented at the call site).

`setGenesisCeremonyCondition` is hoisted above any early-return path in `Reconcile`, so the condition is visible on every reconcile and `kubectl describe snd` never shows an absent value during initial-reconcile windows.

## Spec.genesis immutability

Replaces a field-level `+kubebuilder:validation:XValidation:rule="self == oldSelf"` (which silently allowed set→nil through, because CEL on an optional pointer field doesn't fire when the field is removed) with a spec-level rule using explicit `has()` checks:

```
!has(oldSelf.genesis) || (has(self.genesis) && self.genesis == oldSelf.genesis)
```

- Creation with or without `spec.genesis`: allowed
- Adding `spec.genesis` to an SND that didn't have it (`nil → set`): allowed
- Mutating any field, list, or map within `spec.genesis`: **rejected**
- Clearing `spec.genesis`: **rejected**

## Planner translation

`needsGenesisPlan` previously triggered on presence of `GenesisCeremonyNeeded`; now triggers on absence of `GenesisCeremonyComplete=True`. Same semantics across all four states (`NotApplicable` / `NotStarted` / `InProgress` / `Complete`), one fewer condition to maintain.

## Operator-visible cleanup

Pre-existing SNDs in etcd carry a stale `GenesisCeremonyNeeded` entry. The new controller never reads or writes that type, so the entry is harmless — same situation as #330's stale `RouteReady`. Manual cleanup is a one-shot `kubectl patch` per SND.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all unit tests pass
- [x] `make test-integration` — envtest passes (46.2s, no regression)
- [x] New unit cases in `TestSetGenesisCeremonyCondition` cover NotApplicable, latched-True (twice, including operator-clears-spec-after-completion), InProgress, NotStarted, post-failPlan return-to-NotStarted
- [x] New envtests in `genesis_immutable_test.go`:
  - `TestGenesis_ImmutabilityGate` — 6 subtests: clear rejected; chainId / stakingAmount / Accounts / Overrides mutations rejected; same-content update allowed
  - `TestGenesis_CreationWithoutGenesisAllowsLaterAddition` — confirms the `!has(oldSelf.genesis)` short-circuit permits nil → set
  - `TestGenesis_ConditionSeededOnEveryReconcile` — confirms the controller-side hoist ensures `GenesisCeremonyComplete` is visible after first reconcile

## Deferred follow-ups

- **End-to-end ceremony envtest** that exercises the full `NotStarted → InProgress → Complete` reason transition driven by a real plan. The current envtest harness focuses on InPlace rollouts; adding a genesis ceremony plan path is its own investment and best landed alongside an explicit "Phase X envtest: genesis ceremony" effort.
- **`manifests/` mirror** — the platform repo's Kustomization consumes `config/default`, not `manifests/`. The `manifests/` mirror is redundant overhead and a candidate for deletion in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)