### PR TITLE
fix(scenarios/major-upgrade): tolerate space after colon in gov REST status

### DIFF
--- a/scenarios/major-upgrade.yaml
+++ b/scenarios/major-upgrade.yaml
@@ -358,7 +358,7 @@ spec:
               set -eu
               for i in $(seq 1 300); do
                 STATUS=$(curl -fsS "${VALIDATOR_REST}/cosmos/gov/v1beta1/proposals/${PROPOSAL_ID}" \
-                          | sed -n 's/.*"status":"\([A-Z_]*\)".*/\1/p' | head -1)
+                          | sed -n 's/.*"status":[[:space:]]*"\([A-Z_]*\)".*/\1/p' | head -1)
                 echo "attempt=${i} proposal=${PROPOSAL_ID} status=${STATUS:-unknown}"
                 [ "${STATUS}" = "PROPOSAL_STATUS_PASSED" ] && exit 0
                 sleep 1


### PR DESCRIPTION
## Summary

`wait-for-proposal-to-pass` polls the gov v1beta1 REST endpoint and extracts the proposal status with sed:

```bash
sed -n 's/.*"status":"\([A-Z_]*\)".*/\1/p'
```

The API returns pretty-printed JSON with a **space after the colon**:
```
"status": "PROPOSAL_STATUS_PASSED"
```

The regex matched the no-space form only, so `STATUS` was always empty and all 300 polling attempts returned "unknown" — even though the proposal had passed on-chain.

**Validated live on harbor** against the running chain:
- Old regex: empty (no match)
- New regex: `PROPOSAL_STATUS_PASSED` ✓

One-character fix: `[[:space:]]*` between the colon and the opening quote.

## Test plan

- [x] Merge + ECR build → bump SCENARIO_REF + SEITASK_IMAGE on platform side
- [x] Re-fire major-upgrade; confirm `wait-for-proposal-to-pass` resolves to `PROPOSAL_STATUS_PASSED` and the full upgrade sequence completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)