### PR TITLE
chore: bump default controller image to 8b3f1749067b

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           - --metrics-bind-address=:8080
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8701d65737d33ddb3859ce6821d64c3b8abeb10a
+        image: 189176372795.dkr.ecr.us-east-2.amazonaws.com/sei/sei-k8s-controller:8b3f1749067bd07140fccd6d05da7894754688ca
         name: manager
         env:
           - name: SEI_NODEPOOL_NAME


### PR DESCRIPTION
Picks up the sei-config v0.0.16 dependency from #353 (atlantic-2 genesis fix).

```diff
-image: ...sei-k8s-controller:8701d65737d33ddb3859ce6821d64c3b8abeb10a
+image: ...sei-k8s-controller:8b3f1749067bd07140fccd6d05da7894754688ca
```

The platform repo's prod and dev cluster overlays inherit this manifest via `?ref=main`, so updating the image tag here is what flows the new controller image to those clusters. Harbor pins separately and is being bumped in a sibling platform PR.

Refs: #353 / sei-protocol/sei-config#21.