### PR TITLE
test(envtest): wait for child CurrentImage before pausing faker (TestInPlaceRollout_StuckUntilUnstuck)

### DIFF
--- a/internal/controller/nodedeployment/envtest/inplace_stuck_test.go
+++ b/internal/controller/nodedeployment/envtest/inplace_stuck_test.go
@@ -67,10 +67,28 @@ func TestInPlaceRollout_StuckUntilUnstuck(t *testing.T) {
 	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
 	key := client.ObjectKeyFromObject(snd)
 
-	// Initial v1 deployment reaches steady state.
-	waitForStatus(t, key, func(latest *seiv1alpha1.SeiNodeDeployment) bool {
-		return latest.Status.TemplateHash != "" && latest.Status.Rollout == nil
-	}, "initial v1 deployment reached steady state")
+	// Initial v1 deployment reaches steady state. The SND-level gate
+	// (TemplateHash set, no in-flight Rollout) fires as soon as the
+	// init plan ends at mark-ready — which does NOT include observe-image.
+	// For a fresh InPlace SND with no Genesis, Status.CurrentImage on each
+	// child is stamped only later, via the steady-state drift NodeUpdate
+	// that runs observe-image. If we Pause the faker before that drift
+	// pass observes the StatefulSet, observe-image stalls forever on
+	// ObservedGeneration < Generation and Status.CurrentImage stays "".
+	// Wait at the child level: every child must have Status.CurrentImage
+	// == v1 before the v2 patch lands.
+	waitFor(t, func() bool {
+		kids := listChildren(t, getSND(t, key))
+		if len(kids) != replicas {
+			return false
+		}
+		for i := range kids {
+			if kids[i].Status.CurrentImage != v1 {
+				return false
+			}
+		}
+		return true
+	}, "all children Status.CurrentImage stamped at v1 before pausing faker")
 
 	// Pause the faker. StatefulSet .Status freezes, ObserveImage stalls,
 	// AwaitSpecUpdate stalls behind it. The Cleanup ensures other tests
@@ -143,8 +161,10 @@ func TestInPlaceRollout_StuckUntilUnstuck(t *testing.T) {
 		// Status.CurrentImage is stamped by the SeiNode-side ObserveImage
 		// task; with the faker paused, that task never observes the new
 		// StatefulSet revision and never stamps the field. It stays at v1
-		// (the value the first rollout's ObserveImage stamped) — not
-		// empty, not v2.
+		// — the value stamped earlier by the steady-state drift NodeUpdate
+		// (init plan ends at mark-ready and never runs observe-image, so
+		// the v1 stamp comes from drift, gated on by the pre-pause barrier
+		// above). Not empty, not v2.
 		g.Expect(kids[i].Status.CurrentImage).To(Equal(v1),
 			"child %s status.currentImage stays at v1 (stuck signal)", kids[i].Name)
 	}


### PR DESCRIPTION
## Problem

`TestInPlaceRollout_StuckUntilUnstuck` (`internal/controller/nodedeployment/envtest/inplace_stuck_test.go`) has been intermittently failing on main CI — observed on #353, #357, #358. Verdict from prior investigation: test orchestration bug, not a controller bug.

## Mechanism

- Pre-pause gate at `inplace_stuck_test.go:71-73` used the SND-level signal: `TemplateHash != "" && Rollout == nil`.
- For a fresh InPlace SND with no Genesis, no SND-side plan runs — `TemplateHash` is stamped immediately, so the gate fires fast.
- The test then calls `testFaker.Pause()` (line 78) before any child's drift `NodeUpdate` has had a chance to run `observe-image`.
- The init plan ends at `mark-ready` and does NOT include `observe-image`. `Status.CurrentImage = v1` is stamped only via the steady-state drift correction (`internal/controller/seinode/planner.go:707`).
- Once the faker is paused, `observe-image` stalls forever on `ObservedGeneration < Generation` (`internal/task/observe_image.go:65-66`). `Status.CurrentImage` stays `""`. The final assertion at line 148 (`CurrentImage == v1`) fails.

## Fix

Replace the SND-level gate with a child-level barrier that waits for `Status.CurrentImage == v1` on every child before `testFaker.Pause()`. Also corrects the misleading comment at lines 143-147 — it claimed v1 came from "the first rollout's ObserveImage", but there is no first rollout for v1; the stamp comes from drift.

Test-side patch only. No controller code changes (`observe_image.go`, `planner.go`, `status.go` untouched). The controller behavior is correct as-is.

## Independent of #355

#355 correctly addresses a different race in `seinode_statefulset_test.go` (test mutations vs controller status flush). This PR does not extend or revert that change — it targets a separate orchestration bug in `inplace_stuck_test.go`.

## Test plan

- [x] `KUBEBUILDER_ASSETS=… go test -tags=envtest -run TestInPlaceRollout_StuckUntilUnstuck -count=10 -timeout 600s ./internal/controller/nodedeployment/envtest/...` — 10/10 pass locally (162s wall).
- [x] `KUBEBUILDER_ASSETS=… go test -tags=envtest -count=2 -timeout 600s ./internal/controller/nodedeployment/envtest/...` — full envtest suite passes 2x (106s wall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)