### PR TITLE
fix(scenarios): hardcode memiavl_only write mode for nightly seid

### DIFF
--- a/scenarios/load-test/rpc.yaml.tmpl
+++ b/scenarios/load-test/rpc.yaml.tmpl
@@ -13,5 +13,8 @@ spec:
         - label:
             selector:
               sei.io/chain: "{{ .CHAIN_ID }}"
+      overrides:
+        storage.state_commit.write_mode: memiavl_only
+        storage.state_store.write_mode: memiavl_only
   updateStrategy:
     type: InPlace

--- a/scenarios/load-test/validator.yaml.tmpl
+++ b/scenarios/load-test/validator.yaml.tmpl
@@ -9,6 +9,9 @@ spec:
       chainId: "{{ .CHAIN_ID }}"
       image: "{{ .IMAGE }}"
       validator: {}
+      overrides:
+        storage.state_commit.write_mode: memiavl_only
+        storage.state_store.write_mode: memiavl_only
   genesis:
     chainId: "{{ .CHAIN_ID }}"
   updateStrategy:

--- a/scenarios/release-test/rpc.yaml.tmpl
+++ b/scenarios/release-test/rpc.yaml.tmpl
@@ -15,6 +15,8 @@ spec:
               sei.io/chain: "{{ .CHAIN_ID }}"
       overrides:
         tx_index.indexer: kv
+        storage.state_commit.write_mode: memiavl_only
+        storage.state_store.write_mode: memiavl_only
         mempool.ttl_duration: 60s
         # Tighten /lag_status readiness to 2 blocks so SND phase=Ready
         # means lag<=2 across the fleet. The release-test harness opens

--- a/scenarios/release-test/validator.yaml.tmpl
+++ b/scenarios/release-test/validator.yaml.tmpl
@@ -11,6 +11,8 @@ spec:
       validator: {}
       overrides:
         tx_index.indexer: kv
+        storage.state_commit.write_mode: memiavl_only
+        storage.state_store.write_mode: memiavl_only
         mempool.ttl_duration: 60s
   genesis:
     chainId: "{{ .CHAIN_ID }}"


### PR DESCRIPTION
seid nightly/main rejects `cosmos_only`; sei-config v0.0.19 reverts default to `cosmos_only` (safe for v6.5.1). All four scenario templates explicitly set `memiavl_only` so nightly validators and RPC nodes start cleanly.

Remove these overrides when sei-config default bumps to `memiavl_only` at seid v6.6.0.

Paired with sei-config#27 + seictl#193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)