### PR TITLE
refactor(snd): seed PlanInProgress and RolloutInProgress on every reconcile

### DIFF
--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -82,7 +82,7 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Seed always-present conditions before any early-return path so they
 	// are visible on every reconcile (see CLAUDE.md `### Conditions`).
-	r.setGenesisCeremonyCondition(group)
+	r.seedAlwaysPresentConditions(group)
 
 	if err := r.reconcileInternalService(ctx, group); err != nil {
 		logger.Error(err, "reconciling internal RPC service")

--- a/internal/controller/nodedeployment/envtest/conditions_seeded_test.go
+++ b/internal/controller/nodedeployment/envtest/conditions_seeded_test.go
@@ -1,0 +1,55 @@
+//go:build envtest
+
+package envtest_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
+)
+
+// TestSND_AlwaysPresentConditionsSeededOnFirstReconcile asserts the
+// three always-present conditions land on a fresh SND with their
+// not-started state values:
+//   - PlanInProgress=False/NotStarted
+//   - RolloutInProgress=False/NotStarted
+//   - GenesisCeremonyComplete=False/NotApplicable (spec.genesis unset)
+func TestSND_AlwaysPresentConditionsSeededOnFirstReconcile(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	snd := fixtures.NewSND(ns, "fresh-snd")
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	waitForStatus(t, client.ObjectKeyFromObject(snd), func(s *seiv1alpha1.SeiNodeDeployment) bool {
+		return findCondition(s, seiv1alpha1.ConditionPlanInProgress) != nil &&
+			findCondition(s, seiv1alpha1.ConditionRolloutInProgress) != nil &&
+			findCondition(s, seiv1alpha1.ConditionGenesisCeremonyComplete) != nil
+	}, "PlanInProgress, RolloutInProgress, GenesisCeremonyComplete must all be present after first reconcile")
+
+	cur := &seiv1alpha1.SeiNodeDeployment{}
+	g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
+
+	plan := findCondition(cur, seiv1alpha1.ConditionPlanInProgress)
+	g.Expect(plan.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(plan.Reason).To(Equal("NotStarted"))
+
+	rollout := findCondition(cur, seiv1alpha1.ConditionRolloutInProgress)
+	g.Expect(rollout.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(rollout.Reason).To(Equal("NotStarted"))
+
+	genesis := findCondition(cur, seiv1alpha1.ConditionGenesisCeremonyComplete)
+	g.Expect(genesis.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(genesis.Reason).To(Equal("NotApplicable"))
+}
+
+func findCondition(s *seiv1alpha1.SeiNodeDeployment, condType string) *metav1.Condition {
+	return apimeta.FindStatusCondition(s.Status.Conditions, condType)
+}

--- a/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
+++ b/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
@@ -159,11 +159,12 @@ func errString(err error) string {
 	return strings.TrimSpace(err.Error())
 }
 
-// TestGenesis_ConditionSeededOnEveryReconcile guards the hoist in
-// controller.go: setGenesisCeremonyCondition runs before any path
-// that may early-return, so the condition is visible immediately
-// once the controller has reconciled the SND.
-func TestGenesis_ConditionSeededOnEveryReconcile(t *testing.T) {
+// TestGenesis_ConditionSeededWithGenesisSpec asserts the condition is
+// present on a genesis-bearing SND after first reconcile. Asserting
+// only presence (not reason) avoids a race: the planner schedules a
+// ceremony plan immediately, which advances the reason from
+// NotStarted to InProgress. Reason coverage lives in unit tests.
+func TestGenesis_ConditionSeededWithGenesisSpec(t *testing.T) {
 	g := NewWithT(t)
 	ns := makeNamespace(t)
 

--- a/internal/controller/nodedeployment/status.go
+++ b/internal/controller/nodedeployment/status.go
@@ -138,6 +138,28 @@ func setNodesReadyCondition(group *seiv1alpha1.SeiNodeDeployment, ready, desired
 	setCondition(group, seiv1alpha1.ConditionNodesReady, status, reason, message)
 }
 
+// seedAlwaysPresentConditions stamps every condition the doctrine
+// requires to be visible on every reconciled SND (see CLAUDE.md
+// `### Conditions`). The seed fires only when the condition is absent,
+// so transition paths (startPlan, completePlan, etc.) own the reason
+// vocabulary once an SND has lifecycle state.
+func (r *SeiNodeDeploymentReconciler) seedAlwaysPresentConditions(group *seiv1alpha1.SeiNodeDeployment) {
+	r.setGenesisCeremonyCondition(group)
+	seedConditionIfAbsent(group, seiv1alpha1.ConditionPlanInProgress,
+		"NotStarted", "no plan has run yet")
+	seedConditionIfAbsent(group, seiv1alpha1.ConditionRolloutInProgress,
+		"NotStarted", "no rollout has run yet")
+}
+
+// seedConditionIfAbsent writes False/<reason>/<message> only when the
+// condition is absent from the SND.
+func seedConditionIfAbsent(group *seiv1alpha1.SeiNodeDeployment, condType, reason, message string) {
+	if apimeta.FindStatusCondition(group.Status.Conditions, condType) != nil {
+		return
+	}
+	setCondition(group, condType, metav1.ConditionFalse, reason, message)
+}
+
 func hasConditionTrue(group *seiv1alpha1.SeiNodeDeployment, condType string) bool { //nolint:unparam // general-purpose utility
 	c := apimeta.FindStatusCondition(group.Status.Conditions, condType)
 	return c != nil && c.Status == metav1.ConditionTrue

--- a/internal/controller/nodedeployment/status_test.go
+++ b/internal/controller/nodedeployment/status_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
@@ -186,4 +188,76 @@ func TestBuildNetworkingStatus_ProtocolValues(t *testing.T) {
 		protocols[i] = rs.Protocol
 	}
 	g.Expect(protocols).To(ConsistOf("evm", "rpc", "rest", "grpc"))
+}
+
+func TestSeedAlwaysPresentConditions(t *testing.T) {
+	cases := []struct {
+		name       string
+		mutate     func(*seiv1alpha1.SeiNodeDeployment)
+		condType   string
+		wantStatus metav1.ConditionStatus
+		wantReason string
+	}{
+		{
+			name:       "PlanInProgress seeds False/NotStarted on a fresh SND",
+			mutate:     func(g *seiv1alpha1.SeiNodeDeployment) {},
+			condType:   seiv1alpha1.ConditionPlanInProgress,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NotStarted",
+		},
+		{
+			name:       "RolloutInProgress seeds False/NotStarted on a fresh SND",
+			mutate:     func(g *seiv1alpha1.SeiNodeDeployment) {},
+			condType:   seiv1alpha1.ConditionRolloutInProgress,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NotStarted",
+		},
+		{
+			// The seed runs before transition paths in the same
+			// reconcile, so a True write from startPlan must not be
+			// re-seeded on the next pass.
+			name: "PlanInProgress=True is preserved",
+			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
+				setCondition(g, seiv1alpha1.ConditionPlanInProgress, metav1.ConditionTrue, "PlanStarted", "")
+			},
+			condType:   seiv1alpha1.ConditionPlanInProgress,
+			wantStatus: metav1.ConditionTrue,
+			wantReason: "PlanStarted",
+		},
+		{
+			// The seed only fires on absence, so the transition reason
+			// from completePlan (False/PlanComplete) stays put.
+			name: "PlanInProgress=False/PlanComplete is preserved",
+			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
+				setCondition(g, seiv1alpha1.ConditionPlanInProgress, metav1.ConditionFalse, "PlanComplete", "")
+			},
+			condType:   seiv1alpha1.ConditionPlanInProgress,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "PlanComplete",
+		},
+		{
+			name: "RolloutInProgress=False/RolloutComplete is preserved",
+			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
+				setCondition(g, seiv1alpha1.ConditionRolloutInProgress, metav1.ConditionFalse, "RolloutComplete", "")
+			},
+			condType:   seiv1alpha1.ConditionRolloutInProgress,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "RolloutComplete",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			group := newTestGroup("archive-rpc", "sei")
+			tc.mutate(group)
+
+			r := &SeiNodeDeploymentReconciler{Recorder: record.NewFakeRecorder(10)}
+			r.seedAlwaysPresentConditions(group)
+
+			cond := apimeta.FindStatusCondition(group.Status.Conditions, tc.condType)
+			g.Expect(cond).NotTo(BeNil(), "%s must be present after seeding", tc.condType)
+			g.Expect(cond.Status).To(Equal(tc.wantStatus))
+			g.Expect(cond.Reason).To(Equal(tc.wantReason))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Finishes the SND-side conditions harmonization started by #329 (doctrine), #330 (RouteReady→NetworkingReady), and #333 (GenesisCeremonyComplete). `PlanInProgress` and `RolloutInProgress` are the last two SND conditions whose presence was School 2 (presence-style — True/<reason> when active, absent otherwise). After this change they are seeded `False/NotStarted` on first reconcile, matching the always-present School 1 doctrine.

> Based on #333. Merge #333 first or change the base to `main` once that lands.

## What changes

`seedAlwaysPresentConditions` consolidates the three SND always-present conditions into a single helper called from `Reconcile` before any early-return path:

```go
r.seedAlwaysPresentConditions(group)
//   → r.setGenesisCeremonyCondition(group)
//   → seedConditionIfAbsent(group, ConditionPlanInProgress,    "NotStarted", ...)
//   → seedConditionIfAbsent(group, ConditionRolloutInProgress, "NotStarted", ...)
```

`seedConditionIfAbsent` is the new minimal helper: write `False/<reason>/<message>` only when the condition is absent on the SND. Transition paths (`startPlan`, `completePlan`, `failPlan`, `detectDeploymentNeeded`) keep ownership of the reason vocabulary once an SND has any lifecycle state — the seed only fires on absence.

## SND conditions surface after this PR

| Condition | School / pattern | Status |
|---|---|---|
| `NodesReady` | School 1 — written every reconcile in `updateStatus` | ✅ |
| `NetworkingReady` | School 1 — #330 | ✅ |
| `GenesisCeremonyComplete` | School 1 — #333 | ✅ |
| `PlanInProgress` | School 1 — this PR | ✅ |
| `RolloutInProgress` | School 1 — this PR | ✅ |

Every SND condition now satisfies the doctrine. SeiNode-level conditions are a separate audit pass.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all unit tests pass
- [x] `make test-integration` — envtest passes (46.3s, no regression)
- [x] New unit test `TestSeedAlwaysPresentConditions` covers:
  - Fresh SND seeds `PlanInProgress=False/NotStarted`
  - Fresh SND seeds `RolloutInProgress=False/NotStarted`
  - Existing `PlanInProgress=True/PlanStarted` survives the seed (transition write wins)
  - Existing `PlanInProgress=False/PlanComplete` survives the seed
  - Existing `RolloutInProgress=False/RolloutComplete` survives the seed
- [x] New envtest `TestSND_AlwaysPresentConditionsSeededOnFirstReconcile` asserts a fresh full-node SND has all three conditions present after first reconcile with their not-started state values

## Operator-visible cleanup

Existing production SNDs that have never run a plan or rollout will start carrying `PlanInProgress=False/NotStarted` and `RolloutInProgress=False/NotStarted` on the next reconcile after this controller version ships. No prior absence-keyed PromQL queries today (verified by grep of platform-repo monitoring config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)