### PR TITLE
chore(deps): bump sei-config v0.0.16 → v0.0.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.39.1
-	github.com/sei-protocol/sei-config v0.0.16
+	github.com/sei-protocol/sei-config v0.0.19
 	github.com/sei-protocol/seictl v0.0.50
 	github.com/urfave/cli/v3 v3.6.1
 	go.opentelemetry.io/otel v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -1773,6 +1773,8 @@ github.com/sei-protocol/sei-config v0.0.15 h1:kd9ZbDYq4eAJxpELI8oISVXFiPr3Jf1kTH
 github.com/sei-protocol/sei-config v0.0.15/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-config v0.0.16 h1:2wBHVmCaHnGeqRNrdpUSJByehYTLOSEkk+IP/rwJJBE=
 github.com/sei-protocol/sei-config v0.0.16/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
+github.com/sei-protocol/sei-config v0.0.19 h1:87jB4u/TmZ8+xMLWqIDNODGslOdMGhw6ydOpOEb2dK8=
+github.com/sei-protocol/sei-config v0.0.19/go.mod h1:IEAv5ynYw8Gu2F2qNfE4MQR0PPihAT6g7RWLpWdw5O0=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082 h1:f2sY8OcN60UL1/6POx+HDMZ4w04FTZtSScnrFSnGZHg=
 github.com/sei-protocol/sei-load v0.0.0-20251007135253-78fbdc141082/go.mod h1:V0fNURAjS6A8+sA1VllegjNeSobay3oRUW5VFZd04bA=
 github.com/sei-protocol/sei-tm-db v0.0.5 h1:3WONKdSXEqdZZeLuWYfK5hP37TJpfaUa13vAyAlvaQY=


### PR DESCRIPTION
## Summary

Bumps sei-config from v0.0.16 to v0.0.19. The relevant change is **v0.0.18** (\`feat: v1→v2 config schema migration for seid v6.5 write mode rename\`), which adds the new \`storage.state_commit.write_mode\` enum values:

- \`memiavl_only\` (was \`cosmos_only\`)
- \`migrate_evm\` (was \`dual_write\`)
- \`evm_migrated\` (was \`split_write\`)
- \`migrate_all_but_bank\`, \`all_migrated_but_bank\`, \`migrate_bank\`, \`flatkv_only\` (new FlatKV-migration stages)

The controller's \`config-apply\` task uses sei-config's validator, so without this bump the controller rejects any SeiNode whose overrides reference the new names.

## Why now

Observed today on harbor's \`pacific1-flatkv-migrating-0\` in \`eng-yiren\`:

\`\`\`
config validation failed: [{
  "severity":"ERROR",
  "field":"storage.state_commit.write_mode",
  "message":"invalid write_mode: \"migrate_evm\""
}]
\`\`\`

The SeiNode entered \`Failed\` phase. Alert \`SeiNodeFailed\` fired in harbor.

## Backward compatibility

Non-breaking. v0.0.19's validator still accepts the old names (\`cosmos_only\`, \`dual_write\`, \`split_write\`) — they remain valid alongside the new ones. Existing SeiNodes continue to validate unchanged.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — full suite passes (planner, controller, noderesource, nodetask, runner, seitask/*, sidecartransport, taskruntime)
- [x] Image build via CI
- [x] Platform manifest pin bumped in a follow-up PR against \`sei-protocol/platform\` to point the harbor controller at the new image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)