### PR TITLE
test(envtest): fix race between test mutations and controller status flush

### DIFF
--- a/internal/controller/nodedeployment/envtest/seinode_statefulset_test.go
+++ b/internal/controller/nodedeployment/envtest/seinode_statefulset_test.go
@@ -127,6 +127,22 @@ func TestSeiNode_StatefulSetRecreatedAfterDelete(t *testing.T) {
 	g.Expect(testCli.Get(testCtx, stsKey, sts)).To(Succeed())
 	g.Expect(testCli.Delete(testCtx, sts)).To(Succeed())
 
+	// Wait for the Owns(StatefulSet) watch to fire the deletion-observation
+	// reconcile before issuing the spec patch below. Without this barrier,
+	// the spec patch can land between the in-flight reconcile's Get and
+	// its optimistic-locked Status.Patch (see controller/node/controller.go's
+	// MergeFromWithOptimisticLock at the reconcile entry), producing a 409
+	// "the object has been modified". Controller-runtime re-queues on 409,
+	// but the exponential backoff can stretch convergence past the test's
+	// pollTimeout — surfacing as a flake. The condition is satisfied when
+	// the StatefulSet is briefly NotFound or has already been recreated
+	// with a new UID; both signal the deletion has been observed.
+	waitFor(t, func() bool {
+		s := &appsv1.StatefulSet{}
+		err := testCli.Get(testCtx, stsKey, s)
+		return apierrors.IsNotFound(err) || (err == nil && s.UID != originalUID)
+	}, "controller must observe the StatefulSet deletion before next mutation")
+
 	// Bump the spec so the controller reconciles again (the SeiNode
 	// reconciler watches StatefulSet via Owns, but envtest sometimes
 	// races; a Spec edit triggers the predicate deterministically).
@@ -200,6 +216,25 @@ func TestSeiNode_StatefulSetImpostorReplaced(t *testing.T) {
 	// the full object and avoids that pitfall.
 	cur.Status.StatefulSet.UID = "00000000-0000-0000-0000-000000000000"
 	g.Expect(testCli.Status().Update(testCtx, cur)).To(Succeed())
+
+	// Confirm the forged status is durable on the apiserver before
+	// issuing the spec patch below. This collapses the window where the
+	// two writes land back-to-back and an in-flight reconcile (if the
+	// controller's predicate doesn't filter the Status.Update) sees
+	// them at conflicting resource versions, triggering a 409 on
+	// optimistic-locked Status.Patch (see controller/node/controller.go's
+	// MergeFromWithOptimisticLock). The re-Get round-trip also serves
+	// as a synchronization barrier against any reconcile woken by the
+	// Status.Update, letting it drain before the spec patch fires a
+	// second predicate.
+	waitFor(t, func() bool {
+		latest := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, key, latest); err != nil {
+			return false
+		}
+		return latest.Status.StatefulSet != nil &&
+			latest.Status.StatefulSet.UID == "00000000-0000-0000-0000-000000000000"
+	}, "Status.Update forging UID must be durable before next mutation")
 
 	// Trigger a spec-bumped reconcile so the controller picks up the
 	// forged mismatch. The Owns(StatefulSet) watch would fire on the

--- a/internal/controller/nodedeployment/envtest/seinode_statefulset_test.go
+++ b/internal/controller/nodedeployment/envtest/seinode_statefulset_test.go
@@ -127,16 +127,9 @@ func TestSeiNode_StatefulSetRecreatedAfterDelete(t *testing.T) {
 	g.Expect(testCli.Get(testCtx, stsKey, sts)).To(Succeed())
 	g.Expect(testCli.Delete(testCtx, sts)).To(Succeed())
 
-	// Wait for the Owns(StatefulSet) watch to fire the deletion-observation
-	// reconcile before issuing the spec patch below. Without this barrier,
-	// the spec patch can land between the in-flight reconcile's Get and
-	// its optimistic-locked Status.Patch (see controller/node/controller.go's
-	// MergeFromWithOptimisticLock at the reconcile entry), producing a 409
-	// "the object has been modified". Controller-runtime re-queues on 409,
-	// but the exponential backoff can stretch convergence past the test's
-	// pollTimeout — surfacing as a flake. The condition is satisfied when
-	// the StatefulSet is briefly NotFound or has already been recreated
-	// with a new UID; both signal the deletion has been observed.
+	// Barrier: let the Owns watch fire its deletion reconcile before the
+	// spec patch below. Without it, the spec patch races the in-flight
+	// reconcile's optimistic-locked status flush → 409 → flake.
 	waitFor(t, func() bool {
 		s := &appsv1.StatefulSet{}
 		err := testCli.Get(testCtx, stsKey, s)
@@ -217,16 +210,10 @@ func TestSeiNode_StatefulSetImpostorReplaced(t *testing.T) {
 	cur.Status.StatefulSet.UID = "00000000-0000-0000-0000-000000000000"
 	g.Expect(testCli.Status().Update(testCtx, cur)).To(Succeed())
 
-	// Confirm the forged status is durable on the apiserver before
-	// issuing the spec patch below. This collapses the window where the
-	// two writes land back-to-back and an in-flight reconcile (if the
-	// controller's predicate doesn't filter the Status.Update) sees
-	// them at conflicting resource versions, triggering a 409 on
-	// optimistic-locked Status.Patch (see controller/node/controller.go's
-	// MergeFromWithOptimisticLock). The re-Get round-trip also serves
-	// as a synchronization barrier against any reconcile woken by the
-	// Status.Update, letting it drain before the spec patch fires a
-	// second predicate.
+	// Barrier: confirm the forged status is durable and any reconcile
+	// woken by Status.Update has drained before the spec patch below.
+	// Without it, back-to-back writes race the in-flight reconcile's
+	// optimistic-locked status flush → 409 → flake.
 	waitFor(t, func() bool {
 		latest := &seiv1alpha1.SeiNode{}
 		if err := testCli.Get(testCtx, key, latest); err != nil {


### PR DESCRIPTION
## Summary

Fixes an intermittent flake in the envtest integration suite for `TestSeiNode_StatefulSetRecreatedAfterDelete` and `TestSeiNode_StatefulSetImpostorReplaced` (the \`sts-recreated\` and \`sts-impostor\` scenarios).

## Diagnosis

Both tests issue **two near-simultaneous mutations** on the same SeiNode:
1. A destabilizing mutation — `Delete(sts)` for `sts-recreated`, or `Status().Update` forging a UID mismatch for `sts-impostor`.
2. A spec patch — bumping `spec.overrides["chain.touch-counter"]` to fire the SeiNode predicate deterministically.

The SeiNode reconciler uses optimistic locking for its status flush (`internal/controller/node/controller.go:92`):

\`\`\`go
statusBase := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
\`\`\`

When the spec patch in step (2) lands between the in-flight reconcile's `Get` and its `Status.Patch`, the patch fails with 409:

\`\`\`
"flushing status: Operation cannot be fulfilled on seinodes.sei.io \"sts-recreated\":
 the object has been modified; please apply your changes to the latest version and try again"
\`\`\`

Controller-runtime re-queues on 409, but the exponential backoff occasionally stretches convergence past the 30s `pollTimeout` (`helpers_test.go:26`) — surfacing as a flake.

## History

- 2026-05-26 — main run [`26460706817`](https://github.com/sei-protocol/sei-k8s-controller/actions/runs/26460706817) failed with this exact pattern after #353 squash-merged into main. The PR itself (#353) had passed test-integration in 3m51s; only the post-merge run on main caught the race.
- 2026-05-21 — main on commit `2cc9e8c0` also failed similarly.
- Otherwise green — low-single-digit % flake rate, consistent with timing-sensitive interleaves rather than a behavior regression.

## Fix

Test-only. Insert a `waitFor` between the two mutations in each test:

### `sts-recreated`

After `Delete(sts)`, wait for the Owns watch to fire the deletion-observation reconcile — condition succeeds when the StatefulSet is briefly NotFound or has been recreated with a new UID. Both signal the Owns watch has already done its work, so the subsequent spec patch triggers a fresh reconcile rather than racing one in flight.

### `sts-impostor`

After `Status().Update` forging the UID, wait for the forged value to be durable on the apiserver before issuing the spec patch. The re-Get round-trip also serves as a drain barrier against any reconcile the Status.Update may have woken (predicate configurations that don't filter status updates).

## What this PR does not change

- No controller behavior change (the `MergeFromWithOptimisticLock` semantics stay — they're correct as defensive checks against stale-view writes).
- No timeout change (`pollTimeout`/`pollInterval` unchanged).
- Pure test-side ordering fix.

## Validation

Local envtest unavailable on this machine (no `etcd` in `/usr/local/kubebuilder/bin/`). Compilation + vet clean. Relying on CI to validate; recommend at least one re-run after merge to confirm the flake is gone.

## Refs

- Cross-discussed with #353 (the merge that surfaced the flake) and the open #354 (controller-image bump that's blocked on this).