### PR TITLE
fix(load-test/rpc): tune EVM RPC worker pool for chaos-suite tps

### DIFF
--- a/scenarios/load-test/rpc.yaml.tmpl
+++ b/scenarios/load-test/rpc.yaml.tmpl
@@ -16,5 +16,14 @@ spec:
       overrides:
         storage.state_commit.write_mode: memiavl_only
         storage.state_store.write_mode: memiavl_only
+        # EVM RPC worker pool tuning — defaults are min(64, NumCPU*2) workers
+        # and a 1000-deep queue, which saturates at seiload's 2-4k tps
+        # (send + receipt-poll fan-out) on a 4-vCPU pod. Receipt fetches
+        # then time out at the HTTP layer. See platform-engineer deep dive
+        # 2026-05-28: receipts ARE being written to sei-db receipt.db; the
+        # bottleneck is the EVM JSON-RPC dispatch layer, not storage.
+        evm.worker_pool_size: "32"
+        evm.worker_queue_size: "4000"
+        evm.max_tx_pool_txs: "10000"
   updateStrategy:
     type: InPlace


### PR DESCRIPTION
Replaces closed PR #363 (which was based on a falsified hypothesis). Source-cited platform-engineer deep dive confirmed:

- EVM receipts ARE being written (separate sei-db `receipt.db`, unconditional init)
- `tx_index.indexer=kv` is already the default for full nodes
- Real bottleneck: EVM RPC worker pool defaults (`min(64, NumCPU*2)` workers, 1000-deep queue) saturate at seiload's 2-4k tps on a 4-vCPU pod

This PR adds three overrides to the load-test RPC template:
- `evm.worker_pool_size: 32` (4× default at 4-vCPU)
- `evm.worker_queue_size: 4000` (4× default)
- `evm.max_tx_pool_txs: 10000` (10× default)

Validators untouched; only changes seiload-facing pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)