### PR TITLE
fix(snd): propagate Spec.Peers from SND template to existing child SeiNodes

### DIFF
--- a/internal/controller/nodedeployment/envtest/fixtures/snd.go
+++ b/internal/controller/nodedeployment/envtest/fixtures/snd.go
@@ -82,3 +82,10 @@ func WithValidator() Option {
 		snd.Spec.Template.Spec.Validator = &seiv1alpha1.ValidatorSpec{}
 	}
 }
+
+// WithPeers sets spec.template.spec.peers.
+func WithPeers(peers ...seiv1alpha1.PeerSource) Option {
+	return func(snd *seiv1alpha1.SeiNodeDeployment) {
+		snd.Spec.Template.Spec.Peers = peers
+	}
+}

--- a/internal/controller/nodedeployment/envtest/peers_propagation_test.go
+++ b/internal/controller/nodedeployment/envtest/peers_propagation_test.go
@@ -1,0 +1,107 @@
+//go:build envtest
+
+package envtest_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
+)
+
+// Live edit to SND.spec.template.spec.peers must reach the already-created
+// child. Regression for the silent-allow-list gap in ensureSeiNode.
+func TestPeersPropagation_AddSourceOnLiveSND(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	initial := []seiv1alpha1.PeerSource{
+		{EC2Tags: &seiv1alpha1.EC2TagsPeerSource{
+			Region: "eu-central-1",
+			Tags:   map[string]string{"ChainIdentifier": "pacific-1", "Component": "state-syncer"},
+		}},
+	}
+	snd := fixtures.NewSND(ns, "peers-add",
+		fixtures.WithReplicas(1),
+		fixtures.WithPeers(initial...),
+	)
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	childKey := types.NamespacedName{Name: snd.Name + "-0", Namespace: ns}
+	waitFor(t, func() bool {
+		child := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, childKey, child); err != nil {
+			return false
+		}
+		return len(child.Spec.Peers) == 1
+	}, "child converged with initial peer set")
+
+	// Live edit: add a LabelPeerSource (the platform#759 shape).
+	g.Eventually(func() error {
+		latest := getSND(t, client.ObjectKeyFromObject(snd))
+		patch := client.MergeFrom(latest.DeepCopy())
+		latest.Spec.Template.Spec.Peers = append(latest.Spec.Template.Spec.Peers,
+			seiv1alpha1.PeerSource{Label: &seiv1alpha1.LabelPeerSource{
+				Namespace: ns,
+				Selector:  map[string]string{"sei.io/chain": "pacific-1"},
+			}})
+		return testCli.Patch(testCtx, latest, patch)
+	}, 5*time.Second, 200*time.Millisecond).Should(Succeed())
+
+	waitFor(t, func() bool {
+		child := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, childKey, child); err != nil {
+			return false
+		}
+		if len(child.Spec.Peers) != 2 {
+			return false
+		}
+		return child.Spec.Peers[1].Label != nil &&
+			child.Spec.Peers[1].Label.Selector["sei.io/chain"] == "pacific-1"
+	}, "child Spec.Peers reflected the live SND peer-list addition")
+}
+
+// Removing a peer source on a live SND must propagate (shrink case).
+func TestPeersPropagation_RemoveSourceOnLiveSND(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	initial := []seiv1alpha1.PeerSource{
+		{EC2Tags: &seiv1alpha1.EC2TagsPeerSource{Region: "eu-central-1", Tags: map[string]string{"k": "v"}}},
+		{Label: &seiv1alpha1.LabelPeerSource{Namespace: ns, Selector: map[string]string{"k": "v"}}},
+	}
+	snd := fixtures.NewSND(ns, "peers-remove",
+		fixtures.WithReplicas(1),
+		fixtures.WithPeers(initial...),
+	)
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	childKey := types.NamespacedName{Name: snd.Name + "-0", Namespace: ns}
+	waitFor(t, func() bool {
+		child := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, childKey, child); err != nil {
+			return false
+		}
+		return len(child.Spec.Peers) == 2
+	}, "child converged with initial 2-source peer set")
+
+	g.Eventually(func() error {
+		latest := getSND(t, client.ObjectKeyFromObject(snd))
+		patch := client.MergeFrom(latest.DeepCopy())
+		latest.Spec.Template.Spec.Peers = latest.Spec.Template.Spec.Peers[:1]
+		return testCli.Patch(testCtx, latest, patch)
+	}, 5*time.Second, 200*time.Millisecond).Should(Succeed())
+
+	waitFor(t, func() bool {
+		child := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, childKey, child); err != nil {
+			return false
+		}
+		return len(child.Spec.Peers) == 1 && child.Spec.Peers[0].EC2Tags != nil
+	}, "child Spec.Peers shrunk to match the live SND")
+}

--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -217,6 +218,14 @@ func (r *SeiNodeDeploymentReconciler) ensureSeiNode(ctx context.Context, group *
 	}
 	if !maps.Equal(existing.Spec.PodLabels, desired.Spec.PodLabels) {
 		existing.Spec.PodLabels = desired.Spec.PodLabels
+		updated = true
+	}
+	// Peers are intentionally in-place propagatable (templateHash godoc
+	// in labels.go). Semantic.DeepEqual treats nil and empty maps/slices
+	// as equal — etcd round-trips normalize empties to nil, so reflect
+	// would spuriously diff after the first reconcile post-restart.
+	if !equality.Semantic.DeepEqual(existing.Spec.Peers, desired.Spec.Peers) {
+		existing.Spec.Peers = desired.Spec.Peers
 		updated = true
 	}
 	if existing.Spec.ExternalAddress != desired.Spec.ExternalAddress {

--- a/internal/controller/nodedeployment/nodes_test.go
+++ b/internal/controller/nodedeployment/nodes_test.go
@@ -1,15 +1,19 @@
 package nodedeployment
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 )
+
+const testSyncerOrd0 = "syncer-0"
 
 func newTestGroup(name, namespace string) *seiv1alpha1.SeiNodeDeployment {
 	return &seiv1alpha1.SeiNodeDeployment{
@@ -397,4 +401,97 @@ func TestSetGenesisCeremonyCondition(t *testing.T) {
 			g.Expect(cond.Reason).To(Equal(tc.wantReason))
 		})
 	}
+}
+
+// Adding a peer source to an existing SND must reach the child.
+func TestEnsureSeiNode_PropagatesPeersOnUpdate(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	group := newTestGroup("syncer", "pacific-1")
+	group.Spec.Template.Spec.Peers = []seiv1alpha1.PeerSource{
+		{EC2Tags: &seiv1alpha1.EC2TagsPeerSource{
+			Region: "eu-central-1",
+			Tags:   map[string]string{"ChainIdentifier": "pacific-1", "Component": "state-syncer"},
+		}},
+	}
+
+	r := newPlanTestReconciler(t, group)
+
+	// First reconcile: child created with the EC2Tags-only spec.
+	g.Expect(r.ensureSeiNode(ctx, group, 0)).To(Succeed())
+
+	child := &seiv1alpha1.SeiNode{}
+	childKey := types.NamespacedName{Name: testSyncerOrd0, Namespace: "pacific-1"}
+	g.Expect(r.Get(ctx, childKey, child)).To(Succeed())
+	g.Expect(child.Spec.Peers).To(HaveLen(1))
+
+	// SND template gains a LabelPeerSource (the platform#759 shape).
+	group.Spec.Template.Spec.Peers = append(group.Spec.Template.Spec.Peers,
+		seiv1alpha1.PeerSource{Label: &seiv1alpha1.LabelPeerSource{
+			Namespace: "pacific-1",
+			Selector:  map[string]string{"sei.io/chain": "pacific-1"},
+		}})
+
+	// Second reconcile: the new peer source must propagate to the
+	// already-existing child.
+	g.Expect(r.ensureSeiNode(ctx, group, 0)).To(Succeed())
+
+	g.Expect(r.Get(ctx, childKey, child)).To(Succeed())
+	g.Expect(child.Spec.Peers).To(HaveLen(2),
+		"existing child Spec.Peers must reflect SND template additions")
+	g.Expect(child.Spec.Peers[1].Label).NotTo(BeNil(),
+		"second entry must be the newly-added LabelPeerSource")
+	g.Expect(child.Spec.Peers[1].Label.Selector).To(Equal(map[string]string{"sei.io/chain": "pacific-1"}))
+}
+
+// Removing a peer source from the SND must also propagate (proves the
+// diff captures shrink, not just grow).
+func TestEnsureSeiNode_PropagatesPeerRemoval(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	group := newTestGroup("syncer", "pacific-1")
+	group.Spec.Template.Spec.Peers = []seiv1alpha1.PeerSource{
+		{EC2Tags: &seiv1alpha1.EC2TagsPeerSource{Region: "eu-central-1", Tags: map[string]string{"k": "v"}}},
+		{Label: &seiv1alpha1.LabelPeerSource{Namespace: "pacific-1", Selector: map[string]string{"k": "v"}}},
+	}
+
+	r := newPlanTestReconciler(t, group)
+	g.Expect(r.ensureSeiNode(ctx, group, 0)).To(Succeed())
+
+	// Drop the label entry from the SND template.
+	group.Spec.Template.Spec.Peers = group.Spec.Template.Spec.Peers[:1]
+	g.Expect(r.ensureSeiNode(ctx, group, 0)).To(Succeed())
+
+	child := &seiv1alpha1.SeiNode{}
+	g.Expect(r.Get(ctx, types.NamespacedName{Name: testSyncerOrd0, Namespace: "pacific-1"}, child)).To(Succeed())
+	g.Expect(child.Spec.Peers).To(HaveLen(1))
+	g.Expect(child.Spec.Peers[0].EC2Tags).NotTo(BeNil())
+	g.Expect(child.Spec.Peers[0].Label).To(BeNil())
+}
+
+// No-op reconcile path: identical SND template across two reconciles
+// should not trigger a child Update (no resourceVersion bump).
+func TestEnsureSeiNode_PeersNoOpWhenUnchanged(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	group := newTestGroup("syncer", "pacific-1")
+	group.Spec.Template.Spec.Peers = []seiv1alpha1.PeerSource{
+		{Label: &seiv1alpha1.LabelPeerSource{Namespace: "pacific-1", Selector: map[string]string{"k": "v"}}},
+	}
+
+	r := newPlanTestReconciler(t, group)
+	g.Expect(r.ensureSeiNode(ctx, group, 0)).To(Succeed())
+
+	child := &seiv1alpha1.SeiNode{}
+	childKey := types.NamespacedName{Name: testSyncerOrd0, Namespace: "pacific-1"}
+	g.Expect(r.Get(ctx, childKey, child)).To(Succeed())
+	rvBefore := child.ResourceVersion
+
+	g.Expect(r.ensureSeiNode(ctx, group, 0)).To(Succeed())
+	g.Expect(r.Get(ctx, childKey, child)).To(Succeed())
+	g.Expect(child.ResourceVersion).To(Equal(rvBefore),
+		"no-op reconcile must not bump resourceVersion")
 }


### PR DESCRIPTION
## Summary

`ensureSeiNode` only propagated `Spec.Peers` from `SND.spec.template.spec` on the **create-path** (via `generateSeiNode`'s deep copy). The **update-path** used an allow-list of fields to diff and re-apply — `Labels`, `Annotations`, `Spec.Image`, `Spec.Sidecar`, `Spec.PodLabels`, `Spec.ExternalAddress` — and `Spec.Peers` was silently missing.

This contradicted the existing `templateHash` godoc in `labels.go:85-97`, which explicitly states peers "propagate in-place via ensureSeiNode" and so are excluded from the hash. **Adding a peer source to a live SND** (e.g. platform#759 adding a `LabelPeerSource` to existing Harbor syncers) appeared to work at the SND CR but never reached the child SeiNodes — their `spec.peers` stayed frozen at child-creation time, the resolver kept re-emitting the stale list, and `Status.ResolvedPeers` never picked up new sources.

## Fix

Add a `Spec.Peers` diff/update branch between `PodLabels` and `ExternalAddress` in `ensureSeiNode`, using `equality.Semantic.DeepEqual` (so etcd nil/empty round-trips don't churn the diff):

```go
// Peers are intentionally in-place propagatable (templateHash godoc
// in labels.go). Semantic.DeepEqual treats nil and empty maps/slices
// as equal — etcd round-trips normalize empties to nil, so reflect
// would spuriously diff after the first reconcile post-restart.
if !equality.Semantic.DeepEqual(existing.Spec.Peers, desired.Spec.Peers) {
    existing.Spec.Peers = desired.Spec.Peers
    updated = true
}
```

## Coral cross-review

Both kubernetes-specialist and platform-engineer voted GO independently. Validated load-bearing concern: **does this fix open a deployment-trigger feedback loop via live resolver fluctuations?**

- `detectDeploymentNeeded` (nodes.go:108) gates on `templateHash`, which hashes only ChainID + Image + Sidecar.Image. **Peers are excluded by design.**
- `childPhaseChangedPredicate` (predicates.go:18-38) filters out status-only updates — pure `Status.ResolvedPeers` churn on a child does NOT enqueue the SND.
- The `Update()` only fires when `SND.spec.peers != child.spec.peers` — i.e., a human/Flux edit, not a resolver fluctuation.

No loop. Fix completes the contract the `templateHash` godoc already promised.

## Test coverage

**Unit (`nodes_test.go`):**
- `TestEnsureSeiNode_PropagatesPeersOnUpdate` — adds a LabelPeerSource to a live SND, asserts the child carries 2 entries.
- `TestEnsureSeiNode_PropagatesPeerRemoval` — shrinks the source list, asserts the child shrinks too.
- `TestEnsureSeiNode_PeersNoOpWhenUnchanged` — identical template across reconciles must not bump `resourceVersion`.

**Envtest (`envtest/peers_propagation_test.go`):**
- `TestPeersPropagation_AddSourceOnLiveSND` — live patch against a real apiserver.
- `TestPeersPropagation_RemoveSourceOnLiveSND` — shrink case end-to-end.

**Fixture:** `fixtures.WithPeers(...)` added to envtest fixtures package.

## Genesis interaction (analyzed, not a concern)

`task/genesis_peers.go:92` writes `child.Spec.Peers = [{Static{cohort}}]` during the genesis ceremony. After this fix, the post-ceremony SND reconcile would revert that to the SND template's peers value.

Not a concern because:
1. `ensureSeiNode` is gated by `!ConditionPlanInProgress`, so my new branch doesn't fire during the active genesis plan.
2. The static cohort was bootstrap scaffolding, not a contract. Once the plan completes, the chain is live and CometBFT's runtime peer machinery (PEX, addrbook) handles membership — the template's normal peer sources take over for ongoing discovery.

The structural genesis pieces (the plan orchestration, S3 artifact distribution, per-validator genesis.json) are independent of `Spec.Peers` and unaffected by this fix.

## Test plan

- [x] Unit + envtest pass on CI.
- [x] After merge + image bump + Flux sync on harbor: `pacific-1/syncer-0-0` `spec.peers` shows all three sources (2 ec2Tags + 1 label); `Status.ResolvedPeers` populates with composed entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)