### PR TITLE
fix(scenarios/major-upgrade): downward-API env on runner Tasks + tolerate space in gov REST status

### DIFF
--- a/scenarios/major-upgrade.yaml
+++ b/scenarios/major-upgrade.yaml
@@ -156,6 +156,15 @@ spec:
             - --var=FEES=10000usei
             - --var=GAS=500000
             - --timeout=8m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -232,6 +241,15 @@ spec:
             - --var=FEES=10000usei
             - --var=GAS=200000
             - --timeout=5m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -253,6 +271,15 @@ spec:
             - --var=FEES=10000usei
             - --var=GAS=200000
             - --timeout=5m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -274,6 +301,15 @@ spec:
             - --var=FEES=10000usei
             - --var=GAS=200000
             - --timeout=5m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -295,6 +331,15 @@ spec:
             - --var=FEES=10000usei
             - --var=GAS=200000
             - --timeout=5m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -341,6 +386,15 @@ spec:
             - --var=IMAGE=$SEI_POST_UPGRADE_IMG
             - --var=REQUIRE_PHASE=Running
             - --timeout=8m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -382,6 +436,15 @@ spec:
             - --var=IMAGE=$SEI_POST_UPGRADE_IMG
             - --var=REQUIRE_PHASE=Running
             - --timeout=8m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -400,6 +463,15 @@ spec:
             - --var=IMAGE=$SEI_POST_UPGRADE_IMG
             - --var=REQUIRE_PHASE=Running
             - --timeout=8m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -418,6 +490,15 @@ spec:
             - --var=IMAGE=$SEI_POST_UPGRADE_IMG
             - --var=REQUIRE_PHASE=Running
             - --timeout=8m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -445,6 +526,15 @@ spec:
             - --var=NODE=$SEI_CHAIN_ID-1
             - --var=TARGET_HEIGHT=$(POST_UPGRADE_HEIGHT)
             - --timeout=6m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -462,6 +552,15 @@ spec:
             - --var=NODE=$SEI_CHAIN_ID-2
             - --var=TARGET_HEIGHT=$(POST_UPGRADE_HEIGHT)
             - --timeout=6m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID
@@ -479,6 +578,15 @@ spec:
             - --var=NODE=$SEI_CHAIN_ID-3
             - --var=TARGET_HEIGHT=$(POST_UPGRADE_HEIGHT)
             - --timeout=6m
+          env:
+            - name: SEI_WORKFLOW_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['chaos-mesh.org/workflow']
+            - name: SEI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - configMapRef:
                 name: workflow-vars-major-upgrade-$SEI_WORKFLOW_RUN_ID


### PR DESCRIPTION
## Summary

Two scenario fixes discovered on the first successful end-to-end major-upgrade fire.

### 1. Missing downward-API env on runner Task containers

`#350` made `taskruntime.LoadWorkflowIdentity` mandatory at runner startup (reads `SEI_WORKFLOW_NAME` + `SEI_NAMESPACE` from env via downward API). The 12 `runner` Task containers in `scenarios/major-upgrade.yaml` never had the env block; every runner step exited code 2 with `seitask: infra: downward-API env not projected`.

Added the standard env block to all 12 containers (matching keygen/provision-snd/upload-report).

### 2. Gov REST response has space after colon

`wait-for-proposal-to-pass` extracts the proposal status with:
```bash
sed -n 's/.*"status":"\([A-Z_]*\)".*/\1/p'
```

The API returns `"status": "PROPOSAL_STATUS_PASSED"` (space after colon). The regex required no space, so `STATUS` was always empty and all 300 polling attempts returned "unknown" — even though the proposal had already passed on-chain (verified by live curl post-mortem).

Changed to `[[:space:]]*` to tolerate any whitespace.

## Test plan

- [ ] Bump `SCENARIO_REF` + `SEITASK_IMAGE` to this commit's SHA after ECR builds
- [ ] Re-fire major-upgrade; confirm `wait-for-proposal-to-pass` resolves `PROPOSAL_STATUS_PASSED` and the full upgrade sequence completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)