### PR TITLE
fix(load-test/rpc): enable tx_index.indexer=kv

### DIFF
--- a/scenarios/load-test/rpc.yaml.tmpl
+++ b/scenarios/load-test/rpc.yaml.tmpl
@@ -14,6 +14,7 @@ spec:
             selector:
               sei.io/chain: "{{ .CHAIN_ID }}"
       overrides:
+        tx_index.indexer: kv
         storage.state_commit.write_mode: memiavl_only
         storage.state_store.write_mode: memiavl_only
   updateStrategy:


### PR DESCRIPTION
Chaos suite seiload logs showed a steady stream of `❌ timeout waiting for receipt for tx 0x...` even though the chain was committing transactions. Root cause: the load-test RPC template doesn't set `tx_index.indexer`, so seid doesn't index txs by hash and `eth_getTransactionReceipt` can't find them. release-test/rpc.yaml.tmpl has had this setting since inception.