### PR TITLE
refactor(snd): recover seeding + Spec.Paused stack into main (was #338 + #342)

### DIFF
--- a/api/v1alpha1/seinode_types.go
+++ b/api/v1alpha1/seinode_types.go
@@ -66,6 +66,13 @@ type SeiNodeSpec struct {
 	// Validator configures a consensus-participating validator node.
 	// +optional
 	Validator *ValidatorSpec `json:"validator,omitempty"`
+
+	// Paused freezes reconciliation. While true, the controller does not
+	// advance the lifecycle, start plans, or mutate derived resources.
+	// In-flight tasks on the cluster run to completion but their results
+	// are not polled until the field is cleared.
+	// +optional
+	Paused bool `json:"paused,omitempty"`
 }
 
 // DataVolumeSpec configures how the data PVC is sourced.
@@ -264,6 +271,8 @@ const (
 	// spec.validator.operatorKeyring.
 	ConditionOperatorKeyringReady = "OperatorKeyringReady"
 
+	// ConditionSeiNodePaused mirrors spec.paused: True when paused.
+	ConditionSeiNodePaused = "Paused"
 )
 
 // Reasons for the ImportPVCReady condition.

--- a/api/v1alpha1/seinodedeployment_types.go
+++ b/api/v1alpha1/seinodedeployment_types.go
@@ -45,6 +45,13 @@ type SeiNodeDeploymentSpec struct {
 	// UpdateStrategy controls how changes to the template are rolled out
 	// to child SeiNodes. Every deployment must declare an explicit strategy.
 	UpdateStrategy UpdateStrategy `json:"updateStrategy"`
+
+	// Paused freezes plan-driven orchestration. While true, no new plans
+	// start, no rollouts trigger, no template changes propagate to
+	// children, and any active plan freezes in place. Networking and
+	// Service reconciliation continue. Children inherit the paused state.
+	// +optional
+	Paused bool `json:"paused,omitempty"`
 }
 
 // UpdateStrategyType identifies the deployment strategy.
@@ -136,7 +143,7 @@ type SeiNodeTemplateMeta struct {
 // ---------------------------------------------------------------------------
 
 // SeiNodeDeploymentPhase represents the high-level lifecycle state.
-// +kubebuilder:validation:Enum=Pending;Initializing;Ready;Upgrading;Degraded;Failed;Terminating
+// +kubebuilder:validation:Enum=Pending;Initializing;Ready;Upgrading;Paused;Degraded;Failed;Terminating
 type SeiNodeDeploymentPhase string
 
 const (
@@ -144,6 +151,7 @@ const (
 	GroupPhaseInitializing SeiNodeDeploymentPhase = "Initializing"
 	GroupPhaseReady        SeiNodeDeploymentPhase = "Ready"
 	GroupPhaseUpgrading    SeiNodeDeploymentPhase = "Upgrading"
+	GroupPhasePaused       SeiNodeDeploymentPhase = "Paused"
 	GroupPhaseDegraded     SeiNodeDeploymentPhase = "Degraded"
 	GroupPhaseFailed       SeiNodeDeploymentPhase = "Failed"
 	GroupPhaseTerminating  SeiNodeDeploymentPhase = "Terminating"
@@ -366,6 +374,7 @@ const (
 	ConditionGenesisCeremonyComplete = "GenesisCeremonyComplete"
 	ConditionPlanInProgress          = "PlanInProgress"
 	ConditionRolloutInProgress       = "RolloutInProgress"
+	ConditionPaused                  = "Paused"
 )
 
 // +kubebuilder:object:root=true
@@ -374,6 +383,7 @@ const (
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.readyReplicas`
 // +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Paused",type=boolean,JSONPath=`.spec.paused`,priority=1
 // +kubebuilder:printcolumn:name="Target",type=string,JSONPath=`.status.rollout.targetHash`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/api/v1alpha1/seinodedeployment_types.go
+++ b/api/v1alpha1/seinodedeployment_types.go
@@ -383,7 +383,7 @@ const (
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.readyReplicas`
 // +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
-// +kubebuilder:printcolumn:name="Paused",type=boolean,JSONPath=`.spec.paused`,priority=1
+// +kubebuilder:printcolumn:name="Paused",type=boolean,JSONPath=`.spec.paused`
 // +kubebuilder:printcolumn:name="Target",type=string,JSONPath=`.status.rollout.targetHash`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/config/crd/sei.io_seinodedeployments.yaml
+++ b/config/crd/sei.io_seinodedeployments.yaml
@@ -28,7 +28,6 @@ spec:
       type: string
     - jsonPath: .spec.paused
       name: Paused
-      priority: 1
       type: boolean
     - jsonPath: .status.rollout.targetHash
       name: Target
@@ -144,12 +143,10 @@ spec:
                 type: object
               paused:
                 description: |-
-                  Paused freezes plan-driven orchestration on this SeiNodeDeployment.
-                  While true, the controller does not build new plans, does not start
-                  new rollouts, and does not propagate spec.template changes to child
-                  SeiNodes. In-flight plans drain to their natural conclusion.
-                  Networking and Service reconciliation continue normally so existing
-                  traffic is not disrupted. Operators clear the field to resume.
+                  Paused freezes plan-driven orchestration. While true, no new plans
+                  start, no rollouts trigger, no template changes propagate to
+                  children, and any active plan freezes in place. Networking and
+                  Service reconciliation continue. Children inherit the paused state.
                 type: boolean
               replicas:
                 default: 1
@@ -351,13 +348,10 @@ spec:
                         type: object
                       paused:
                         description: |-
-                          Paused freezes reconciliation on this SeiNode. While true, the
-                          controller does not advance the lifecycle, does not start new plans,
-                          and does not mutate derived resources (StatefulSet, Services, PVCs).
-                          In-flight tasks already running on the cluster (e.g., sidecar Jobs)
-                          run to their natural conclusion but the controller does not poll or
-                          transition state machines based on their results. Operators clear
-                          the field to resume.
+                          Paused freezes reconciliation. While true, the controller does not
+                          advance the lifecycle, start plans, or mutate derived resources.
+                          In-flight tasks on the cluster run to completion but their results
+                          are not polled until the field is cleared.
                         type: boolean
                       peers:
                         description: |-

--- a/config/crd/sei.io_seinodedeployments.yaml
+++ b/config/crd/sei.io_seinodedeployments.yaml
@@ -26,6 +26,10 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .spec.paused
+      name: Paused
+      priority: 1
+      type: boolean
     - jsonPath: .status.rollout.targetHash
       name: Target
       priority: 1
@@ -138,6 +142,15 @@ spec:
                   HTTPRoutes on the platform Gateway. When absent, the deployment
                   is private with only per-node headless Services.
                 type: object
+              paused:
+                description: |-
+                  Paused freezes plan-driven orchestration on this SeiNodeDeployment.
+                  While true, the controller does not build new plans, does not start
+                  new rollouts, and does not propagate spec.template changes to child
+                  SeiNodes. In-flight plans drain to their natural conclusion.
+                  Networking and Service reconciliation continue normally so existing
+                  traffic is not disrupted. Operators clear the field to resume.
+                type: boolean
               replicas:
                 default: 1
                 description: Replicas is the number of SeiNode instances to create.
@@ -336,6 +349,16 @@ spec:
                           Keys use the sei-config unified schema (e.g. "evm.http_port", "storage.pruning").
                           These are applied on top of mode defaults during config-apply.
                         type: object
+                      paused:
+                        description: |-
+                          Paused freezes reconciliation on this SeiNode. While true, the
+                          controller does not advance the lifecycle, does not start new plans,
+                          and does not mutate derived resources (StatefulSet, Services, PVCs).
+                          In-flight tasks already running on the cluster (e.g., sidecar Jobs)
+                          run to their natural conclusion but the controller does not poll or
+                          transition state machines based on their results. Operators clear
+                          the field to resume.
+                        type: boolean
                       peers:
                         description: |-
                           Peers configures how this node discovers and connects to network peers.
@@ -1137,6 +1160,7 @@ spec:
                 - Initializing
                 - Ready
                 - Upgrading
+                - Paused
                 - Degraded
                 - Failed
                 - Terminating

--- a/config/crd/sei.io_seinodes.yaml
+++ b/config/crd/sei.io_seinodes.yaml
@@ -217,13 +217,10 @@ spec:
                 type: object
               paused:
                 description: |-
-                  Paused freezes reconciliation on this SeiNode. While true, the
-                  controller does not advance the lifecycle, does not start new plans,
-                  and does not mutate derived resources (StatefulSet, Services, PVCs).
-                  In-flight tasks already running on the cluster (e.g., sidecar Jobs)
-                  run to their natural conclusion but the controller does not poll or
-                  transition state machines based on their results. Operators clear
-                  the field to resume.
+                  Paused freezes reconciliation. While true, the controller does not
+                  advance the lifecycle, start plans, or mutate derived resources.
+                  In-flight tasks on the cluster run to completion but their results
+                  are not polled until the field is cleared.
                 type: boolean
               peers:
                 description: |-

--- a/config/crd/sei.io_seinodes.yaml
+++ b/config/crd/sei.io_seinodes.yaml
@@ -215,6 +215,16 @@ spec:
                   Keys use the sei-config unified schema (e.g. "evm.http_port", "storage.pruning").
                   These are applied on top of mode defaults during config-apply.
                 type: object
+              paused:
+                description: |-
+                  Paused freezes reconciliation on this SeiNode. While true, the
+                  controller does not advance the lifecycle, does not start new plans,
+                  and does not mutate derived resources (StatefulSet, Services, PVCs).
+                  In-flight tasks already running on the cluster (e.g., sidecar Jobs)
+                  run to their natural conclusion but the controller does not poll or
+                  transition state machines based on their results. Operators clear
+                  the field to resume.
+                type: boolean
               peers:
                 description: |-
                   Peers configures how this node discovers and connects to network peers.

--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -100,6 +100,18 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	observedPhase := node.Status.Phase
 	prevSidecar := apimeta.FindStatusCondition(node.Status.Conditions, seiv1alpha1.ConditionSidecarReady)
 
+	setNodePausedCondition(node)
+	if node.Spec.Paused {
+		// Patch the paused condition so kubectl describe shows the state;
+		// nothing else runs while paused.
+		if !apiequality.Semantic.DeepEqual(before.Status, node.Status) {
+			if err := r.Status().Patch(ctx, node, statusBase); err != nil {
+				return ctrl.Result{}, fmt.Errorf("flushing paused status: %w", err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
 	if err := r.reconcilePeers(ctx, node); err != nil {
 		return ctrl.Result{}, fmt.Errorf("reconciling peers: %w", err)
 	}
@@ -236,6 +248,24 @@ func (r *SeiNodeReconciler) deleteNodeDataPVC(ctx context.Context, node *seiv1al
 		return err
 	}
 	return r.Delete(ctx, pvc)
+}
+
+// setNodePausedCondition mirrors spec.paused into ConditionSeiNodePaused.
+func setNodePausedCondition(node *seiv1alpha1.SeiNode) {
+	cond := metav1.Condition{
+		Type:               seiv1alpha1.ConditionSeiNodePaused,
+		ObservedGeneration: node.Generation,
+	}
+	if node.Spec.Paused {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = "Paused"
+		cond.Message = "spec.paused is true; reconciliation is frozen"
+	} else {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "NotPaused"
+		cond.Message = "spec.paused is unset or false"
+	}
+	apimeta.SetStatusCondition(&node.Status.Conditions, cond)
 }
 
 func (r *SeiNodeReconciler) emitSidecarReadinessEvent(node *seiv1alpha1.SeiNode, prev *metav1.Condition) {

--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -88,26 +88,33 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	// Failed is terminal — nothing to do.
-	if node.Status.Phase == seiv1alpha1.PhaseFailed {
-		r.Recorder.Eventf(node, corev1.EventTypeWarning, "NodeFailed",
-			"SeiNode is in Failed state. Delete and recreate the resource to retry.")
-		return ctrl.Result{}, nil
-	}
-
 	before := node.DeepCopy()
 	statusBase := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
 	observedPhase := node.Status.Phase
 	prevSidecar := apimeta.FindStatusCondition(node.Status.Conditions, seiv1alpha1.ConditionSidecarReady)
 
 	setNodePausedCondition(node)
+
+	flushStatus := func() error {
+		if apiequality.Semantic.DeepEqual(before.Status, node.Status) {
+			return nil
+		}
+		return r.Status().Patch(ctx, node, statusBase)
+	}
+
+	// Failed is terminal — flush any condition updates and exit.
+	if node.Status.Phase == seiv1alpha1.PhaseFailed {
+		if err := flushStatus(); err != nil {
+			return ctrl.Result{}, fmt.Errorf("flushing status on Failed: %w", err)
+		}
+		r.Recorder.Eventf(node, corev1.EventTypeWarning, "NodeFailed",
+			"SeiNode is in Failed state. Delete and recreate the resource to retry.")
+		return ctrl.Result{}, nil
+	}
+
 	if node.Spec.Paused {
-		// Patch the paused condition so kubectl describe shows the state;
-		// nothing else runs while paused.
-		if !apiequality.Semantic.DeepEqual(before.Status, node.Status) {
-			if err := r.Status().Patch(ctx, node, statusBase); err != nil {
-				return ctrl.Result{}, fmt.Errorf("flushing paused status: %w", err)
-			}
+		if err := flushStatus(); err != nil {
+			return ctrl.Result{}, fmt.Errorf("flushing paused status: %w", err)
 		}
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -80,9 +80,12 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	statusBase := client.MergeFromWithOptions(group.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	ns, name := group.Namespace, group.Name
 
-	// Seed always-present conditions before any early-return path so
-	// they are visible on every reconcile.
 	r.seedAlwaysPresentConditions(group)
+
+	if err := r.syncPausedToChildren(ctx, group, group.Spec.Paused); err != nil {
+		logger.Error(err, "propagating paused state to children")
+		return ctrl.Result{}, fmt.Errorf("propagating paused state: %w", err)
+	}
 
 	if err := r.reconcileInternalService(ctx, group); err != nil {
 		logger.Error(err, "reconciling internal RPC service")

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -80,8 +80,8 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	statusBase := client.MergeFromWithOptions(group.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	ns, name := group.Namespace, group.Name
 
-	// Seed always-present conditions before any early-return path so they
-	// are visible on every reconcile (see CLAUDE.md `### Conditions`).
+	// Seed always-present conditions before any early-return path so
+	// they are visible on every reconcile.
 	r.seedAlwaysPresentConditions(group)
 
 	if err := r.reconcileInternalService(ctx, group); err != nil {

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -82,7 +82,7 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Seed always-present conditions before any early-return path so they
 	// are visible on every reconcile (see CLAUDE.md `### Conditions`).
-	r.setGenesisCeremonyCondition(group)
+	r.seedAlwaysPresentConditions(group)
 
 	if err := r.reconcileInternalService(ctx, group); err != nil {
 		logger.Error(err, "reconciling internal RPC service")

--- a/internal/controller/nodedeployment/envtest/conditions_seeded_test.go
+++ b/internal/controller/nodedeployment/envtest/conditions_seeded_test.go
@@ -1,0 +1,55 @@
+//go:build envtest
+
+package envtest_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
+)
+
+// TestSND_AlwaysPresentConditionsSeededOnFirstReconcile asserts the
+// three always-present conditions land on a fresh SND with their
+// not-started state values:
+//   - PlanInProgress=False/NotStarted
+//   - RolloutInProgress=False/NotStarted
+//   - GenesisCeremonyComplete=False/NotApplicable (spec.genesis unset)
+func TestSND_AlwaysPresentConditionsSeededOnFirstReconcile(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	snd := fixtures.NewSND(ns, "fresh-snd")
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	waitForStatus(t, client.ObjectKeyFromObject(snd), func(s *seiv1alpha1.SeiNodeDeployment) bool {
+		return findCondition(s, seiv1alpha1.ConditionPlanInProgress) != nil &&
+			findCondition(s, seiv1alpha1.ConditionRolloutInProgress) != nil &&
+			findCondition(s, seiv1alpha1.ConditionGenesisCeremonyComplete) != nil
+	}, "PlanInProgress, RolloutInProgress, GenesisCeremonyComplete must all be present after first reconcile")
+
+	cur := &seiv1alpha1.SeiNodeDeployment{}
+	g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(snd), cur)).To(Succeed())
+
+	plan := findCondition(cur, seiv1alpha1.ConditionPlanInProgress)
+	g.Expect(plan.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(plan.Reason).To(Equal("NotStarted"))
+
+	rollout := findCondition(cur, seiv1alpha1.ConditionRolloutInProgress)
+	g.Expect(rollout.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(rollout.Reason).To(Equal("NotStarted"))
+
+	genesis := findCondition(cur, seiv1alpha1.ConditionGenesisCeremonyComplete)
+	g.Expect(genesis.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(genesis.Reason).To(Equal("NotApplicable"))
+}
+
+func findCondition(s *seiv1alpha1.SeiNodeDeployment, condType string) *metav1.Condition {
+	return apimeta.FindStatusCondition(s.Status.Conditions, condType)
+}

--- a/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
+++ b/internal/controller/nodedeployment/envtest/genesis_immutable_test.go
@@ -159,11 +159,12 @@ func errString(err error) string {
 	return strings.TrimSpace(err.Error())
 }
 
-// TestGenesis_ConditionSeededOnEveryReconcile guards the hoist in
-// controller.go: setGenesisCeremonyCondition runs before any path
-// that may early-return, so the condition is visible immediately
-// once the controller has reconciled the SND.
-func TestGenesis_ConditionSeededOnEveryReconcile(t *testing.T) {
+// TestGenesis_ConditionSeededWithGenesisSpec asserts the condition is
+// present on a genesis-bearing SND after first reconcile. Asserting
+// only presence (not reason) avoids a race: the planner schedules a
+// ceremony plan immediately, which advances the reason from
+// NotStarted to InProgress. Reason coverage lives in unit tests.
+func TestGenesis_ConditionSeededWithGenesisSpec(t *testing.T) {
 	g := NewWithT(t)
 	ns := makeNamespace(t)
 

--- a/internal/controller/nodedeployment/envtest/paused_test.go
+++ b/internal/controller/nodedeployment/envtest/paused_test.go
@@ -131,6 +131,78 @@ func pausedCond(s *seiv1alpha1.SeiNodeDeployment) *metav1.Condition {
 	return apimeta.FindStatusCondition(s.Status.Conditions, seiv1alpha1.ConditionPaused)
 }
 
+// TestSND_Unpause_DuringActivePlan_PropagatesToChildren guards the
+// deadlock case: pause flips on with a plan in progress, then operator
+// unpauses. The unpause must clear Spec.Paused on every child or
+// await-nodes-running spins forever because the SeiNode controller
+// short-circuits on the still-paused children.
+func TestSND_Unpause_DuringActivePlan_PropagatesToChildren(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	snd := fixtures.NewSND(ns, "pause-during-plan", fixtures.WithReplicas(2))
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+	key := client.ObjectKeyFromObject(snd)
+
+	// Initial settle — both children exist, no plan, paused condition seeded False.
+	waitForStatus(t, key, func(s *seiv1alpha1.SeiNodeDeployment) bool {
+		return len(listChildren(t, s)) == 2 &&
+			pausedCond(s) != nil && pausedCond(s).Status == metav1.ConditionFalse
+	}, "two children exist and ConditionPaused=False is seeded")
+
+	// Stall the faker so the v2 rollout's plan parks in flight.
+	testFaker.Pause()
+	t.Cleanup(testFaker.Resume)
+
+	patchSNDImage(t, getSND(t, key), "ghcr.io/sei-protocol/seid:v2.0.0")
+
+	// Wait for ConditionPlanInProgress=True — the SND has an active
+	// stalled plan, which is the precondition the deadlock-on-unpause
+	// case requires.
+	waitForStatus(t, key, func(s *seiv1alpha1.SeiNodeDeployment) bool {
+		return condTrue(s, seiv1alpha1.ConditionPlanInProgress)
+	}, "plan must be in progress before pause flips on")
+
+	// Pause with the plan active. Children pick up Paused=true.
+	cur := getSND(t, key)
+	patch := client.MergeFrom(cur.DeepCopy())
+	cur.Spec.Paused = true
+	g.Expect(testCli.Patch(testCtx, cur, patch)).To(Succeed())
+
+	waitFor(t, func() bool {
+		for _, c := range listChildren(t, getSND(t, key)) {
+			if !c.Spec.Paused {
+				return false
+			}
+		}
+		return true
+	}, "every child must reach Spec.Paused=true after SND pause")
+
+	// Unpause while ConditionPlanInProgress is still True. The
+	// controller propagates Spec.Paused=false to every child on this
+	// reconcile path so resume is not gated on plan completion.
+	cur = getSND(t, key)
+	patch = client.MergeFrom(cur.DeepCopy())
+	cur.Spec.Paused = false
+	g.Expect(testCli.Patch(testCtx, cur, patch)).To(Succeed())
+
+	waitFor(t, func() bool {
+		s := getSND(t, key)
+		if !condTrue(s, seiv1alpha1.ConditionPlanInProgress) {
+			// Test precondition lost — fail loudly so the test isn't
+			// silently passing on a non-deadlock path.
+			t.Fatalf("ConditionPlanInProgress must remain True throughout the test; got %+v",
+				apimeta.FindStatusCondition(s.Status.Conditions, seiv1alpha1.ConditionPlanInProgress))
+		}
+		for _, c := range listChildren(t, s) {
+			if c.Spec.Paused {
+				return false
+			}
+		}
+		return true
+	}, "every child must clear Spec.Paused=false on unpause even while ConditionPlanInProgress=True")
+}
+
 // TestSeiNode_Paused_FreezesReconcile asserts a paused SeiNode reports
 // ConditionSeiNodePaused=True and does not advance through its lifecycle.
 func TestSeiNode_Paused_FreezesReconcile(t *testing.T) {

--- a/internal/controller/nodedeployment/envtest/paused_test.go
+++ b/internal/controller/nodedeployment/envtest/paused_test.go
@@ -1,0 +1,176 @@
+//go:build envtest
+
+package envtest_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
+)
+
+// TestSND_Paused_PropagatesAndBlocksOrchestration asserts:
+//  1. spec.paused=true sets ConditionPaused=True and Status.Phase=Paused.
+//  2. Paused state propagates to every owned child SeiNode.
+//  3. A template change applied while paused does not start a rollout
+//     and does not mutate children's spec.
+//  4. Clearing spec.paused propagates back to children and the deferred
+//     template change rolls forward to convergence.
+func TestSND_Paused_PropagatesAndBlocksOrchestration(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	snd := fixtures.NewSND(ns, "paused-snd", fixtures.WithReplicas(2))
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+	key := client.ObjectKeyFromObject(snd)
+
+	// 1. Initial settle. Both children exist and the SND has
+	//    ConditionPaused=False/NotPaused seeded.
+	waitForStatus(t, key, func(s *seiv1alpha1.SeiNodeDeployment) bool {
+		return len(listChildren(t, s)) == 2 &&
+			pausedCond(s) != nil && pausedCond(s).Status == metav1.ConditionFalse
+	}, "two children exist and ConditionPaused=False is seeded on a fresh SND")
+
+	// 2. Pause the SND. ConditionPaused flips True, Status.Phase moves
+	//    to Paused, and children pick up Spec.Paused=true on the next
+	//    reconcile.
+	cur := getSND(t, key)
+	patch := client.MergeFrom(cur.DeepCopy())
+	cur.Spec.Paused = true
+	g.Expect(testCli.Patch(testCtx, cur, patch)).To(Succeed())
+
+	waitForStatus(t, key, func(s *seiv1alpha1.SeiNodeDeployment) bool {
+		c := pausedCond(s)
+		return c != nil && c.Status == metav1.ConditionTrue && c.Reason == "Paused" &&
+			s.Status.Phase == seiv1alpha1.GroupPhasePaused
+	}, "ConditionPaused must transition to True/Paused and Status.Phase to Paused")
+
+	waitFor(t, func() bool {
+		children := listChildren(t, getSND(t, key))
+		if len(children) == 0 {
+			return false
+		}
+		for i := range children {
+			if !children[i].Spec.Paused {
+				return false
+			}
+		}
+		return true
+	}, "every child SeiNode must have Spec.Paused=true after SND pause")
+
+	// 3. Template change is observed but blocked. Patch v1→v2 while
+	//    paused and assert no rollout fires for 3s. The SND's
+	//    TemplateHash isn't rolled forward, Status.Rollout stays nil,
+	//    and child Spec.Image stays at the original.
+	cur = getSND(t, key)
+	patchSNDImage(t, cur, "ghcr.io/sei-protocol/seid:v2.0.0")
+
+	g.Consistently(func(g Gomega) {
+		s := getSND(t, key)
+		g.Expect(s.Status.Rollout).To(BeNil(), "Status.Rollout must stay nil while paused")
+		g.Expect(condTrue(s, seiv1alpha1.ConditionRolloutInProgress)).To(BeFalse(),
+			"ConditionRolloutInProgress must not be True while paused")
+		g.Expect(s.Status.Plan).To(BeNil(), "Status.Plan must stay nil while paused")
+		for _, child := range listChildren(t, s) {
+			g.Expect(child.Spec.Image).To(Equal(fixtures.DefaultImage),
+				"child Spec.Image must not propagate while paused")
+		}
+	}, 3*time.Second, 200*time.Millisecond).Should(Succeed())
+
+	// 4. Unpause. Children's Spec.Paused clears, and the deferred v2
+	//    template change rolls forward — TemplateHash must NOT have
+	//    silently advanced during the pause window, or this resume
+	//    converges to a stale spec.
+	cur = getSND(t, key)
+	patch = client.MergeFrom(cur.DeepCopy())
+	cur.Spec.Paused = false
+	g.Expect(testCli.Patch(testCtx, cur, patch)).To(Succeed())
+
+	waitFor(t, func() bool {
+		children := listChildren(t, getSND(t, key))
+		if len(children) == 0 {
+			return false
+		}
+		for i := range children {
+			if children[i].Spec.Paused {
+				return false
+			}
+		}
+		return true
+	}, "every child SeiNode must have Spec.Paused=false after unpause")
+
+	// 5. Deferred template change converges. ConditionRolloutInProgress
+	//    must reach True (the rollout starts), and every child's
+	//    Spec.Image must advance to v2 on subsequent ensureSeiNode runs.
+	waitForStatus(t, key, func(s *seiv1alpha1.SeiNodeDeployment) bool {
+		return condTrue(s, seiv1alpha1.ConditionRolloutInProgress) || s.Status.Rollout != nil
+	}, "deferred template change must trigger a rollout after unpause")
+
+	waitFor(t, func() bool {
+		children := listChildren(t, getSND(t, key))
+		if len(children) == 0 {
+			return false
+		}
+		for i := range children {
+			if children[i].Spec.Image != "ghcr.io/sei-protocol/seid:v2.0.0" {
+				return false
+			}
+		}
+		return true
+	}, "child Spec.Image must converge to the v2 template after unpause")
+}
+
+func pausedCond(s *seiv1alpha1.SeiNodeDeployment) *metav1.Condition {
+	return apimeta.FindStatusCondition(s.Status.Conditions, seiv1alpha1.ConditionPaused)
+}
+
+// TestSeiNode_Paused_FreezesReconcile asserts a paused SeiNode reports
+// ConditionSeiNodePaused=True and does not advance through its lifecycle.
+func TestSeiNode_Paused_FreezesReconcile(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	node := &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "paused-node",
+			Namespace: ns,
+		},
+		Spec: seiv1alpha1.SeiNodeSpec{
+			ChainID:  "pacific-1",
+			Image:    fixtures.DefaultImage,
+			FullNode: &seiv1alpha1.FullNodeSpec{},
+			Paused:   true,
+		},
+	}
+	g.Expect(testCli.Create(testCtx, node)).To(Succeed())
+	key := client.ObjectKeyFromObject(node)
+
+	// ConditionSeiNodePaused must appear True.
+	waitFor(t, func() bool {
+		cur := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, key, cur); err != nil {
+			return false
+		}
+		c := apimeta.FindStatusCondition(cur.Status.Conditions, seiv1alpha1.ConditionSeiNodePaused)
+		return c != nil && c.Status == metav1.ConditionTrue && c.Reason == "Paused"
+	}, "ConditionSeiNodePaused must be True/Paused on a paused node")
+
+	// Phase must not advance — a paused node never leaves whatever
+	// state it started in. The first reconcile may set Phase="" or
+	// Phase=Pending; neither should progress further.
+	g.Consistently(func(g Gomega) {
+		cur := &seiv1alpha1.SeiNode{}
+		g.Expect(testCli.Get(testCtx, key, cur)).To(Succeed())
+		g.Expect(cur.Status.Phase).NotTo(Equal(seiv1alpha1.PhaseInitializing),
+			"phase must not advance past Pending while paused")
+		g.Expect(cur.Status.Phase).NotTo(Equal(seiv1alpha1.PhaseRunning),
+			"phase must not reach Running while paused")
+	}, 3*time.Second, 200*time.Millisecond).Should(Succeed())
+}

--- a/internal/controller/nodedeployment/metrics.go
+++ b/internal/controller/nodedeployment/metrics.go
@@ -14,6 +14,7 @@ var allGroupPhases = []string{
 	string(seiv1alpha1.GroupPhaseInitializing),
 	string(seiv1alpha1.GroupPhaseReady),
 	string(seiv1alpha1.GroupPhaseUpgrading),
+	string(seiv1alpha1.GroupPhasePaused),
 	string(seiv1alpha1.GroupPhaseDegraded),
 	string(seiv1alpha1.GroupPhaseFailed),
 	string(seiv1alpha1.GroupPhaseTerminating),

--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -28,6 +28,13 @@ func (r *SeiNodeDeploymentReconciler) reconcileSeiNodes(ctx context.Context, gro
 		return r.populateIncumbentNodes(ctx, group)
 	}
 
+	// Spec.Paused propagates to children on every reconcile, including
+	// while a plan is in progress. Children that remain paused stall
+	// await-nodes-running and prevent the plan from advancing.
+	if err := r.syncPausedToChildren(ctx, group, false); err != nil {
+		return err
+	}
+
 	if !hasConditionTrue(group, seiv1alpha1.ConditionPlanInProgress) {
 		for i := range int(group.Spec.Replicas) {
 			if err := r.ensureSeiNode(ctx, group, i); err != nil {
@@ -35,11 +42,6 @@ func (r *SeiNodeDeploymentReconciler) reconcileSeiNodes(ctx context.Context, gro
 			}
 		}
 		if err := r.scaleDown(ctx, group); err != nil {
-			return err
-		}
-		// Clear any stale Paused=true on children so each SeiNode
-		// resumes reconciling once spec.paused goes false.
-		if err := r.syncPausedToChildren(ctx, group, false); err != nil {
 			return err
 		}
 	} else {

--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -16,11 +16,18 @@ import (
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
 
-// reconcileSeiNodes ensures the desired set of child SeiNodes exist,
-// populates IncumbentNodes on the group status, and detects spec changes
-// that require deployment orchestration. When a plan is in progress,
-// mutations are skipped to avoid interfering with active orchestration.
+// reconcileSeiNodes ensures the desired child SeiNodes exist, populates
+// IncumbentNodes, and detects spec changes that require orchestration.
+// Mutations are skipped while a plan is in progress. While paused, the
+// only action taken is propagating the paused state to children.
 func (r *SeiNodeDeploymentReconciler) reconcileSeiNodes(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
+	if group.Spec.Paused {
+		if err := r.syncPausedToChildren(ctx, group, true); err != nil {
+			return err
+		}
+		return r.populateIncumbentNodes(ctx, group)
+	}
+
 	if !hasConditionTrue(group, seiv1alpha1.ConditionPlanInProgress) {
 		for i := range int(group.Spec.Replicas) {
 			if err := r.ensureSeiNode(ctx, group, i); err != nil {
@@ -28,6 +35,11 @@ func (r *SeiNodeDeploymentReconciler) reconcileSeiNodes(ctx context.Context, gro
 			}
 		}
 		if err := r.scaleDown(ctx, group); err != nil {
+			return err
+		}
+		// Clear any stale Paused=true on children so each SeiNode
+		// resumes reconciling once spec.paused goes false.
+		if err := r.syncPausedToChildren(ctx, group, false); err != nil {
 			return err
 		}
 	} else {
@@ -39,6 +51,33 @@ func (r *SeiNodeDeploymentReconciler) reconcileSeiNodes(ctx context.Context, gro
 	}
 
 	r.detectDeploymentNeeded(group)
+	return nil
+}
+
+// syncPausedToChildren brings every owned child SeiNode's Spec.Paused
+// in line with desired. Children already in sync are left untouched.
+func (r *SeiNodeDeploymentReconciler) syncPausedToChildren(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment, desired bool) error {
+	children, err := r.listChildSeiNodes(ctx, group)
+	if err != nil {
+		return fmt.Errorf("listing child SeiNodes: %w", err)
+	}
+	for i := range children {
+		child := &children[i]
+		if child.Spec.Paused == desired {
+			continue
+		}
+		child.Spec.Paused = desired
+		if err := r.Update(ctx, child); err != nil {
+			return fmt.Errorf("syncing paused=%t to %s: %w", desired, child.Name, err)
+		}
+		action := "ChildPaused"
+		message := fmt.Sprintf("Paused SeiNode %s", child.Name)
+		if !desired {
+			action = "ChildResumed"
+			message = fmt.Sprintf("Resumed SeiNode %s", child.Name)
+		}
+		r.Recorder.Event(group, corev1.EventTypeNormal, action, message)
+	}
 	return nil
 }
 

--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -97,7 +97,7 @@ func (r *SeiNodeDeploymentReconciler) setGenesisCeremonyCondition(group *seiv1al
 		return
 	}
 	setCondition(group, seiv1alpha1.ConditionGenesisCeremonyComplete, metav1.ConditionFalse,
-		"NotStarted", "genesis ceremony has not yet started")
+		ReasonNotStarted, "genesis ceremony has not yet started")
 }
 
 // detectDeploymentNeeded checks if deployment-worthy fields have changed

--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -18,21 +18,10 @@ import (
 
 // reconcileSeiNodes ensures the desired child SeiNodes exist, populates
 // IncumbentNodes, and detects spec changes that require orchestration.
-// Mutations are skipped while a plan is in progress. While paused, the
-// only action taken is propagating the paused state to children.
+// Mutations are skipped while a plan is in progress or while paused.
 func (r *SeiNodeDeploymentReconciler) reconcileSeiNodes(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
 	if group.Spec.Paused {
-		if err := r.syncPausedToChildren(ctx, group, true); err != nil {
-			return err
-		}
 		return r.populateIncumbentNodes(ctx, group)
-	}
-
-	// Spec.Paused propagates to children on every reconcile, including
-	// while a plan is in progress. Children that remain paused stall
-	// await-nodes-running and prevent the plan from advancing.
-	if err := r.syncPausedToChildren(ctx, group, false); err != nil {
-		return err
 	}
 
 	if !hasConditionTrue(group, seiv1alpha1.ConditionPlanInProgress) {

--- a/internal/controller/nodedeployment/nodes_test.go
+++ b/internal/controller/nodedeployment/nodes_test.go
@@ -356,7 +356,7 @@ func TestSetGenesisCeremonyCondition(t *testing.T) {
 			name:       "genesis configured but not started sets False/NotStarted",
 			mutate:     func(g *seiv1alpha1.SeiNodeDeployment) {},
 			wantStatus: metav1.ConditionFalse,
-			wantReason: "NotStarted",
+			wantReason: ReasonNotStarted,
 		},
 		{
 			// Post-failPlan: PlanInProgress=False, no latched Complete.
@@ -367,7 +367,7 @@ func TestSetGenesisCeremonyCondition(t *testing.T) {
 				setCondition(g, seiv1alpha1.ConditionPlanInProgress, metav1.ConditionFalse, "PlanFailed", "previous attempt failed")
 			},
 			wantStatus: metav1.ConditionFalse,
-			wantReason: "NotStarted",
+			wantReason: ReasonNotStarted,
 		},
 	}
 	for _, tc := range cases {

--- a/internal/controller/nodedeployment/plan.go
+++ b/internal/controller/nodedeployment/plan.go
@@ -14,11 +14,15 @@ import (
 	"github.com/sei-protocol/sei-k8s-controller/internal/planner"
 )
 
-// reconcilePlan is the single entry point for plan-driven orchestration.
-// It drives an active plan to completion, or builds a new plan if the
-// planner determines one is needed. All status mutations are in-memory;
-// the caller flushes via a single status patch.
+// reconcilePlan drives an active plan to completion or builds a new
+// plan if the planner determines one is needed. All status mutations
+// are in-memory; the caller flushes via a single status patch.
+// Paused short-circuits entirely; an active plan freezes in place.
 func (r *SeiNodeDeploymentReconciler) reconcilePlan(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) (ctrl.Result, error) {
+	if group.Spec.Paused {
+		return ctrl.Result{}, nil
+	}
+
 	// Drive active plan.
 	if group.Status.Plan != nil && group.Status.Plan.Phase == seiv1alpha1.TaskPlanActive {
 		return r.drivePlan(ctx, group)

--- a/internal/controller/nodedeployment/status.go
+++ b/internal/controller/nodedeployment/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,9 +32,11 @@ func (r *SeiNodeDeploymentReconciler) updateStatus(ctx context.Context, group *s
 		})
 	}
 
-	// Update ObservedGeneration and TemplateHash when no rollout or plan is active.
-	// During rollout/plan execution, these are updated by completePlan.
-	if !hasConditionTrue(group, seiv1alpha1.ConditionPlanInProgress) &&
+	// TemplateHash advances only while the controller is free to act on
+	// template changes. Pause must hold the hash so a deferred edit
+	// converges on unpause; rollout/plan execution defers to completePlan.
+	if !group.Spec.Paused &&
+		!hasConditionTrue(group, seiv1alpha1.ConditionPlanInProgress) &&
 		!hasConditionTrue(group, seiv1alpha1.ConditionRolloutInProgress) {
 		group.Status.ObservedGeneration = group.Generation
 		group.Status.TemplateHash = templateHash(&group.Spec.Template.Spec)
@@ -54,6 +57,9 @@ func (r *SeiNodeDeploymentReconciler) updateStatus(ctx context.Context, group *s
 }
 
 func computeGroupPhase(group *seiv1alpha1.SeiNodeDeployment, ready, desired int32, nodes []seiv1alpha1.SeiNode) seiv1alpha1.SeiNodeDeploymentPhase {
+	if group.Spec.Paused {
+		return seiv1alpha1.GroupPhasePaused
+	}
 	if hasConditionTrue(group, seiv1alpha1.ConditionRolloutInProgress) {
 		return seiv1alpha1.GroupPhaseUpgrading
 	}
@@ -138,17 +144,43 @@ func setNodesReadyCondition(group *seiv1alpha1.SeiNodeDeployment, ready, desired
 	setCondition(group, seiv1alpha1.ConditionNodesReady, status, reason, message)
 }
 
-// seedAlwaysPresentConditions stamps every condition the doctrine
-// requires to be visible on every reconciled SND (see CLAUDE.md
-// `### Conditions`). The seed fires only when the condition is absent,
-// so transition paths (startPlan, completePlan, etc.) own the reason
-// vocabulary once an SND has lifecycle state.
+// seedAlwaysPresentConditions stamps every always-present condition.
+// The InProgress seeds fire only when absent so transition paths
+// (startPlan, completePlan, etc.) own the reason vocabulary once an
+// SND has lifecycle state.
 func (r *SeiNodeDeploymentReconciler) seedAlwaysPresentConditions(group *seiv1alpha1.SeiNodeDeployment) {
 	r.setGenesisCeremonyCondition(group)
+	r.setPausedCondition(group)
 	seedConditionIfAbsent(group, seiv1alpha1.ConditionPlanInProgress,
 		"NotStarted", "no plan has run yet")
 	seedConditionIfAbsent(group, seiv1alpha1.ConditionRolloutInProgress,
 		"NotStarted", "no rollout has run yet")
+}
+
+// setPausedCondition mirrors spec.paused and emits an event on each
+// Paused↔Unpaused transition.
+func (r *SeiNodeDeploymentReconciler) setPausedCondition(group *seiv1alpha1.SeiNodeDeployment) {
+	prev := apimeta.FindStatusCondition(group.Status.Conditions, seiv1alpha1.ConditionPaused)
+	wasPaused := prev != nil && prev.Status == metav1.ConditionTrue
+
+	if group.Spec.Paused {
+		setCondition(group, seiv1alpha1.ConditionPaused, metav1.ConditionTrue,
+			"Paused", "spec.paused is true; plan-driven orchestration is frozen")
+		if !wasPaused && r.Recorder != nil {
+			msg := "operator set spec.paused; controller will not advance plans, rollouts, or template changes until unpaused"
+			if group.Status.Plan != nil {
+				msg = fmt.Sprintf("operator set spec.paused with active plan %s; plan freezes in place until unpaused", group.Status.Plan.ID)
+			}
+			r.Recorder.Event(group, corev1.EventTypeNormal, "Paused", msg)
+		}
+		return
+	}
+	setCondition(group, seiv1alpha1.ConditionPaused, metav1.ConditionFalse,
+		"NotPaused", "spec.paused is unset or false")
+	if wasPaused && r.Recorder != nil {
+		r.Recorder.Event(group, corev1.EventTypeNormal, "Unpaused",
+			"operator cleared spec.paused; controller resumes plan-driven orchestration")
+	}
 }
 
 // seedConditionIfAbsent writes False/<reason>/<message> only when the

--- a/internal/controller/nodedeployment/status.go
+++ b/internal/controller/nodedeployment/status.go
@@ -32,14 +32,18 @@ func (r *SeiNodeDeploymentReconciler) updateStatus(ctx context.Context, group *s
 		})
 	}
 
-	// TemplateHash advances only while the controller is free to act on
-	// template changes. Pause must hold the hash so a deferred edit
-	// converges on unpause; rollout/plan execution defers to completePlan.
-	if !group.Spec.Paused &&
-		!hasConditionTrue(group, seiv1alpha1.ConditionPlanInProgress) &&
+	// ObservedGeneration tracks "controller has processed this spec" and
+	// must advance on every reconcile that runs to completion, including
+	// paused ones — generation-drift consumers (kubectl wait, ArgoCD,
+	// Flux) depend on it. TemplateHash is what defers template edits, so
+	// pause holds only that. Both still defer to completePlan during
+	// rollout/plan execution.
+	if !hasConditionTrue(group, seiv1alpha1.ConditionPlanInProgress) &&
 		!hasConditionTrue(group, seiv1alpha1.ConditionRolloutInProgress) {
 		group.Status.ObservedGeneration = group.Generation
-		group.Status.TemplateHash = templateHash(&group.Spec.Template.Spec)
+		if !group.Spec.Paused {
+			group.Status.TemplateHash = templateHash(&group.Spec.Template.Spec)
+		}
 	}
 	group.Status.Replicas = group.Spec.Replicas
 	group.Status.ReadyReplicas = readyReplicas

--- a/internal/controller/nodedeployment/status.go
+++ b/internal/controller/nodedeployment/status.go
@@ -138,6 +138,28 @@ func setNodesReadyCondition(group *seiv1alpha1.SeiNodeDeployment, ready, desired
 	setCondition(group, seiv1alpha1.ConditionNodesReady, status, reason, message)
 }
 
+// seedAlwaysPresentConditions stamps every condition the doctrine
+// requires to be visible on every reconciled SND (see CLAUDE.md
+// `### Conditions`). The seed fires only when the condition is absent,
+// so transition paths (startPlan, completePlan, etc.) own the reason
+// vocabulary once an SND has lifecycle state.
+func (r *SeiNodeDeploymentReconciler) seedAlwaysPresentConditions(group *seiv1alpha1.SeiNodeDeployment) {
+	r.setGenesisCeremonyCondition(group)
+	seedConditionIfAbsent(group, seiv1alpha1.ConditionPlanInProgress,
+		"NotStarted", "no plan has run yet")
+	seedConditionIfAbsent(group, seiv1alpha1.ConditionRolloutInProgress,
+		"NotStarted", "no rollout has run yet")
+}
+
+// seedConditionIfAbsent writes False/<reason>/<message> only when the
+// condition is absent from the SND.
+func seedConditionIfAbsent(group *seiv1alpha1.SeiNodeDeployment, condType, reason, message string) {
+	if apimeta.FindStatusCondition(group.Status.Conditions, condType) != nil {
+		return
+	}
+	setCondition(group, condType, metav1.ConditionFalse, reason, message)
+}
+
 func hasConditionTrue(group *seiv1alpha1.SeiNodeDeployment, condType string) bool { //nolint:unparam // general-purpose utility
 	c := apimeta.FindStatusCondition(group.Status.Conditions, condType)
 	return c != nil && c.Status == metav1.ConditionTrue

--- a/internal/controller/nodedeployment/status.go
+++ b/internal/controller/nodedeployment/status.go
@@ -166,7 +166,10 @@ func (r *SeiNodeDeploymentReconciler) setPausedCondition(group *seiv1alpha1.SeiN
 	if group.Spec.Paused {
 		setCondition(group, seiv1alpha1.ConditionPaused, metav1.ConditionTrue,
 			"Paused", "spec.paused is true; plan-driven orchestration is frozen")
-		if !wasPaused && r.Recorder != nil {
+		// Emit on the False→True transition only. An SND created
+		// already paused has prev=nil and doesn't need an event — its
+		// condition already tells the story.
+		if r.Recorder != nil && prev != nil && !wasPaused {
 			msg := "operator set spec.paused; controller will not advance plans, rollouts, or template changes until unpaused"
 			if group.Status.Plan != nil {
 				msg = fmt.Sprintf("operator set spec.paused with active plan %s; plan freezes in place until unpaused", group.Status.Plan.ID)

--- a/internal/controller/nodedeployment/status.go
+++ b/internal/controller/nodedeployment/status.go
@@ -148,6 +148,11 @@ func setNodesReadyCondition(group *seiv1alpha1.SeiNodeDeployment, ready, desired
 	setCondition(group, seiv1alpha1.ConditionNodesReady, status, reason, message)
 }
 
+// ReasonNotStarted is the seed reason for always-present lifecycle
+// conditions before any transition has occurred. Shared across
+// PlanInProgress, RolloutInProgress, and GenesisCeremonyComplete.
+const ReasonNotStarted = "NotStarted"
+
 // seedAlwaysPresentConditions stamps every always-present condition.
 // The InProgress seeds fire only when absent so transition paths
 // (startPlan, completePlan, etc.) own the reason vocabulary once an
@@ -156,9 +161,9 @@ func (r *SeiNodeDeploymentReconciler) seedAlwaysPresentConditions(group *seiv1al
 	r.setGenesisCeremonyCondition(group)
 	r.setPausedCondition(group)
 	seedConditionIfAbsent(group, seiv1alpha1.ConditionPlanInProgress,
-		"NotStarted", "no plan has run yet")
+		ReasonNotStarted, "no plan has run yet")
 	seedConditionIfAbsent(group, seiv1alpha1.ConditionRolloutInProgress,
-		"NotStarted", "no rollout has run yet")
+		ReasonNotStarted, "no rollout has run yet")
 }
 
 // setPausedCondition mirrors spec.paused and emits an event on each

--- a/internal/controller/nodedeployment/status_test.go
+++ b/internal/controller/nodedeployment/status_test.go
@@ -257,14 +257,14 @@ func TestSeedAlwaysPresentConditions(t *testing.T) {
 			mutate:     func(g *seiv1alpha1.SeiNodeDeployment) {},
 			condType:   seiv1alpha1.ConditionPlanInProgress,
 			wantStatus: metav1.ConditionFalse,
-			wantReason: "NotStarted",
+			wantReason: ReasonNotStarted,
 		},
 		{
 			name:       "RolloutInProgress seeds False/NotStarted on a fresh SND",
 			mutate:     func(g *seiv1alpha1.SeiNodeDeployment) {},
 			condType:   seiv1alpha1.ConditionRolloutInProgress,
 			wantStatus: metav1.ConditionFalse,
-			wantReason: "NotStarted",
+			wantReason: ReasonNotStarted,
 		},
 		{
 			// The seed runs before transition paths in the same

--- a/internal/controller/nodedeployment/status_test.go
+++ b/internal/controller/nodedeployment/status_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
@@ -186,4 +188,76 @@ func TestBuildNetworkingStatus_ProtocolValues(t *testing.T) {
 		protocols[i] = rs.Protocol
 	}
 	g.Expect(protocols).To(ConsistOf("evm", "rpc", "rest", "grpc"))
+}
+
+func TestSeedAlwaysPresentConditions(t *testing.T) {
+	cases := []struct {
+		name       string
+		mutate     func(*seiv1alpha1.SeiNodeDeployment)
+		condType   string
+		wantStatus metav1.ConditionStatus
+		wantReason string
+	}{
+		{
+			name:       "PlanInProgress seeds False/NotStarted on a fresh SND",
+			mutate:     func(g *seiv1alpha1.SeiNodeDeployment) {},
+			condType:   seiv1alpha1.ConditionPlanInProgress,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NotStarted",
+		},
+		{
+			name:       "RolloutInProgress seeds False/NotStarted on a fresh SND",
+			mutate:     func(g *seiv1alpha1.SeiNodeDeployment) {},
+			condType:   seiv1alpha1.ConditionRolloutInProgress,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NotStarted",
+		},
+		{
+			// The seed runs before transition paths in the same
+			// reconcile, so a True write from startPlan must not be
+			// re-seeded on the next pass.
+			name: "PlanInProgress=True is preserved",
+			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
+				setCondition(g, seiv1alpha1.ConditionPlanInProgress, metav1.ConditionTrue, "PlanStarted", "")
+			},
+			condType:   seiv1alpha1.ConditionPlanInProgress,
+			wantStatus: metav1.ConditionTrue,
+			wantReason: "PlanStarted",
+		},
+		{
+			// The seed only fires on absence, so the transition reason
+			// from completePlan (False/PlanComplete) stays put.
+			name: "PlanInProgress=False/PlanComplete is preserved",
+			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
+				setCondition(g, seiv1alpha1.ConditionPlanInProgress, metav1.ConditionFalse, "PlanComplete", "")
+			},
+			condType:   seiv1alpha1.ConditionPlanInProgress,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "PlanComplete",
+		},
+		{
+			name: "RolloutInProgress=False/RolloutComplete is preserved",
+			mutate: func(g *seiv1alpha1.SeiNodeDeployment) {
+				setCondition(g, seiv1alpha1.ConditionRolloutInProgress, metav1.ConditionFalse, "RolloutComplete", "")
+			},
+			condType:   seiv1alpha1.ConditionRolloutInProgress,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "RolloutComplete",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			group := newTestGroup("archive-rpc", "sei")
+			tc.mutate(group)
+
+			r := &SeiNodeDeploymentReconciler{Recorder: record.NewFakeRecorder(10)}
+			r.seedAlwaysPresentConditions(group)
+
+			cond := apimeta.FindStatusCondition(group.Status.Conditions, tc.condType)
+			g.Expect(cond).NotTo(BeNil(), "%s must be present after seeding", tc.condType)
+			g.Expect(cond.Status).To(Equal(tc.wantStatus))
+			g.Expect(cond.Reason).To(Equal(tc.wantReason))
+		})
+	}
 }

--- a/internal/controller/nodedeployment/status_test.go
+++ b/internal/controller/nodedeployment/status_test.go
@@ -190,6 +190,60 @@ func TestBuildNetworkingStatus_ProtocolValues(t *testing.T) {
 	g.Expect(protocols).To(ConsistOf("evm", "rpc", "rest", "grpc"))
 }
 
+func TestSetPausedCondition(t *testing.T) {
+	cases := []struct {
+		name       string
+		paused     bool
+		seedExist  *metav1.Condition
+		wantStatus metav1.ConditionStatus
+		wantReason string
+	}{
+		{
+			name:       "spec.paused=true writes True/Paused",
+			paused:     true,
+			wantStatus: metav1.ConditionTrue,
+			wantReason: "Paused",
+		},
+		{
+			name:       "spec.paused=false writes False/NotPaused",
+			paused:     false,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NotPaused",
+		},
+		{
+			// setPausedCondition is fully derived from spec — a stale
+			// True flips back to False once spec.paused clears.
+			name:   "stale True flips to False when spec clears",
+			paused: false,
+			seedExist: &metav1.Condition{
+				Type:   seiv1alpha1.ConditionPaused,
+				Status: metav1.ConditionTrue,
+				Reason: "Paused",
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NotPaused",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			group := newTestGroup("archive-rpc", "sei")
+			group.Spec.Paused = tc.paused
+			if tc.seedExist != nil {
+				group.Status.Conditions = append(group.Status.Conditions, *tc.seedExist)
+			}
+
+			r := &SeiNodeDeploymentReconciler{Recorder: record.NewFakeRecorder(10)}
+			r.setPausedCondition(group)
+
+			cond := apimeta.FindStatusCondition(group.Status.Conditions, seiv1alpha1.ConditionPaused)
+			g.Expect(cond).NotTo(BeNil(), "ConditionPaused must be present after setPausedCondition")
+			g.Expect(cond.Status).To(Equal(tc.wantStatus))
+			g.Expect(cond.Reason).To(Equal(tc.wantReason))
+		})
+	}
+}
+
 func TestSeedAlwaysPresentConditions(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/manifests/sei.io_seinodedeployments.yaml
+++ b/manifests/sei.io_seinodedeployments.yaml
@@ -28,7 +28,6 @@ spec:
       type: string
     - jsonPath: .spec.paused
       name: Paused
-      priority: 1
       type: boolean
     - jsonPath: .status.rollout.targetHash
       name: Target
@@ -144,12 +143,10 @@ spec:
                 type: object
               paused:
                 description: |-
-                  Paused freezes plan-driven orchestration on this SeiNodeDeployment.
-                  While true, the controller does not build new plans, does not start
-                  new rollouts, and does not propagate spec.template changes to child
-                  SeiNodes. In-flight plans drain to their natural conclusion.
-                  Networking and Service reconciliation continue normally so existing
-                  traffic is not disrupted. Operators clear the field to resume.
+                  Paused freezes plan-driven orchestration. While true, no new plans
+                  start, no rollouts trigger, no template changes propagate to
+                  children, and any active plan freezes in place. Networking and
+                  Service reconciliation continue. Children inherit the paused state.
                 type: boolean
               replicas:
                 default: 1
@@ -351,13 +348,10 @@ spec:
                         type: object
                       paused:
                         description: |-
-                          Paused freezes reconciliation on this SeiNode. While true, the
-                          controller does not advance the lifecycle, does not start new plans,
-                          and does not mutate derived resources (StatefulSet, Services, PVCs).
-                          In-flight tasks already running on the cluster (e.g., sidecar Jobs)
-                          run to their natural conclusion but the controller does not poll or
-                          transition state machines based on their results. Operators clear
-                          the field to resume.
+                          Paused freezes reconciliation. While true, the controller does not
+                          advance the lifecycle, start plans, or mutate derived resources.
+                          In-flight tasks on the cluster run to completion but their results
+                          are not polled until the field is cleared.
                         type: boolean
                       peers:
                         description: |-

--- a/manifests/sei.io_seinodedeployments.yaml
+++ b/manifests/sei.io_seinodedeployments.yaml
@@ -26,6 +26,10 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .spec.paused
+      name: Paused
+      priority: 1
+      type: boolean
     - jsonPath: .status.rollout.targetHash
       name: Target
       priority: 1
@@ -138,6 +142,15 @@ spec:
                   HTTPRoutes on the platform Gateway. When absent, the deployment
                   is private with only per-node headless Services.
                 type: object
+              paused:
+                description: |-
+                  Paused freezes plan-driven orchestration on this SeiNodeDeployment.
+                  While true, the controller does not build new plans, does not start
+                  new rollouts, and does not propagate spec.template changes to child
+                  SeiNodes. In-flight plans drain to their natural conclusion.
+                  Networking and Service reconciliation continue normally so existing
+                  traffic is not disrupted. Operators clear the field to resume.
+                type: boolean
               replicas:
                 default: 1
                 description: Replicas is the number of SeiNode instances to create.
@@ -336,6 +349,16 @@ spec:
                           Keys use the sei-config unified schema (e.g. "evm.http_port", "storage.pruning").
                           These are applied on top of mode defaults during config-apply.
                         type: object
+                      paused:
+                        description: |-
+                          Paused freezes reconciliation on this SeiNode. While true, the
+                          controller does not advance the lifecycle, does not start new plans,
+                          and does not mutate derived resources (StatefulSet, Services, PVCs).
+                          In-flight tasks already running on the cluster (e.g., sidecar Jobs)
+                          run to their natural conclusion but the controller does not poll or
+                          transition state machines based on their results. Operators clear
+                          the field to resume.
+                        type: boolean
                       peers:
                         description: |-
                           Peers configures how this node discovers and connects to network peers.
@@ -1137,6 +1160,7 @@ spec:
                 - Initializing
                 - Ready
                 - Upgrading
+                - Paused
                 - Degraded
                 - Failed
                 - Terminating

--- a/manifests/sei.io_seinodes.yaml
+++ b/manifests/sei.io_seinodes.yaml
@@ -217,13 +217,10 @@ spec:
                 type: object
               paused:
                 description: |-
-                  Paused freezes reconciliation on this SeiNode. While true, the
-                  controller does not advance the lifecycle, does not start new plans,
-                  and does not mutate derived resources (StatefulSet, Services, PVCs).
-                  In-flight tasks already running on the cluster (e.g., sidecar Jobs)
-                  run to their natural conclusion but the controller does not poll or
-                  transition state machines based on their results. Operators clear
-                  the field to resume.
+                  Paused freezes reconciliation. While true, the controller does not
+                  advance the lifecycle, start plans, or mutate derived resources.
+                  In-flight tasks on the cluster run to completion but their results
+                  are not polled until the field is cleared.
                 type: boolean
               peers:
                 description: |-

--- a/manifests/sei.io_seinodes.yaml
+++ b/manifests/sei.io_seinodes.yaml
@@ -215,6 +215,16 @@ spec:
                   Keys use the sei-config unified schema (e.g. "evm.http_port", "storage.pruning").
                   These are applied on top of mode defaults during config-apply.
                 type: object
+              paused:
+                description: |-
+                  Paused freezes reconciliation on this SeiNode. While true, the
+                  controller does not advance the lifecycle, does not start new plans,
+                  and does not mutate derived resources (StatefulSet, Services, PVCs).
+                  In-flight tasks already running on the cluster (e.g., sidecar Jobs)
+                  run to their natural conclusion but the controller does not poll or
+                  transition state machines based on their results. Operators clear
+                  the field to resume.
+                type: boolean
               peers:
                 description: |-
                   Peers configures how this node discovers and connects to network peers.


### PR DESCRIPTION
## Summary

Recovers the seeding (#338) + Spec.Paused (#342) work that was phantom-merged. Both PRs were marked merged on GitHub but their content went sideways into stacked base branches instead of `main` after #333 squash-merged. This PR is the rebase of `feat/snd-pause` onto current main.

## Phantom-merge timeline

```
17:51 UTC  #333 merged → main (squash commit e442ac3)             ✅ landed
18:14 UTC  #338 merged → refactor/genesis-ceremony-condition       ⚠️  sideways
19:17 UTC  #342 merged → refactor/inprogress-seeding               ⚠️  sideways
```

When #333 squash-merged at 17:51, its source branch (`refactor/genesis-ceremony-condition`) stayed alive and remained the base for the stacked PRs. Clicking Merge on #338 and #342 merged them into those stacked bases, not into main. The commits are intact on the remote (`refactor/inprogress-seeding`, `feat/snd-pause`, `origin/pr/338`, `origin/pr/342`) but never reached main.

## What's in this PR

Four commits cherry-picked from `feat/snd-pause` onto current main:

1. **`refactor(snd): seed PlanInProgress and RolloutInProgress on every reconcile`** — was #338. Finishes the SND-side conditions harmonization by seeding the InProgress conditions with False/NotStarted on first reconcile.
2. **`feat(snd): SND.Spec.Paused + SeiNode.Spec.Paused with transitive propagation`** — was #342. Operator-set pause on both objects; SND propagates Paused to children.
3. **`fixup(pause): propagate unpause to children regardless of plan state`** — Coral cross-review caught a deadlock where unpause-mid-plan left children frozen. Hoisted `syncPausedToChildren(false)` out of the plan-in-progress gate.
4. **`fixup(pause): address three Cursor findings`** — DNS-pending propagation gap, ObservedGeneration freeze gap, SeiNode Failed early-return gap.

## Review provenance

All four commits were reviewed and signed off in their original PRs:

- **#338** — Coral k8s + SRE pass, sign-off
- **#342** — Coral k8s + Platform pass, sign-off; one blocker (unpause deadlock) fixed in commit 3 above
- **Cursor Bugbot** — three medium/low findings on #342, fixed in commit 4

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all unit tests pass (`TestSeedAlwaysPresentConditions`, `TestSetPausedCondition`)
- [x] `make test-integration` — envtest passes (55.0s)
  - `TestSND_AlwaysPresentConditionsSeededOnFirstReconcile`
  - `TestSND_Paused_PropagatesAndBlocksOrchestration`
  - `TestSeiNode_Paused_FreezesReconcile`
  - `TestSND_Unpause_DuringActivePlan_PropagatesToChildren`

Cherry-picks applied cleanly with no conflicts — main has all of #333's content via squash, so the seeding + pause commits land on top with no merge friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)