### PR TITLE
chore(config): bump manager image to 8701d65 (post-#348)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:7caf9ba01f7a492ffdb567fd70871e7f1cd202f3
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8701d65737d33ddb3859ce6821d64c3b8abeb10a
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
## Summary

Rolls forward the controller image pin from `7caf9ba` → `8701d65` so platform clusters (which import `config/default` at `?ref=main`) pick up:

- **#345** — SeiNode StatefulSet refactor: typed SSA sync, `Status.StatefulSet` tracking, pause-scales-to-zero
- **#348** — impostor-clear fix: `SyncStatefulSet` clears `Status.StatefulSet` when deleting an impostor, preventing the cross-reconcile churn loop Cursor caught

## Rollout

Once merged, platform repo's next reconcile picks up the new tag automatically via `github.com/sei-protocol/sei-k8s-controller/config/default?ref=main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)