### PR TITLE
feat(nodedeployment): stamp sei.io/chain on every child SeiNode

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -30,16 +30,14 @@ type PeerSource struct {
 // headless Service DNS names ({name}-0.{name}.{namespace}.svc.cluster.local)
 // and writes them to status.resolvedPeers on every reconcile.
 //
-// Controller-managed labels available on every SeiNode owned by an SND
-// (use these in Selector for reliable cross-SND peer discovery):
-//   - sei.io/chain  — derived from SND .spec.template.spec.chainId
-//   - sei.io/nodedeployment — the owning SND's metadata.name
-//   - sei.io/nodedeployment-ordinal — string-encoded replica index
-//   - sei.io/revision — string-encoded SND generation
+// Controller-managed labels available on every SeiNode owned by an SND:
+//   - sei.io/chain — from .spec.template.spec.chainId
+//   - sei.io/nodedeployment — owning SND name
+//   - sei.io/nodedeployment-ordinal — replica index
+//   - sei.io/revision — SND generation
 //
-// User-set keys on SND .spec.template.metadata.labels are merged in,
-// but the four reserved keys above are always controller-stamped from
-// authoritative spec — user attempts to override them are ignored.
+// User-set keys on .spec.template.metadata.labels merge in; the four
+// reserved keys above are always controller-stamped.
 type LabelPeerSource struct {
 	// Selector is a set of key-value label pairs. SeiNode resources
 	// matching ALL labels are included as peers.

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -29,6 +29,17 @@ type PeerSource struct {
 // Kubernetes labels. The controller resolves matching nodes to their
 // headless Service DNS names ({name}-0.{name}.{namespace}.svc.cluster.local)
 // and writes them to status.resolvedPeers on every reconcile.
+//
+// Controller-managed labels available on every SeiNode owned by an SND
+// (use these in Selector for reliable cross-SND peer discovery):
+//   - sei.io/chain  — derived from SND .spec.template.spec.chainId
+//   - sei.io/nodedeployment — the owning SND's metadata.name
+//   - sei.io/nodedeployment-ordinal — string-encoded replica index
+//   - sei.io/revision — string-encoded SND generation
+//
+// User-set keys on SND .spec.template.metadata.labels are merged in,
+// but the four reserved keys above are always controller-stamped from
+// authoritative spec — user attempts to override them are ignored.
 type LabelPeerSource struct {
 	// Selector is a set of key-value label pairs. SeiNode resources
 	// matching ALL labels are included as peers.

--- a/internal/controller/nodedeployment/envtest/inplace_rollout_test.go
+++ b/internal/controller/nodedeployment/envtest/inplace_rollout_test.go
@@ -83,9 +83,17 @@ func TestInPlaceRollout_EndToEnd(t *testing.T) {
 			if refs[0].Controller == nil || !*refs[0].Controller {
 				return false
 			}
+			// sei.io/chain stamped by the controller from
+			// spec.template.spec.chainId. LabelPeerSource consumers
+			// rely on this to discover peers across SNDs of the same
+			// chain — peer discovery silently breaks without it.
+			if got := kids[i].GetLabels()["sei.io/chain"]; got != "pacific-1" {
+				t.Logf("child %s missing sei.io/chain label (got %q)", kids[i].GetName(), got)
+				return false
+			}
 		}
 		return true
-	}, "3 child SeiNodes owned by the SND")
+	}, "3 child SeiNodes owned by the SND with sei.io/chain stamped")
 
 	// 2. Status converges: templateHash populated, replicas reported,
 	//    no rollout in flight on the steady-state spec.

--- a/internal/controller/nodedeployment/envtest/inplace_rollout_test.go
+++ b/internal/controller/nodedeployment/envtest/inplace_rollout_test.go
@@ -3,6 +3,7 @@
 package envtest_test
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -83,12 +84,24 @@ func TestInPlaceRollout_EndToEnd(t *testing.T) {
 			if refs[0].Controller == nil || !*refs[0].Controller {
 				return false
 			}
-			// sei.io/chain stamped by the controller from
-			// spec.template.spec.chainId. LabelPeerSource consumers
-			// rely on this to discover peers across SNDs of the same
-			// chain — peer discovery silently breaks without it.
-			if got := kids[i].GetLabels()["sei.io/chain"]; got != "pacific-1" {
-				t.Logf("child %s missing sei.io/chain label (got %q)", kids[i].GetName(), got)
+			want := map[string]string{
+				"sei.io/nodedeployment":         "rollout-test",
+				"sei.io/nodedeployment-ordinal": strconv.Itoa(i),
+				"sei.io/chain":                  "pacific-1",
+			}
+			labels := kids[i].GetLabels()
+			ok := true
+			for k, v := range want {
+				if labels[k] != v {
+					t.Logf("child %s: label %s = %q, want %q", kids[i].GetName(), k, labels[k], v)
+					ok = false
+				}
+			}
+			if labels["sei.io/revision"] == "" {
+				t.Logf("child %s: sei.io/revision empty", kids[i].GetName())
+				ok = false
+			}
+			if !ok {
 				return false
 			}
 		}

--- a/internal/controller/nodedeployment/labels.go
+++ b/internal/controller/nodedeployment/labels.go
@@ -14,11 +14,6 @@ const (
 	groupLabel          = "sei.io/nodedeployment"
 	groupOrdinalLabel   = "sei.io/nodedeployment-ordinal"
 	revisionLabel       = "sei.io/revision"
-	// chainLabel is stamped on every SeiNode the controller owns,
-	// derived from the SND's authoritative chainId (genesis ceremony
-	// resolution included). LabelPeerSource consumers rely on this
-	// being controller-managed so peer discovery works without scenarios
-	// having to mirror the value into template.metadata.labels.
 	chainLabel          = "sei.io/chain"
 	managedByAnnotation = "sei.io/managed-by"
 )

--- a/internal/controller/nodedeployment/labels.go
+++ b/internal/controller/nodedeployment/labels.go
@@ -14,6 +14,12 @@ const (
 	groupLabel          = "sei.io/nodedeployment"
 	groupOrdinalLabel   = "sei.io/nodedeployment-ordinal"
 	revisionLabel       = "sei.io/revision"
+	// chainLabel is stamped on every SeiNode the controller owns,
+	// derived from the SND's authoritative chainId (genesis ceremony
+	// resolution included). LabelPeerSource consumers rely on this
+	// being controller-managed so peer discovery works without scenarios
+	// having to mirror the value into template.metadata.labels.
+	chainLabel          = "sei.io/chain"
 	managedByAnnotation = "sei.io/managed-by"
 )
 
@@ -52,6 +58,7 @@ func seiNodeLabels(group *seiv1alpha1.SeiNodeDeployment, ordinal int) map[string
 	labels[groupLabel] = group.Name
 	labels[groupOrdinalLabel] = strconv.Itoa(ordinal)
 	labels[revisionLabel] = activeRevision(group)
+	labels[chainLabel] = group.Spec.Template.Spec.ChainID
 	return labels
 }
 

--- a/internal/controller/nodedeployment/nodes_test.go
+++ b/internal/controller/nodedeployment/nodes_test.go
@@ -49,38 +49,13 @@ func TestGenerateSeiNode_NameAndNamespace(t *testing.T) {
 func TestGenerateSeiNode_SystemLabels(t *testing.T) {
 	g := NewWithT(t)
 	group := newTestGroup("archive-rpc", "sei")
+	group.Generation = 7
 
 	node := generateSeiNode(group, 1)
 
 	g.Expect(node.Labels).To(HaveKeyWithValue(groupLabel, "archive-rpc"))
 	g.Expect(node.Labels).To(HaveKeyWithValue(groupOrdinalLabel, "1"))
-}
-
-// TestGenerateSeiNode_StampsChainLabel guards the contract surfaced by
-// the load-test fire: LabelPeerSource consumers select on sei.io/chain
-// to discover peers across SNDs of the same chain. The label must be
-// derived from SND.spec.template.spec.chainId (authoritative) so
-// scenario YAMLs don't have to mirror the value manually.
-func TestGenerateSeiNode_StampsChainLabel(t *testing.T) {
-	g := NewWithT(t)
-	group := newTestGroup("archive-rpc", "sei")
-
-	node := generateSeiNode(group, 0)
-
-	g.Expect(node.Labels).To(HaveKeyWithValue(chainLabel, group.Spec.Template.Spec.ChainID))
-}
-
-func TestGenerateSeiNode_ChainLabelOverridesUserAttempt(t *testing.T) {
-	g := NewWithT(t)
-	group := newTestGroup("archive-rpc", "sei")
-	group.Spec.Template.Metadata = &seiv1alpha1.SeiNodeTemplateMeta{
-		Labels: map[string]string{
-			chainLabel: "user-spoofed-chain",
-		},
-	}
-
-	node := generateSeiNode(group, 0)
-
+	g.Expect(node.Labels).To(HaveKeyWithValue(revisionLabel, "7"))
 	g.Expect(node.Labels).To(HaveKeyWithValue(chainLabel, group.Spec.Template.Spec.ChainID))
 }
 
@@ -104,14 +79,22 @@ func TestGenerateSeiNode_UserLabelsAreMerged(t *testing.T) {
 func TestGenerateSeiNode_SystemLabelsOverrideUser(t *testing.T) {
 	g := NewWithT(t)
 	group := newTestGroup("archive-rpc", "sei")
+	group.Generation = 3
 	group.Spec.Template.Metadata = &seiv1alpha1.SeiNodeTemplateMeta{
 		Labels: map[string]string{
-			groupLabel: "should-be-overridden",
+			groupLabel:        "user-spoof-group",
+			groupOrdinalLabel: "99",
+			revisionLabel:     "user-spoof-revision",
+			chainLabel:        "user-spoof-chain",
 		},
 	}
 
 	node := generateSeiNode(group, 0)
+
 	g.Expect(node.Labels).To(HaveKeyWithValue(groupLabel, "archive-rpc"))
+	g.Expect(node.Labels).To(HaveKeyWithValue(groupOrdinalLabel, "0"))
+	g.Expect(node.Labels).To(HaveKeyWithValue(revisionLabel, "3"))
+	g.Expect(node.Labels).To(HaveKeyWithValue(chainLabel, group.Spec.Template.Spec.ChainID))
 }
 
 func TestGenerateSeiNode_InjectsPodLabels(t *testing.T) {

--- a/internal/controller/nodedeployment/nodes_test.go
+++ b/internal/controller/nodedeployment/nodes_test.go
@@ -56,6 +56,34 @@ func TestGenerateSeiNode_SystemLabels(t *testing.T) {
 	g.Expect(node.Labels).To(HaveKeyWithValue(groupOrdinalLabel, "1"))
 }
 
+// TestGenerateSeiNode_StampsChainLabel guards the contract surfaced by
+// the load-test fire: LabelPeerSource consumers select on sei.io/chain
+// to discover peers across SNDs of the same chain. The label must be
+// derived from SND.spec.template.spec.chainId (authoritative) so
+// scenario YAMLs don't have to mirror the value manually.
+func TestGenerateSeiNode_StampsChainLabel(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("archive-rpc", "sei")
+
+	node := generateSeiNode(group, 0)
+
+	g.Expect(node.Labels).To(HaveKeyWithValue(chainLabel, group.Spec.Template.Spec.ChainID))
+}
+
+func TestGenerateSeiNode_ChainLabelOverridesUserAttempt(t *testing.T) {
+	g := NewWithT(t)
+	group := newTestGroup("archive-rpc", "sei")
+	group.Spec.Template.Metadata = &seiv1alpha1.SeiNodeTemplateMeta{
+		Labels: map[string]string{
+			chainLabel: "user-spoofed-chain",
+		},
+	}
+
+	node := generateSeiNode(group, 0)
+
+	g.Expect(node.Labels).To(HaveKeyWithValue(chainLabel, group.Spec.Template.Spec.ChainID))
+}
+
 func TestGenerateSeiNode_UserLabelsAreMerged(t *testing.T) {
 	g := NewWithT(t)
 	group := newTestGroup("archive-rpc", "sei")


### PR DESCRIPTION
## Summary

Foundation bug surfaced by today's load-test fire: the RPC fleet's \`LabelPeerSource{sei.io/chain: <id>}\` selector found zero matching SeiNodes because the SND controller's \`seiNodeLabels\` never stamped the chain label. seictl works around this with client-side stamping at \`nodedeployment/preset.go:89\`; scenarios that author SND templates without remembering that workaround silently lose peer discovery.

**Make the label controller-managed instead.** The chain id is already authoritative on \`SND.spec.template.spec.chainId\` (CRD MinLength=1 — always non-empty at admission). The SND controller derives the label from that spec field on every SeiNode it owns. Invariant by construction; no client tool can forget.

## Why this is the right K8s pattern

Derived-from-owner labels stamped on owned children in a reserved namespace is the upstream pattern:
- Deployment stamps \`pod-template-hash\` on managed ReplicaSets
- StatefulSet stamps \`statefulset.kubernetes.io/pod-name\`
- Job stamps \`batch.kubernetes.io/controller-uid\` and \`job-name\`
- Now SND stamps \`sei.io/chain\` on owned SeiNodes

The chain id is a derived fact about every SeiNode in the SND, not a knob clients tune.

## Scope

Per kubernetes-specialist cross-review (see PR thread):

- **\`seiNodeLabels\`**: stamp \`sei.io/chain\` from \`group.Spec.Template.Spec.ChainID\` after existing user-label merge. System-owned, overwrites user value.
- **\`common_types.go\`**: document the LabelPeerSource controller-managed label contract — \`sei.io/chain\`, \`sei.io/nodedeployment\`, \`sei.io/nodedeployment-ordinal\`, \`sei.io/revision\`. Selector consumers can rely on these keys being present.
- **Unit tests** (\`nodes_test.go\`): chain label stamped from spec; user override ignored.
- **Envtest** (\`inplace_rollout_test.go\`): existing \`TestInPlaceRollout_EndToEnd\` now asserts child SeiNodes carry \`sei.io/chain\`. Would have caught this before first cluster fire.

## Deferred (separate follow-ups)

- **\`sei.io/role\`** controller-management — only metric consumers today, not load-bearing for peer discovery. K8s-specialist flagged it as "more controversial" (consumer enum stability) — defer until peer-discovery-by-role becomes a real use case.
- **Scenario template cleanup** — \`scenarios/release-test/{validator,rpc}.yaml.tmpl\` had no explicit \`sei.io/chain\` stamping (which is exactly the bug); nothing to remove. Future scenarios authored against the post-merge controller can rely on the contract.
- **seictl client-side stamping** — \`nodedeployment/preset.go:89-95\` becomes redundant once the controller stamps the label. Drop in a follow-up.
- **Constants export from \`internal/noderesource\`** — keeping \`chainLabel\` unexported in \`internal/controller/nodedeployment/labels.go\` for now (kubernetes-specialist's "would-cut-first" recommendation).

## Test plan

- [x] \`go test ./internal/controller/nodedeployment/...\` passes
- [x] \`go build ./...\` clean
- [x] CI envtest fires \`TestInPlaceRollout_EndToEnd\` against the real apiserver; new label assertion must pass
- [x] Post-merge + image build + Flux reconcile + manual release-test fire — RPC SND reaches Ready (peer discovery now works against the chain-labeled validators)

🤖 Generated with [Claude Code](https://claude.com/claude-code)