### PR TITLE
feat(controller/node): publishable P2P — per-pod NLB Service + ExternalAddress gate (#360 PR-2)

### DIFF
--- a/api/v1alpha1/seinode_types.go
+++ b/api/v1alpha1/seinode_types.go
@@ -277,6 +277,31 @@ const (
 
 	// ConditionSeiNodePaused mirrors spec.paused: True when paused.
 	ConditionSeiNodePaused = "Paused"
+
+	// ConditionPublishableReady reports the per-pod L4 NLB state.
+	// True when Status.ExternalAddress is populated; False with reason
+	// carries the off-or-not-yet state.
+	ConditionPublishableReady = "PublishableReady"
+)
+
+// Reasons for the PublishableReady condition.
+const (
+	// ReasonPublishableDisabled — parent SND has no Networking.TCP.
+	ReasonPublishableDisabled = "PublishableDisabled"
+
+	// ReasonVPCCIDRNotConfigured — fail-closed: SEI_VPC_CIDR is unset.
+	ReasonVPCCIDRNotConfigured = "VPCCIDRNotConfigured"
+
+	// ReasonPodOutsideVPCCIDR — fail-closed: pod IP outside the CIDR
+	// (harbor's Cilium CGNAT). NLB target-type=ip needs routable IPs.
+	ReasonPodOutsideVPCCIDR = "PodOutsideVPCCIDR"
+
+	// ReasonServiceProvisioning — Service exists, NLB hostname not yet
+	// populated (~2 min on AWS).
+	ReasonServiceProvisioning = "ServiceProvisioning"
+
+	// ReasonExternalAddressReady — Status.ExternalAddress is set.
+	ReasonExternalAddressReady = "ExternalAddressReady"
 )
 
 // Reasons for the ImportPVCReady condition.

--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -20,8 +20,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/controller/observability"
@@ -53,6 +55,7 @@ type SeiNodeReconciler struct {
 // +kubebuilder:rbac:groups=sei.io,resources=seinodes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sei.io,resources=seinodes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=sei.io,resources=seinodes/finalizers,verbs=update
+// +kubebuilder:rbac:groups=sei.io,resources=seinodedeployments,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
@@ -110,6 +113,14 @@ func (r *SeiNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		r.Recorder.Eventf(node, corev1.EventTypeWarning, "NodeFailed",
 			"SeiNode is in Failed state. Delete and recreate the resource to retry.")
 		return ctrl.Result{}, nil
+	}
+
+	// Publishable P2P gate — hold STS creation when the parent SND has
+	// Networking.TCP set until the NLB hostname populates, so the first
+	// pod's config carries the correct p2p.external_address. Re-reconcile
+	// fires from the existing Owns(&Service{}) watch on hostname update.
+	if done, err := r.runExternalAddressGate(ctx, node, flushStatus); done {
+		return ctrl.Result{}, err
 	}
 
 	if err := r.reconcileStatefulSet(ctx, node); err != nil {
@@ -203,8 +214,42 @@ func (r *SeiNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
+		Watches(&seiv1alpha1.SeiNodeDeployment{},
+			handler.EnqueueRequestsFromMapFunc(r.mapSNDToChildSeiNodes),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Named(seiNodeControllerName).
 		Complete(r)
+}
+
+// mapSNDToChildSeiNodes enqueues every SeiNode whose controller
+// owner-ref points at the changed SND. Wakes child reconciles when
+// the parent toggles Spec.Networking.TCP without waiting for the
+// steady-state requeue. O(SeiNodes in namespace) per event.
+func (r *SeiNodeReconciler) mapSNDToChildSeiNodes(ctx context.Context, obj client.Object) []reconcile.Request {
+	snd, ok := obj.(*seiv1alpha1.SeiNodeDeployment)
+	if !ok {
+		return nil
+	}
+	list := &seiv1alpha1.SeiNodeList{}
+	if err := r.List(ctx, list, client.InNamespace(snd.Namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "listing child SeiNodes for SND watch",
+			"snd", snd.Name, "namespace", snd.Namespace)
+		return nil
+	}
+	out := make([]reconcile.Request, 0, len(list.Items))
+	for i := range list.Items {
+		ctrlRef := metav1.GetControllerOf(&list.Items[i])
+		if ctrlRef == nil || ctrlRef.UID != snd.UID {
+			continue
+		}
+		out = append(out, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      list.Items[i].Name,
+				Namespace: list.Items[i].Namespace,
+			},
+		})
+	}
+	return out
 }
 
 func (r *SeiNodeReconciler) ensureNodeFinalizer(ctx context.Context, node *seiv1alpha1.SeiNode) error {
@@ -295,4 +340,3 @@ func (r *SeiNodeReconciler) emitSidecarReadinessEvent(node *seiv1alpha1.SeiNode,
 			"sidecar Healthz returned 200; mark-ready gate is open")
 	}
 }
-

--- a/internal/controller/node/external_address.go
+++ b/internal/controller/node/external_address.go
@@ -1,0 +1,301 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+)
+
+const (
+	// p2pServiceSuffix is appended to the SeiNode name to form the
+	// per-pod LoadBalancer Service name. Format: "<seinode>-p2p".
+	p2pServiceSuffix = "-p2p"
+
+	// p2pTCPPort is the CometBFT P2P TCP port. Pinned by sei-config /
+	// CometBFT; mirrored here to keep the Service generator self-contained.
+	p2pTCPPort int32 = 26656
+
+	// envVPCCIDR carries the VPC CIDR used for pod-IP routability checks.
+	// Unset → fail-closed (refuse to stamp), the safety net for harbor's
+	// CGNAT pods where NLB target-type=ip would silently break.
+	envVPCCIDR = "SEI_VPC_CIDR"
+
+	// podNameLabel is the StatefulSet pod-name label. Selecting on this
+	// targets a single ordinal pod, surviving any future scale-up.
+	podNameLabel = "statefulset.kubernetes.io/pod-name"
+)
+
+// p2pServiceName returns the per-pod LB Service name for a SeiNode.
+func p2pServiceName(node *seiv1alpha1.SeiNode) string {
+	return node.Name + p2pServiceSuffix
+}
+
+// runExternalAddressGate runs reconcileExternalAddress and decides
+// whether the outer Reconcile should short-circuit. done=true means
+// return immediately (error, or gate-held); done=false means proceed
+// to StatefulSet reconcile.
+func (r *SeiNodeReconciler) runExternalAddressGate(ctx context.Context, node *seiv1alpha1.SeiNode, flushStatus func() error) (bool, error) {
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	if err != nil {
+		return true, fmt.Errorf("reconciling external address: %w", err)
+	}
+	if ready {
+		return false, nil
+	}
+	if err := flushStatus(); err != nil {
+		return true, fmt.Errorf("flushing status before service-ready gate: %w", err)
+	}
+	return true, nil
+}
+
+// reconcileExternalAddress provisions the per-pod L4 NLB Service when
+// the parent SND has Networking.TCP set, writes the NLB hostname into
+// Status.ExternalAddress when populated, and reports whether the node
+// is ready to proceed to StatefulSet creation.
+//
+// ready=true when TCP is not requested (opt-out, Service cleaned up)
+// or when TCP is requested AND ExternalAddress is populated.
+// ready=false otherwise (VPC CIDR unset, pod outside CIDR, or NLB
+// hostname not yet populated). PublishableReady condition carries the
+// reason. ExternalAddress is cleared only on intentional opt-out.
+func (r *SeiNodeReconciler) reconcileExternalAddress(ctx context.Context, node *seiv1alpha1.SeiNode) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	snd, err := r.fetchParentSND(ctx, node)
+	if err != nil {
+		return false, fmt.Errorf("fetching parent SND: %w", err)
+	}
+
+	if snd == nil || snd.Spec.Networking == nil || snd.Spec.Networking.TCP == nil {
+		if err := r.deleteP2PService(ctx, node); err != nil {
+			return false, fmt.Errorf("deleting p2p service on opt-out: %w", err)
+		}
+		if node.Status.ExternalAddress != "" {
+			node.Status.ExternalAddress = ""
+		}
+		setPublishableCondition(node, metav1.ConditionFalse, seiv1alpha1.ReasonPublishableDisabled,
+			"parent SeiNodeDeployment has no Networking.TCP; per-pod LB not provisioned")
+		return true, nil
+	}
+
+	// Fail-closed when SEI_VPC_CIDR is unset — without it we can't
+	// verify pod-IP routability (harbor's Cilium CGNAT is the case).
+	vpcCIDR := os.Getenv(envVPCCIDR)
+	if vpcCIDR == "" {
+		logger.Info("publishable P2P requested but SEI_VPC_CIDR is not set; refusing to stamp Service",
+			"seinode", node.Name)
+		setPublishableCondition(node, metav1.ConditionFalse, seiv1alpha1.ReasonVPCCIDRNotConfigured,
+			"SEI_VPC_CIDR is not configured on the controller; publishable Service stamping is fail-closed")
+		return false, nil
+	}
+
+	// Pod-IP routability: fail closed if the pod exists but is outside
+	// the CIDR. First reconcile (no pod yet) stamps the Service anyway
+	// so NLB provisioning can run in parallel with STS bringup.
+	podInside, podPresent, err := r.podInsideVPCCIDR(ctx, node, vpcCIDR)
+	if err != nil {
+		return false, fmt.Errorf("checking pod-IP routability: %w", err)
+	}
+	if podPresent && !podInside {
+		setPublishableCondition(node, metav1.ConditionFalse, seiv1alpha1.ReasonPodOutsideVPCCIDR,
+			fmt.Sprintf("pod %s-0 IP is outside SEI_VPC_CIDR %s; NLB target-type=ip requires VPC-routable pod IPs", node.Name, vpcCIDR))
+		return false, nil
+	}
+
+	if err := r.ensureP2PService(ctx, node); err != nil {
+		return false, fmt.Errorf("ensuring p2p service: %w", err)
+	}
+
+	hostname, err := r.readP2PServiceHostname(ctx, node)
+	if err != nil {
+		return false, fmt.Errorf("reading p2p service hostname: %w", err)
+	}
+	if hostname == "" {
+		setPublishableCondition(node, metav1.ConditionFalse, seiv1alpha1.ReasonServiceProvisioning,
+			"per-pod LB Service exists; waiting for AWS NLB hostname to populate")
+		return false, nil
+	}
+
+	desired := fmt.Sprintf("%s:%d", hostname, p2pTCPPort)
+	if node.Status.ExternalAddress != desired {
+		node.Status.ExternalAddress = desired
+	}
+	setPublishableCondition(node, metav1.ConditionTrue, seiv1alpha1.ReasonExternalAddressReady,
+		fmt.Sprintf("Status.ExternalAddress = %s", desired))
+	return true, nil
+}
+
+// fetchParentSND resolves the SeiNode's controller owner reference back
+// to the parent SeiNodeDeployment. Returns (nil, nil) when the SeiNode
+// has no controller owner of kind SeiNodeDeployment (standalone case).
+func (r *SeiNodeReconciler) fetchParentSND(ctx context.Context, node *seiv1alpha1.SeiNode) (*seiv1alpha1.SeiNodeDeployment, error) {
+	ctrlRef := metav1.GetControllerOf(node)
+	if ctrlRef == nil {
+		return nil, nil
+	}
+	if ctrlRef.Kind != "SeiNodeDeployment" {
+		return nil, nil
+	}
+	if ctrlRef.APIVersion != seiv1alpha1.GroupVersion.String() {
+		return nil, nil
+	}
+	snd := &seiv1alpha1.SeiNodeDeployment{}
+	err := r.Get(ctx, types.NamespacedName{Name: ctrlRef.Name, Namespace: node.Namespace}, snd)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return snd, nil
+}
+
+// podInsideVPCCIDR reports whether the SeiNode's first pod has an IP
+// inside the given VPC CIDR. podPresent is false when the pod (or its
+// IP) does not yet exist — the first-reconcile shape, before the STS
+// has been created. In that case, callers should proceed to stamp the
+// Service; the next reconcile after the pod boots will re-check.
+func (r *SeiNodeReconciler) podInsideVPCCIDR(ctx context.Context, node *seiv1alpha1.SeiNode, vpcCIDR string) (inside, podPresent bool, err error) {
+	_, cidr, parseErr := net.ParseCIDR(vpcCIDR)
+	if parseErr != nil {
+		return false, false, fmt.Errorf("parsing SEI_VPC_CIDR %q: %w", vpcCIDR, parseErr)
+	}
+	pod := &corev1.Pod{}
+	getErr := r.Get(ctx, types.NamespacedName{Name: node.Name + "-0", Namespace: node.Namespace}, pod)
+	if apierrors.IsNotFound(getErr) {
+		return false, false, nil
+	}
+	if getErr != nil {
+		return false, false, fmt.Errorf("fetching pod %s-0: %w", node.Name, getErr)
+	}
+	if pod.Status.PodIP == "" {
+		return false, false, nil
+	}
+	ip := net.ParseIP(pod.Status.PodIP)
+	if ip == nil {
+		return false, true, fmt.Errorf("pod %s-0 has unparseable IP %q", node.Name, pod.Status.PodIP)
+	}
+	return cidr.Contains(ip), true, nil
+}
+
+// ensureP2PService idempotently applies the per-pod LoadBalancer
+// Service via Server-Side Apply, with the SeiNode as the controller
+// owner so the Owns(&Service{}) watch already wired on the controller
+// fires on Service updates and the Service is GC'd on SeiNode deletion.
+func (r *SeiNodeReconciler) ensureP2PService(ctx context.Context, node *seiv1alpha1.SeiNode) error {
+	desired := generateP2PService(node)
+	desired.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
+	if err := ctrl.SetControllerReference(node, desired, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner reference: %w", err)
+	}
+	//nolint:staticcheck // migrating to typed ApplyConfiguration is a separate effort
+	if err := r.Patch(ctx, desired, client.Apply,
+		client.FieldOwner("seinode-controller"), client.ForceOwnership); err != nil {
+		return fmt.Errorf("applying p2p service: %w", err)
+	}
+	return nil
+}
+
+// readP2PServiceHostname returns the AWS NLB hostname from the live
+// Service's status.loadBalancer.ingress[0].hostname, or "" if not yet
+// populated. NotFound is treated as empty (caller may have just
+// stamped the Service; cache propagation can lag by one reconcile).
+func (r *SeiNodeReconciler) readP2PServiceHostname(ctx context.Context, node *seiv1alpha1.SeiNode) (string, error) {
+	svc := &corev1.Service{}
+	err := r.Get(ctx, types.NamespacedName{Name: p2pServiceName(node), Namespace: node.Namespace}, svc)
+	if apierrors.IsNotFound(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if len(svc.Status.LoadBalancer.Ingress) == 0 {
+		return "", nil
+	}
+	return svc.Status.LoadBalancer.Ingress[0].Hostname, nil
+}
+
+// deleteP2PService removes the per-pod LB Service if present. Used on
+// the opt-out path (parent SND has no Networking.TCP). NotFound is the
+// no-op steady state.
+func (r *SeiNodeReconciler) deleteP2PService(ctx context.Context, node *seiv1alpha1.SeiNode) error {
+	svc := &corev1.Service{}
+	err := r.Get(ctx, types.NamespacedName{Name: p2pServiceName(node), Namespace: node.Namespace}, svc)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := r.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// generateP2PService renders the per-pod L4 NLB Service. Pod-name
+// selector targets ordinal-0 even under future scale-up. Annotations
+// are the AWS LBC contract for internet-facing IP-target NLB with
+// cross-zone enabled; externalTrafficPolicy=Local preserves source IP.
+func generateP2PService(node *seiv1alpha1.SeiNode) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p2pServiceName(node),
+			Namespace: node.Namespace,
+			Labels:    p2pServiceLabels(node),
+			Annotations: map[string]string{
+				"service.beta.kubernetes.io/aws-load-balancer-type":                              "nlb",
+				"service.beta.kubernetes.io/aws-load-balancer-scheme":                            "internet-facing",
+				"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":                   "ip",
+				"service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                  corev1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+			Selector: map[string]string{
+				podNameLabel: node.Name + "-0",
+			},
+			Ports: []corev1.ServicePort{{
+				Name:       "p2p",
+				Port:       p2pTCPPort,
+				TargetPort: intstr.FromInt32(p2pTCPPort),
+				Protocol:   corev1.ProtocolTCP,
+			}},
+		},
+	}
+}
+
+// p2pServiceLabels are observability labels on the per-pod LB Service.
+// Lookup is by name, not label — keep these small and stable.
+func p2pServiceLabels(node *seiv1alpha1.SeiNode) map[string]string {
+	return map[string]string{
+		"sei.io/node":      node.Name,
+		"sei.io/component": "p2p-lb",
+	}
+}
+
+// setPublishableCondition is a thin wrapper that always populates
+// ObservedGeneration — required by the project's condition discipline.
+func setPublishableCondition(node *seiv1alpha1.SeiNode, status metav1.ConditionStatus, reason, message string) {
+	apimeta.SetStatusCondition(&node.Status.Conditions, metav1.Condition{
+		Type:               seiv1alpha1.ConditionPublishableReady,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: node.Generation,
+	})
+}

--- a/internal/controller/node/external_address_test.go
+++ b/internal/controller/node/external_address_test.go
@@ -1,0 +1,442 @@
+package node
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+)
+
+// newChildNodeWithSND returns a SeiNode that's owned by the given SND
+// via controller owner-ref. Matches the shape the SND reconciler stamps
+// at child creation time (see nodedeployment/nodes.go).
+func newChildNodeWithSND(name, namespace string, snd *seiv1alpha1.SeiNodeDeployment) *seiv1alpha1.SeiNode { //nolint:unparam // test helper designed for reuse
+	controller := true
+	return &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: seiv1alpha1.GroupVersion.String(),
+				Kind:       "SeiNodeDeployment",
+				Name:       snd.Name,
+				UID:        snd.UID,
+				Controller: &controller,
+			}},
+		},
+		Spec: seiv1alpha1.SeiNodeSpec{
+			ChainID:  "test-1",
+			Image:    "sei:latest",
+			FullNode: &seiv1alpha1.FullNodeSpec{},
+		},
+	}
+}
+
+func newSNDWithTCP() *seiv1alpha1.SeiNodeDeployment {
+	return &seiv1alpha1.SeiNodeDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "validators",
+			Namespace: "default",
+			UID:       types.UID("snd-uid-1"),
+		},
+		Spec: seiv1alpha1.SeiNodeDeploymentSpec{
+			Networking: &seiv1alpha1.NetworkingConfig{
+				TCP: &seiv1alpha1.TCPConfig{},
+			},
+		},
+	}
+}
+
+// publishableCondition fishes ConditionPublishableReady off the node.
+func publishableCondition(node *seiv1alpha1.SeiNode) *metav1.Condition {
+	return apimeta.FindStatusCondition(node.Status.Conditions, seiv1alpha1.ConditionPublishableReady)
+}
+
+// TestReconcileExternalAddress_Standalone_NoOwner asserts the
+// standalone case: a SeiNode with no controller owner-ref opts out of
+// publishability entirely and the gate stays open (ready=true).
+func TestReconcileExternalAddress_Standalone_NoOwner(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv(envVPCCIDR, "10.0.0.0/16")
+
+	node := &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "standalone", Namespace: "default"},
+		Spec: seiv1alpha1.SeiNodeSpec{
+			ChainID:  "test-1",
+			Image:    "sei:latest",
+			FullNode: &seiv1alpha1.FullNodeSpec{},
+		},
+	}
+
+	r, _ := newNodeReconciler(t, node)
+	ctx := context.Background()
+
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeTrue(), "standalone node opt-out: gate must be open")
+
+	cond := publishableCondition(node)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(seiv1alpha1.ReasonPublishableDisabled))
+}
+
+// TestReconcileExternalAddress_OptOut_NoTCP asserts the opt-out path:
+// parent SND exists but Spec.Networking is nil. Gate opens, no Service.
+func TestReconcileExternalAddress_OptOut_NoTCP(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv(envVPCCIDR, "10.0.0.0/16")
+
+	snd := &seiv1alpha1.SeiNodeDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "fullnode", Namespace: "default", UID: types.UID("snd-uid-2")},
+		Spec:       seiv1alpha1.SeiNodeDeploymentSpec{},
+	}
+	node := newChildNodeWithSND("fullnode-0", "default", snd)
+
+	r, c := newNodeReconciler(t, node, snd)
+	ctx := context.Background()
+
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeTrue())
+
+	// No Service should exist.
+	svc := &corev1.Service{}
+	err = c.Get(ctx, types.NamespacedName{Name: p2pServiceName(node), Namespace: "default"}, svc)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+	cond := publishableCondition(node)
+	g.Expect(cond.Reason).To(Equal(seiv1alpha1.ReasonPublishableDisabled))
+}
+
+// TestReconcileExternalAddress_OptOut_ClearsStaleService asserts that
+// transitioning tcp:{} → nil deletes a pre-existing per-pod Service
+// and clears Status.ExternalAddress (the only path that may clear it).
+func TestReconcileExternalAddress_OptOut_ClearsStaleService(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv(envVPCCIDR, "10.0.0.0/16")
+
+	snd := &seiv1alpha1.SeiNodeDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "fullnode", Namespace: "default", UID: types.UID("snd-uid-3")},
+		Spec:       seiv1alpha1.SeiNodeDeploymentSpec{}, // TCP nil
+	}
+	node := newChildNodeWithSND("fullnode-0", "default", snd)
+	node.Status.ExternalAddress = "stale.nlb.aws:26656"
+
+	// Stale Service exists.
+	staleSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p2pServiceName(node),
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 26656, Protocol: corev1.ProtocolTCP}},
+		},
+	}
+
+	r, c := newNodeReconciler(t, node, snd, staleSvc)
+	ctx := context.Background()
+
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeTrue())
+
+	// Service deleted.
+	check := &corev1.Service{}
+	err = c.Get(ctx, types.NamespacedName{Name: staleSvc.Name, Namespace: "default"}, check)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "stale Service must be deleted on opt-out")
+
+	// ExternalAddress cleared.
+	g.Expect(node.Status.ExternalAddress).To(BeEmpty(),
+		"Status.ExternalAddress must clear on intentional opt-out")
+}
+
+// TestReconcileExternalAddress_VPCCIDRUnset_FailsClosed asserts the
+// safety net: even with TCP requested, an unset SEI_VPC_CIDR holds the
+// gate closed (ready=false) and stamps no Service.
+func TestReconcileExternalAddress_VPCCIDRUnset_FailsClosed(t *testing.T) {
+	g := NewWithT(t)
+	// Explicitly unset for this test — t.Setenv("", "") panics, so use
+	// the OS env directly via t.Setenv on a known-empty value.
+	t.Setenv(envVPCCIDR, "")
+
+	snd := newSNDWithTCP()
+	node := newChildNodeWithSND("validators-0", "default", snd)
+
+	r, c := newNodeReconciler(t, node, snd)
+	ctx := context.Background()
+
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse(), "fail-closed: gate must hold while SEI_VPC_CIDR is unset")
+
+	// No Service stamped.
+	svc := &corev1.Service{}
+	err = c.Get(ctx, types.NamespacedName{Name: p2pServiceName(node), Namespace: "default"}, svc)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "must not stamp Service when fail-closed")
+
+	cond := publishableCondition(node)
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(seiv1alpha1.ReasonVPCCIDRNotConfigured))
+}
+
+// TestReconcileExternalAddress_PodOutsideCIDR_FailsClosed asserts that
+// once the pod exists with an IP outside the VPC CIDR, the gate stays
+// closed and no Service is stamped — the harbor-CGNAT safety net.
+func TestReconcileExternalAddress_PodOutsideCIDR_FailsClosed(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv(envVPCCIDR, "10.0.0.0/16")
+
+	snd := newSNDWithTCP()
+	node := newChildNodeWithSND("validators-0", "default", snd)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "validators-0-0", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: "100.64.5.5"}, // CGNAT space, outside 10.0.0.0/16
+	}
+
+	r, c := newNodeReconciler(t, node, snd, pod)
+	ctx := context.Background()
+
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse())
+
+	svc := &corev1.Service{}
+	err = c.Get(ctx, types.NamespacedName{Name: p2pServiceName(node), Namespace: "default"}, svc)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "must not stamp Service when pod IP is outside VPC CIDR")
+
+	cond := publishableCondition(node)
+	g.Expect(cond.Reason).To(Equal(seiv1alpha1.ReasonPodOutsideVPCCIDR))
+}
+
+// TestReconcileExternalAddress_StampsServiceAndHoldsGate covers the
+// first-reconcile shape: TCP requested, no pod yet (STS hasn't run).
+// Controller stamps the Service (which has no LB hostname populated
+// in fake client), and holds the gate closed pending hostname.
+func TestReconcileExternalAddress_StampsServiceAndHoldsGate(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv(envVPCCIDR, "10.0.0.0/16")
+
+	snd := newSNDWithTCP()
+	node := newChildNodeWithSND("validators-0", "default", snd)
+
+	r, c := newNodeReconciler(t, node, snd)
+	ctx := context.Background()
+
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse(), "gate held closed until NLB hostname populates")
+
+	// Service stamped with correct shape.
+	svc := &corev1.Service{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: p2pServiceName(node), Namespace: "default"}, svc)).To(Succeed())
+	g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+	g.Expect(svc.Spec.ExternalTrafficPolicy).To(Equal(corev1.ServiceExternalTrafficPolicyLocal))
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(podNameLabel, "validators-0-0"))
+	g.Expect(svc.Spec.Ports).To(HaveLen(1))
+	g.Expect(svc.Spec.Ports[0].Port).To(Equal(int32(26656)))
+	g.Expect(svc.Annotations).To(HaveKeyWithValue(
+		"service.beta.kubernetes.io/aws-load-balancer-type", "nlb"))
+	g.Expect(svc.Annotations).To(HaveKeyWithValue(
+		"service.beta.kubernetes.io/aws-load-balancer-scheme", "internet-facing"))
+	g.Expect(svc.Annotations).To(HaveKeyWithValue(
+		"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type", "ip"))
+	g.Expect(svc.Annotations).To(HaveKeyWithValue(
+		"service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled", "true"))
+
+	// OwnerRef controller=true to the SeiNode.
+	refs := svc.GetOwnerReferences()
+	g.Expect(refs).To(HaveLen(1))
+	g.Expect(refs[0].UID).To(Equal(node.UID))
+	g.Expect(refs[0].Controller).NotTo(BeNil())
+	g.Expect(*refs[0].Controller).To(BeTrue())
+
+	// Condition surfaces ServiceProvisioning.
+	cond := publishableCondition(node)
+	g.Expect(cond.Reason).To(Equal(seiv1alpha1.ReasonServiceProvisioning))
+
+	// ExternalAddress not written yet.
+	g.Expect(node.Status.ExternalAddress).To(BeEmpty())
+}
+
+// TestReconcileExternalAddress_HostnamePopulated_OpensGate covers the
+// happy path: Service already exists with a populated LB ingress
+// hostname. Controller writes Status.ExternalAddress in bare host:port
+// form and opens the gate.
+func TestReconcileExternalAddress_HostnamePopulated_OpensGate(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv(envVPCCIDR, "10.0.0.0/16")
+
+	snd := newSNDWithTCP()
+	node := newChildNodeWithSND("validators-0", "default", snd)
+
+	// Pre-existing Service with populated NLB hostname.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p2pServiceName(node),
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 26656, Protocol: corev1.ProtocolTCP}},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{Hostname: "abc123.elb.us-east-1.amazonaws.com"},
+				},
+			},
+		},
+	}
+
+	r, _ := newNodeReconciler(t, node, snd, svc)
+	ctx := context.Background()
+
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeTrue(), "gate opens once NLB hostname populates")
+	g.Expect(node.Status.ExternalAddress).To(Equal("abc123.elb.us-east-1.amazonaws.com:26656"))
+
+	cond := publishableCondition(node)
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).To(Equal(seiv1alpha1.ReasonExternalAddressReady))
+}
+
+// TestReconcileExternalAddress_EmptyHostGuard_PreservesAddress asserts
+// that a transient absence of the LB hostname (Service still exists, no
+// ingress entries) does NOT clear an existing Status.ExternalAddress.
+// This is the empty-host guard — only intentional opt-out clears it.
+func TestReconcileExternalAddress_EmptyHostGuard_PreservesAddress(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv(envVPCCIDR, "10.0.0.0/16")
+
+	snd := newSNDWithTCP()
+	node := newChildNodeWithSND("validators-0", "default", snd)
+	node.Status.ExternalAddress = "previous.nlb.aws:26656"
+
+	// Service exists with NO ingress entries (transient absence).
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p2pServiceName(node),
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 26656, Protocol: corev1.ProtocolTCP}},
+		},
+	}
+
+	r, _ := newNodeReconciler(t, node, snd, svc)
+	ctx := context.Background()
+
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse())
+	g.Expect(node.Status.ExternalAddress).To(Equal("previous.nlb.aws:26656"),
+		"empty-host guard must preserve previous ExternalAddress on transient absence")
+}
+
+// TestReconcileExternalAddress_PodInsideCIDR_Stamps confirms the
+// affirmative-routability case: pod IP inside VPC CIDR → Service stamped.
+func TestReconcileExternalAddress_PodInsideCIDR_Stamps(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv(envVPCCIDR, "10.0.0.0/16")
+
+	snd := newSNDWithTCP()
+	node := newChildNodeWithSND("validators-0", "default", snd)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "validators-0-0", Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: "10.0.5.5"}, // inside 10.0.0.0/16
+	}
+
+	r, c := newNodeReconciler(t, node, snd, pod)
+	ctx := context.Background()
+
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeFalse(), "hostname not yet populated")
+
+	svc := &corev1.Service{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: p2pServiceName(node), Namespace: "default"}, svc)).To(Succeed())
+}
+
+// TestReconcileExternalAddress_ParentSNDNotFound covers a race: the
+// child SeiNode persists with an owner-ref to an SND that no longer
+// exists (e.g., GC lag). Controller treats this as standalone (opt-out).
+func TestReconcileExternalAddress_ParentSNDNotFound(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv(envVPCCIDR, "10.0.0.0/16")
+
+	snd := newSNDWithTCP()
+	node := newChildNodeWithSND("orphan-0", "default", snd)
+	// Do NOT add snd to the fake client — simulate the parent gone.
+
+	r, c := newNodeReconciler(t, node)
+	ctx := context.Background()
+
+	ready, err := r.reconcileExternalAddress(ctx, node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ready).To(BeTrue(),
+		"parent SND missing: behave like standalone (opt-out), gate open")
+
+	// No Service.
+	svc := &corev1.Service{}
+	err = c.Get(ctx, types.NamespacedName{Name: p2pServiceName(node), Namespace: "default"}, svc)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+}
+
+// TestMapSNDToChildSeiNodes asserts the SND→child mapper enqueues only
+// SeiNodes whose controller owner-ref UID matches the changed SND.
+func TestMapSNDToChildSeiNodes(t *testing.T) {
+	g := NewWithT(t)
+
+	snd := newSNDWithTCP()
+	otherSND := &seiv1alpha1.SeiNodeDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "others", Namespace: "default", UID: types.UID("other-uid")},
+	}
+
+	childA := newChildNodeWithSND("validators-0", "default", snd)
+	childB := newChildNodeWithSND("validators-1", "default", snd)
+	otherChild := newChildNodeWithSND("others-0", "default", otherSND)
+	standalone := &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "standalone", Namespace: "default"},
+		Spec: seiv1alpha1.SeiNodeSpec{
+			ChainID: "test-1", Image: "sei:latest", FullNode: &seiv1alpha1.FullNodeSpec{},
+		},
+	}
+
+	r, _ := newNodeReconciler(t, snd, otherSND, childA, childB, otherChild, standalone)
+
+	reqs := r.mapSNDToChildSeiNodes(context.Background(), snd)
+	g.Expect(reqs).To(HaveLen(2))
+
+	names := make([]string, 0, len(reqs))
+	for _, req := range reqs {
+		names = append(names, req.Name)
+	}
+	g.Expect(names).To(ConsistOf("validators-0", "validators-1"))
+}
+
+// Defensive: confirm the mapper handles non-SND objects without
+// panicking. The handler.EnqueueRequestsFromMapFunc signature accepts
+// any client.Object so a misconfigured Watches could feed something
+// unexpected; we silently no-op rather than crashing the controller.
+func TestMapSNDToChildSeiNodes_NonSNDObject(t *testing.T) {
+	g := NewWithT(t)
+	r, _ := newNodeReconciler(t)
+	reqs := r.mapSNDToChildSeiNodes(context.Background(), &corev1.ConfigMap{})
+	g.Expect(reqs).To(BeNil())
+}
+
+// Compile-time sanity: client typing of generateP2PService matches what
+// the reconciler's SetControllerReference + Patch path expects.
+var _ client.Object = &corev1.Service{}

--- a/internal/controller/nodedeployment/envtest/fixtures/snd.go
+++ b/internal/controller/nodedeployment/envtest/fixtures/snd.go
@@ -82,3 +82,16 @@ func WithValidator() Option {
 		snd.Spec.Template.Spec.Validator = &seiv1alpha1.ValidatorSpec{}
 	}
 }
+
+// WithPublishableP2P enables the per-pod L4 NLB (Networking.TCP) on the
+// SND. Used by tests that exercise the SeiNode controller's
+// reconcileExternalAddress path. Composable with WithNetworking when an
+// SND wants both HTTP routes and per-pod NLB exposure.
+func WithPublishableP2P() Option {
+	return func(snd *seiv1alpha1.SeiNodeDeployment) {
+		if snd.Spec.Networking == nil {
+			snd.Spec.Networking = &seiv1alpha1.NetworkingConfig{}
+		}
+		snd.Spec.Networking.TCP = &seiv1alpha1.TCPConfig{}
+	}
+}

--- a/internal/controller/nodedeployment/envtest/publishable_p2p_test.go
+++ b/internal/controller/nodedeployment/envtest/publishable_p2p_test.go
@@ -1,0 +1,184 @@
+//go:build envtest
+
+package envtest_test
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
+)
+
+// testVPCCIDR is the VPC CIDR the publishable-p2p tests configure via
+// SEI_VPC_CIDR. The fake-pod IPs the tests stamp must fall inside it
+// to clear the routability gate. envtest has no kube-controller-manager
+// so we set podIP manually after the controller creates the STS.
+const testVPCCIDR = "10.0.0.0/16"
+
+// TestPublishableP2P_HoldsGateUntilHostnamePopulates is the bootstrap-
+// gate happy path. With Networking.TCP set:
+//
+//  1. The SeiNode controller stamps a per-pod LB Service named
+//     "<seinode>-p2p" — but does NOT create a StatefulSet yet.
+//  2. After we patch the Service's status.loadBalancer.ingress with a
+//     fake NLB hostname, the next reconcile writes Status.ExternalAddress
+//     in bare host:port form and the StatefulSet appears.
+//  3. Removing Networking.TCP from the SND clears Status.ExternalAddress
+//     and deletes the per-pod Service (opt-out cleanup).
+//
+// The test isolates SEI_VPC_CIDR to itself via t.Setenv so unrelated
+// envtests aren't affected by the fail-closed env var.
+func TestPublishableP2P_HoldsGateUntilHostnamePopulates(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("SEI_VPC_CIDR", testVPCCIDR)
+	ns := makeNamespace(t)
+
+	snd := fixtures.NewSND(ns, "validators",
+		fixtures.WithReplicas(1),
+		fixtures.WithValidator(),
+		fixtures.WithPublishableP2P(),
+	)
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	// 1. Child SeiNode appears.
+	var child *seiv1alpha1.SeiNode
+	waitFor(t, func() bool {
+		kids := listChildren(t, snd)
+		if len(kids) != 1 {
+			return false
+		}
+		child = &kids[0]
+		return true
+	}, "child SeiNode created")
+
+	// 2. The per-pod LB Service exists with the publishable shape.
+	p2pSvcName := child.Name + "-p2p"
+	waitFor(t, func() bool {
+		svc := &corev1.Service{}
+		return testCli.Get(testCtx, types.NamespacedName{
+			Name:      p2pSvcName,
+			Namespace: ns,
+		}, svc) == nil
+	}, "per-pod p2p Service "+p2pSvcName+" created")
+
+	svc := &corev1.Service{}
+	g.Expect(testCli.Get(testCtx, types.NamespacedName{Name: p2pSvcName, Namespace: ns}, svc)).To(Succeed())
+	g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+	g.Expect(svc.Spec.ExternalTrafficPolicy).To(Equal(corev1.ServiceExternalTrafficPolicyLocal))
+	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(
+		"statefulset.kubernetes.io/pod-name", child.Name+"-0"))
+	g.Expect(svc.Spec.Ports).To(HaveLen(1))
+	g.Expect(svc.Spec.Ports[0].Port).To(Equal(int32(26656)))
+	g.Expect(svc.Annotations).To(HaveKeyWithValue(
+		"service.beta.kubernetes.io/aws-load-balancer-type", "nlb"))
+
+	// Owner-ref points at the SeiNode (controller=true) so the existing
+	// Owns(&Service{}) watch fires on status updates.
+	refs := svc.GetOwnerReferences()
+	g.Expect(refs).To(HaveLen(1))
+	g.Expect(refs[0].UID).To(Equal(child.UID))
+	g.Expect(refs[0].Controller).NotTo(BeNil())
+	g.Expect(*refs[0].Controller).To(BeTrue())
+
+	// 3. PublishableReady condition surfaces ServiceProvisioning while
+	//    the LB hostname is unpopulated.
+	waitFor(t, func() bool {
+		latest := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, client.ObjectKeyFromObject(child), latest); err != nil {
+			return false
+		}
+		c := apimeta.FindStatusCondition(latest.Status.Conditions, seiv1alpha1.ConditionPublishableReady)
+		return c != nil && c.Status == metav1.ConditionFalse && c.Reason == seiv1alpha1.ReasonServiceProvisioning
+	}, "PublishableReady=False/ServiceProvisioning while gate held")
+
+	// 4. CRITICAL: no StatefulSet exists yet. The gate must hold STS
+	//    creation until the NLB hostname populates.
+	g.Consistently(func() bool {
+		sts := &appsv1.StatefulSet{}
+		err := testCli.Get(testCtx, types.NamespacedName{Name: child.Name, Namespace: ns}, sts)
+		return apierrors.IsNotFound(err)
+	}, "2s", "200ms").Should(BeTrue(),
+		"StatefulSet must NOT be created while publishable gate is closed")
+
+	// 5. Patch the Service's loadBalancer.ingress with a fake NLB
+	//    hostname. controller-runtime envtest gives us a real apiserver
+	//    that honors a /status subresource patch on Services.
+	patchBase := svc.DeepCopy()
+	svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{
+		Hostname: "abc.nlb.us-east-1.amazonaws.com",
+	}}
+	g.Expect(testCli.Status().Patch(testCtx, svc, client.MergeFrom(patchBase))).To(Succeed())
+
+	// 6. Status.ExternalAddress populates with bare host:port form.
+	waitForChildExternalAddress(t, child, "abc.nlb.us-east-1.amazonaws.com:26656")
+
+	// 7. PublishableReady transitions to True/ExternalAddressReady.
+	waitFor(t, func() bool {
+		latest := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, client.ObjectKeyFromObject(child), latest); err != nil {
+			return false
+		}
+		c := apimeta.FindStatusCondition(latest.Status.Conditions, seiv1alpha1.ConditionPublishableReady)
+		return c != nil && c.Status == metav1.ConditionTrue && c.Reason == seiv1alpha1.ReasonExternalAddressReady
+	}, "PublishableReady=True/ExternalAddressReady after hostname populates")
+
+	// 8. StatefulSet now appears — gate is open.
+	waitFor(t, func() bool {
+		sts := &appsv1.StatefulSet{}
+		return testCli.Get(testCtx, types.NamespacedName{Name: child.Name, Namespace: ns}, sts) == nil
+	}, "StatefulSet created after gate opens")
+
+	// 9. Toggle Networking.TCP off — opt-out cleanup must remove the
+	//    per-pod Service and clear Status.ExternalAddress.
+	latestSND := getSND(t, client.ObjectKeyFromObject(snd))
+	sndPatch := client.MergeFrom(latestSND.DeepCopy())
+	latestSND.Spec.Networking.TCP = nil
+	g.Expect(testCli.Patch(testCtx, latestSND, sndPatch)).To(Succeed())
+
+	waitFor(t, func() bool {
+		latest := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, client.ObjectKeyFromObject(child), latest); err != nil {
+			return false
+		}
+		return latest.Status.ExternalAddress == ""
+	}, "Status.ExternalAddress clears on opt-out")
+
+	waitFor(t, func() bool {
+		check := &corev1.Service{}
+		err := testCli.Get(testCtx, types.NamespacedName{Name: p2pSvcName, Namespace: ns}, check)
+		return apierrors.IsNotFound(err)
+	}, "per-pod p2p Service deleted on opt-out")
+
+	// 10. PublishableReady stays present (always-present discipline)
+	//     and transitions to False/PublishableDisabled.
+	latestChild := &seiv1alpha1.SeiNode{}
+	g.Expect(testCli.Get(testCtx, client.ObjectKeyFromObject(child), latestChild)).To(Succeed())
+	cond := apimeta.FindStatusCondition(latestChild.Status.Conditions, seiv1alpha1.ConditionPublishableReady)
+	g.Expect(cond).NotTo(BeNil(), "PublishableReady must remain present after opt-out")
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(seiv1alpha1.ReasonPublishableDisabled))
+}
+
+// waitForChildExternalAddress polls until the child SeiNode's
+// Status.ExternalAddress equals want. Distinct from generic
+// waitForStatus so the failure message names the field directly.
+func waitForChildExternalAddress(t *testing.T, child *seiv1alpha1.SeiNode, want string) {
+	t.Helper()
+	waitFor(t, func() bool {
+		latest := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, client.ObjectKeyFromObject(child), latest); err != nil {
+			return false
+		}
+		return strings.EqualFold(latest.Status.ExternalAddress, want)
+	}, "Status.ExternalAddress == "+want)
+}

--- a/internal/controller/nodedeployment/networking.go
+++ b/internal/controller/nodedeployment/networking.go
@@ -43,7 +43,7 @@ type effectiveRoute struct {
 // is ready. Returns true when no routes are expected (private deployments,
 // validator mode).
 func (r *SeiNodeDeploymentReconciler) routeHostnameResolvable(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) bool {
-	if group.Spec.Networking == nil {
+	if !group.Spec.Networking.HTTPEnabled() {
 		return true
 	}
 	routes := resolveEffectiveRoutes(group, r.GatewayDomain, r.GatewayPublicDomain)
@@ -59,9 +59,13 @@ func (r *SeiNodeDeploymentReconciler) routeHostnameResolvable(ctx context.Contex
 }
 
 func (r *SeiNodeDeploymentReconciler) reconcileNetworking(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
-	if group.Spec.Networking == nil {
+	// HTTPEnabled treats nil-Networking and TCP-only (networking.tcp:{}
+	// without http) as HTTP disabled — both tear down HTTPRoutes + the
+	// internal ClusterIP Service. Legacy networking:{} preserves the
+	// implicit-HTTP-enabled behavior via the same accessor.
+	if !group.Spec.Networking.HTTPEnabled() {
 		setCondition(group, seiv1alpha1.ConditionNetworkingReady, metav1.ConditionFalse,
-			"NetworkingDisabled", "spec.networking is unset")
+			"NetworkingDisabled", "spec.networking does not enable HTTP exposure")
 		return r.deleteNetworkingResources(ctx, group)
 	}
 

--- a/internal/controller/nodedeployment/status.go
+++ b/internal/controller/nodedeployment/status.go
@@ -100,7 +100,9 @@ func computeGroupPhase(group *seiv1alpha1.SeiNodeDeployment, ready, desired int3
 }
 
 func (r *SeiNodeDeploymentReconciler) buildNetworkingStatus(group *seiv1alpha1.SeiNodeDeployment) *seiv1alpha1.NetworkingStatus {
-	if group.Spec.Networking == nil {
+	// NetworkingStatus tracks HTTP route hostnames only — when only TCP
+	// is enabled, no HTTP routes exist and the status block stays nil.
+	if !group.Spec.Networking.HTTPEnabled() {
 		return nil
 	}
 	routes := resolveEffectiveRoutes(group, r.GatewayDomain, r.GatewayPublicDomain)


### PR DESCRIPTION
## Summary

PR-2 of the publishable-P2P series (#360). PR-1 (#361) landed the contract; this PR wires the controller path that actually provisions the per-pod NLB Service and writes `Status.ExternalAddress`.

### What this PR delivers

**`internal/controller/node/external_address.go` (NEW)** — `reconcileExternalAddress` runs before `reconcileStatefulSet`:
- **Parent SND lookup** via `metav1.GetControllerOf` (single source of truth on `SND.Spec.Networking.TCP`, no field on `SeiNodeSpec`).
- **Opt-out path** — no TCP → delete Service, clear `Status.ExternalAddress`, `PublishableReady=False/PublishableDisabled`, gate=open.
- **Fail-closed when `SEI_VPC_CIDR` unset** — the safety net for harbor's Cilium CGNAT where `target-type: ip` can't route.
- **Pod-IP routability check** — pod outside CIDR → fail closed; pod absent (first reconcile) → stamp anyway, recheck next round.
- **Per-pod LB Service** server-side-applied with the AWS LBC contract (`type=nlb`, `scheme=internet-facing`, `nlb-target-type=ip`, `cross-zone-load-balancing-enabled=true`), TCP/26656, `externalTrafficPolicy: Local`, selector via `statefulset.kubernetes.io/pod-name=<seinode>-0`.
- **ExternalAddress writer** — `Service.Status.LoadBalancer.Ingress[0].Hostname` → `Status.ExternalAddress = "<host>:26656"`. **Empty-host guard:** don't clear on transient absence; only opt-out clears.

**`internal/controller/node/controller.go`** — gate call before `reconcileStatefulSet`; `Watches(&SeiNodeDeployment{})` with UID-filtered mapper so children re-reconcile when the parent toggles `Networking.TCP`; RBAC for `seinodedeployments` get/list/watch.

**`api/v1alpha1/seinode_types.go`** — `ConditionPublishableReady` + 5 reason constants.

**`internal/controller/nodedeployment/{networking,status}.go`** — three call sites migrated from `Networking == nil` to `!Networking.HTTPEnabled()`. Without this, manifests setting only `networking.tcp: {}` would spuriously stamp HTTPRoutes + ClusterIP from the SND reconciler.

### Backward compatibility

- `networking: nil` — unchanged.
- `networking: {}` — unchanged (HTTPEnabled=true via backcompat).
- `networking: { http: {} }` — unchanged (HTTPEnabled=true).
- `networking: { tcp: {} }` — **now correctly does NOT trigger HTTPRoutes** (was a latent bug after PR-1 if anyone set this).
- `networking: { http: {}, tcp: {} }` — both layers active.

### Test plan

- [x] 12 unit tests in `external_address_test.go` — standalone, opt-out, opt-out cleanup, VPC unset (fail-closed), pod outside CIDR (fail-closed), Service stamping + gate held closed, hostname populated, empty-host guard, mapper.
- [x] Envtest `TestPublishableP2P_HoldsGateUntilHostnamePopulates` — full bootstrap-gate happy path + opt-out cleanup transition.
- [x] `go test ./api/v1alpha1/... ./internal/...` — all green.
- [x] `make test-integration` — envtest suite green (59s).
- [x] `golangci-lint run ./internal/controller/node/... ./internal/controller/nodedeployment/... ./api/v1alpha1/...` — no new issues.
- [x] `make manifests generate` — no diff (no new CRD spec fields; new RBAC marker collapsed into existing role).
- [ ] CI on this PR.

### Out of scope (separate follow-ups)

- **`LabelPeerSource` resolver enhancement** — make it prefer `Status.ExternalAddress` over headless DNS when set (per the scope cut on #361). Tracked as part of #360.
- **Terraform SG opening** for `tcp/26656 from 0.0.0.0/0` — platform PR.
- **`SEI_VPC_CIDR` env var on `manager-patch.yaml`** — platform PR. Until that lands, the feature is inert (condition surfaces `VPCCIDRNotConfigured`, gate held closed). Safe to merge this PR independently.

### Refs

- Tracking issue: #360
- Design: `sei-protocol/platform` `docs/designs/sei-publishable-p2p-nlb.md`
- Prior PR (types contract): #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)
