### PR TITLE
feat(load-test): optional MEMPOOL_SIZE override

### DIFF
--- a/scenarios/load-test/rpc.yaml.tmpl
+++ b/scenarios/load-test/rpc.yaml.tmpl
@@ -16,14 +16,15 @@ spec:
       overrides:
         storage.state_commit.write_mode: memiavl_only
         storage.state_store.write_mode: memiavl_only
-        # EVM RPC worker pool tuning — defaults are min(64, NumCPU*2) workers
-        # and a 1000-deep queue, which saturates at seiload's 2-4k tps
-        # (send + receipt-poll fan-out) on a 4-vCPU pod. Receipt fetches
-        # then time out at the HTTP layer. See platform-engineer deep dive
-        # 2026-05-28: receipts ARE being written to sei-db receipt.db; the
-        # bottleneck is the EVM JSON-RPC dispatch layer, not storage.
+        # EVM RPC worker pool tuning — defaults saturate at seiload's
+        # 2-4k tps on a 4-vCPU pod, causing eth_getTransactionReceipt
+        # to time out at the HTTP layer.
         evm.worker_pool_size: "32"
         evm.worker_queue_size: "4000"
         evm.max_tx_pool_txs: "10000"
+        {{- with (index . "MEMPOOL_SIZE") }}
+        mempool.size: "{{ . }}"
+        mempool.pending-size: "{{ . }}"
+        {{- end }}
   updateStrategy:
     type: InPlace

--- a/scenarios/load-test/rpc.yaml.tmpl
+++ b/scenarios/load-test/rpc.yaml.tmpl
@@ -24,7 +24,7 @@ spec:
         evm.max_tx_pool_txs: "10000"
         {{- with (index . "MEMPOOL_SIZE") }}
         mempool.size: "{{ . }}"
-        mempool.pending-size: "{{ . }}"
+        mempool.pending_size: "{{ . }}"
         {{- end }}
   updateStrategy:
     type: InPlace

--- a/scenarios/load-test/validator.yaml.tmpl
+++ b/scenarios/load-test/validator.yaml.tmpl
@@ -12,6 +12,10 @@ spec:
       overrides:
         storage.state_commit.write_mode: memiavl_only
         storage.state_store.write_mode: memiavl_only
+        {{- with (index . "MEMPOOL_SIZE") }}
+        mempool.size: "{{ . }}"
+        mempool.pending-size: "{{ . }}"
+        {{- end }}
   genesis:
     chainId: "{{ .CHAIN_ID }}"
   updateStrategy:

--- a/scenarios/load-test/validator.yaml.tmpl
+++ b/scenarios/load-test/validator.yaml.tmpl
@@ -14,7 +14,7 @@ spec:
         storage.state_store.write_mode: memiavl_only
         {{- with (index . "MEMPOOL_SIZE") }}
         mempool.size: "{{ . }}"
-        mempool.pending-size: "{{ . }}"
+        mempool.pending_size: "{{ . }}"
         {{- end }}
   genesis:
     chainId: "{{ .CHAIN_ID }}"


### PR DESCRIPTION
Adds optional `MEMPOOL_SIZE` template var to both load-test SND templates. Required for the chaos-mempool-capacity-pressure scenario being added to platform per design sei-protocol/platform#739.

When passed, sets both `mempool.size` and `mempool.pending-size` overrides. When omitted, seid defaults apply.