### PR TITLE
fix(scenarios): explicit memiavl_only override for nightly seid

### DIFF
--- a/scenarios/load-test/rpc.yaml.tmpl
+++ b/scenarios/load-test/rpc.yaml.tmpl
@@ -16,6 +16,8 @@ spec:
       overrides:
         tx_index.indexer: kv
         mempool.ttl_duration: 60s
+        storage.state_commit.write_mode: memiavl_only
+        storage.state_store.write_mode: memiavl_only
         # Tighten /lag_status readiness to 2 blocks so SND phase=Ready
         # means lag<=2 across the fleet. The release-test harness opens
         # fresh HTTP connections per call; pods at meaningfully different

--- a/scenarios/load-test/rpc.yaml.tmpl
+++ b/scenarios/load-test/rpc.yaml.tmpl
@@ -1,0 +1,26 @@
+apiVersion: sei.io/v1alpha1
+kind: SeiNodeDeployment
+metadata:
+  name: PLACEHOLDER
+spec:
+  replicas: 2
+  template:
+    spec:
+      chainId: "{{ .CHAIN_ID }}"
+      image: "{{ .IMAGE }}"
+      fullNode: {}
+      peers:
+        - label:
+            selector:
+              sei.io/chain: "{{ .CHAIN_ID }}"
+      overrides:
+        tx_index.indexer: kv
+        mempool.ttl_duration: 60s
+        # Tighten /lag_status readiness to 2 blocks so SND phase=Ready
+        # means lag<=2 across the fleet. The release-test harness opens
+        # fresh HTTP connections per call; pods at meaningfully different
+        # heights break write-then-read sequences.
+        network.rpc.lag_threshold: "2"
+        evm.enabled_legacy_sei_apis: sei_getLogs,sei_getBlockByNumber,sei_getBlockByHash,sei_getSeiAddress,sei_getEVMAddress,sei_getCosmosTx,sei_getEvmTx,sei_newFilter,sei_getFilterLogs
+  updateStrategy:
+    type: InPlace

--- a/scenarios/load-test/validator.yaml.tmpl
+++ b/scenarios/load-test/validator.yaml.tmpl
@@ -12,6 +12,8 @@ spec:
       overrides:
         tx_index.indexer: kv
         mempool.ttl_duration: 60s
+        storage.state_commit.write_mode: memiavl_only
+        storage.state_store.write_mode: memiavl_only
   genesis:
     chainId: "{{ .CHAIN_ID }}"
     accounts:

--- a/scenarios/load-test/validator.yaml.tmpl
+++ b/scenarios/load-test/validator.yaml.tmpl
@@ -1,0 +1,21 @@
+apiVersion: sei.io/v1alpha1
+kind: SeiNodeDeployment
+metadata:
+  name: PLACEHOLDER
+spec:
+  replicas: 4
+  template:
+    spec:
+      chainId: "{{ .CHAIN_ID }}"
+      image: "{{ .IMAGE }}"
+      validator: {}
+      overrides:
+        tx_index.indexer: kv
+        mempool.ttl_duration: 60s
+  genesis:
+    chainId: "{{ .CHAIN_ID }}"
+    accounts:
+      - address: "{{ .ADMIN_ADDRESS }}"
+        balance: 1000000000000usei
+  updateStrategy:
+    type: InPlace

--- a/scenarios/release-test/rpc.yaml.tmpl
+++ b/scenarios/release-test/rpc.yaml.tmpl
@@ -16,6 +16,8 @@ spec:
       overrides:
         tx_index.indexer: kv
         mempool.ttl_duration: 60s
+        storage.state_commit.write_mode: memiavl_only
+        storage.state_store.write_mode: memiavl_only
         # Tighten /lag_status readiness to 2 blocks so SND phase=Ready
         # means lag<=2 across the fleet. The release-test harness opens
         # fresh HTTP connections per call; pods at meaningfully different

--- a/scenarios/release-test/validator.yaml.tmpl
+++ b/scenarios/release-test/validator.yaml.tmpl
@@ -12,6 +12,8 @@ spec:
       overrides:
         tx_index.indexer: kv
         mempool.ttl_duration: 60s
+        storage.state_commit.write_mode: memiavl_only
+        storage.state_store.write_mode: memiavl_only
   genesis:
     chainId: "{{ .CHAIN_ID }}"
     accounts:


### PR DESCRIPTION
## Problem

seid nightly/main (post-`0412e4e84`) rejects `cosmos_only` and requires `memiavl_only`. sei-config v0.0.19 reverts the default back to `cosmos_only` to not break stable seid v6.5.1. Nightly scenario validators and RPC nodes therefore need an explicit override.

## Fix

Add `storage.state_commit.write_mode: memiavl_only` and `storage.state_store.write_mode: memiavl_only` to the `overrides:` block in all four scenario templates:
- `scenarios/load-test/validator.yaml.tmpl`
- `scenarios/load-test/rpc.yaml.tmpl`
- `scenarios/release-test/validator.yaml.tmpl`
- `scenarios/release-test/rpc.yaml.tmpl`

**Why here:** `provision-snd` has no `--set-override` flag; the override must live in the embedded template. Implicit-over-explicit: `memiavl_only` is the only valid value for the nightly binary — no parameterization needed.

**Un-defer:** remove these overrides when sei-config default bumps to `memiavl_only` at seid v6.6.0 release.

Paired with sei-config#27 (revert default to `cosmos_only`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)