### PR TITLE
feat(snd/p2p): SEI_NLB_TARGET_TYPE env var for per-cluster target-type selection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -215,6 +215,16 @@ func main() {
 
 	p2pEndpointDomain := os.Getenv("SEI_P2P_ENDPOINT_DOMAIN")
 
+	nlbTargetType := os.Getenv("SEI_NLB_TARGET_TYPE")
+	switch nlbTargetType {
+	case "":
+		nlbTargetType = nodedeploymentcontroller.DefaultNLBTargetType
+	case nodedeploymentcontroller.NLBTargetTypeIP, nodedeploymentcontroller.NLBTargetTypeInstance:
+	default:
+		setupLog.Error(nil, "Invalid SEI_NLB_TARGET_TYPE — expected \"ip\" or \"instance\"", "value", nlbTargetType)
+		os.Exit(1)
+	}
+
 	//nolint:staticcheck // migrating to events.EventRecorder API is a separate effort
 	recorder := mgr.GetEventRecorderFor("seinodedeployment-controller")
 	if err := (&nodedeploymentcontroller.SeiNodeDeploymentReconciler{
@@ -226,6 +236,7 @@ func main() {
 		GatewayDomain:       platformCfg.GatewayDomain,
 		GatewayPublicDomain: platformCfg.GatewayPublicDomain,
 		P2PEndpointDomain:   p2pEndpointDomain,
+		NLBTargetType:       nlbTargetType,
 		PlanExecutor: &planner.Executor[*seiv1alpha1.SeiNodeDeployment]{
 			ConfigFor: func(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) task.ExecutionConfig {
 				var assemblerNode *seiv1alpha1.SeiNode

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -46,6 +46,15 @@ type SeiNodeDeploymentReconciler struct {
 	// from SEI_P2P_ENDPOINT_DOMAIN. Empty disables the P2P endpoint path.
 	P2PEndpointDomain string
 
+	// NLBTargetType picks the AWS NLB target mode for per-pod P2P endpoint
+	// Services. "ip" registers pod IPs directly — correct on VPC-CNI
+	// clusters (prod, dev). "instance" routes via NodePort — required on
+	// clusters where pod IPs aren't VPC-routable (e.g. harbor, where
+	// Cilium cluster-pool uses 100.64.0.0/14). Wired from SEI_NLB_TARGET_TYPE
+	// in cmd/main.go, which defaults the field to DefaultNLBTargetType
+	// when the env var is unset — the reconciler reads this field as-is.
+	NLBTargetType string
+
 	// PlanExecutor drives group-level task plans (e.g. genesis assembly).
 	PlanExecutor planner.PlanExecutor[*seiv1alpha1.SeiNodeDeployment]
 }

--- a/internal/controller/nodedeployment/p2p_endpoint.go
+++ b/internal/controller/nodedeployment/p2p_endpoint.go
@@ -35,8 +35,17 @@ const (
 	awsLBCrossZoneAnnotation   = "service.beta.kubernetes.io/aws-load-balancer-attributes"
 	awsLBTypeValue             = "external"
 	awsLBSchemeValue           = "internet-facing"
-	awsLBTargetTypeValue       = "ip"
 	awsLBCrossZoneAttributeStr = "load_balancing.cross_zone.enabled=true"
+
+	// NLBTargetTypeIP registers pod IPs directly with the NLB target group.
+	// Correct on VPC-CNI clusters where pod IPs are VPC-routable.
+	NLBTargetTypeIP = "ip"
+	// NLBTargetTypeInstance routes NLB traffic via the node's NodePort and
+	// relies on kube-proxy / Cilium socket-LB to forward to the pod.
+	// Required on clusters where pod IPs aren't VPC-routable.
+	NLBTargetTypeInstance = "instance"
+	// DefaultNLBTargetType matches the prior hardcoded behaviour.
+	DefaultNLBTargetType = NLBTargetTypeIP
 
 	p2pEndpointServiceSuffix = "-p2p"
 )
@@ -85,7 +94,7 @@ func p2pEndpointServiceName(group *seiv1alpha1.SeiNodeDeployment, ordinal int) s
 func (r *SeiNodeDeploymentReconciler) reconcileP2PEndpoints(ctx context.Context, group *seiv1alpha1.SeiNodeDeployment) error {
 	desiredNames := make(map[string]struct{}, group.Spec.Replicas)
 	for i := range int(group.Spec.Replicas) {
-		desired := generateP2PEndpointService(group, i, r.p2pEndpointHostname(group, i))
+		desired := generateP2PEndpointService(group, i, r.p2pEndpointHostname(group, i), r.NLBTargetType)
 		desired.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
 		if err := ctrl.SetControllerReference(group, desired, r.Scheme); err != nil {
 			return fmt.Errorf("setting owner reference on P2P endpoint Service %s: %w", desired.Name, err)
@@ -181,7 +190,7 @@ func (r *SeiNodeDeploymentReconciler) deleteP2PEndpointForOrdinal(ctx context.Co
 	return nil
 }
 
-func generateP2PEndpointService(group *seiv1alpha1.SeiNodeDeployment, ordinal int, hostname string) *corev1.Service {
+func generateP2PEndpointService(group *seiv1alpha1.SeiNodeDeployment, ordinal int, hostname, targetType string) *corev1.Service {
 	name := p2pEndpointServiceName(group, ordinal)
 	childName := seiNodeName(group, ordinal)
 
@@ -195,9 +204,20 @@ func generateP2PEndpointService(group *seiv1alpha1.SeiNodeDeployment, ordinal in
 		externalDNSHostnameAnnotation: hostname,
 		awsLBTypeAnnotation:           awsLBTypeValue,
 		awsLBSchemeAnnotation:         awsLBSchemeValue,
-		awsLBTargetTypeAnnotation:     awsLBTargetTypeValue,
+		awsLBTargetTypeAnnotation:     targetType,
 		awsLBCrossZoneAnnotation:      awsLBCrossZoneAttributeStr,
 		managedByAnnotation:           controllerName,
+	}
+
+	// target-type=ip registers pod IPs directly; NodePort is not used so
+	// we explicitly disable allocation to preserve the limited 30000-32767
+	// range. target-type=instance requires a NodePort for the NLB→node→pod
+	// hop (kube-proxy / Cilium socket-LB), so leave allocation at the
+	// kube default (true) by passing nil.
+	var allocateNodePorts *bool
+	if targetType == NLBTargetTypeIP {
+		f := false
+		allocateNodePorts = &f
 	}
 
 	return &corev1.Service{
@@ -210,7 +230,7 @@ func generateP2PEndpointService(group *seiv1alpha1.SeiNodeDeployment, ordinal in
 		Spec: corev1.ServiceSpec{
 			Type:                          corev1.ServiceTypeLoadBalancer,
 			ExternalTrafficPolicy:         corev1.ServiceExternalTrafficPolicyTypeLocal,
-			AllocateLoadBalancerNodePorts: new(bool),
+			AllocateLoadBalancerNodePorts: allocateNodePorts,
 			Selector: map[string]string{
 				noderesource.NodeLabel: childName,
 			},

--- a/internal/controller/nodedeployment/p2p_endpoint_test.go
+++ b/internal/controller/nodedeployment/p2p_endpoint_test.go
@@ -126,7 +126,7 @@ func TestGeneratePublishableService_Annotations(t *testing.T) {
 	snd := &seiv1alpha1.SeiNodeDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: testChainAtlantic, Namespace: "sei-test-1"},
 	}
-	svc := generateP2PEndpointService(snd, 0, "atlantic-2-0-p2p.atlantic-2.prod.platform.sei.io")
+	svc := generateP2PEndpointService(snd, 0, "atlantic-2-0-p2p.atlantic-2.prod.platform.sei.io", NLBTargetTypeIP)
 
 	g.Expect(svc.Annotations).To(HaveKeyWithValue(
 		"external-dns.alpha.kubernetes.io/hostname",
@@ -147,4 +147,24 @@ func TestGeneratePublishableService_Annotations(t *testing.T) {
 	g.Expect(svc.Spec.Ports).To(HaveLen(1))
 	g.Expect(svc.Spec.Ports[0].Port).To(Equal(seiconfig.PortP2P))
 	g.Expect(svc.Spec.Selector).To(HaveKeyWithValue(noderesource.NodeLabel, "atlantic-2-0"))
+
+	// target-type=ip → NodePort allocation explicitly disabled (preserve
+	// the 30000-32767 range; pod IP is the NLB target, no NodePort hop).
+	g.Expect(svc.Spec.AllocateLoadBalancerNodePorts).NotTo(BeNil())
+	g.Expect(*svc.Spec.AllocateLoadBalancerNodePorts).To(BeFalse())
+}
+
+func TestGeneratePublishableService_InstanceTargetType(t *testing.T) {
+	g := NewWithT(t)
+	snd := &seiv1alpha1.SeiNodeDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: testChainAtlantic, Namespace: "sei-test-1"},
+	}
+	svc := generateP2PEndpointService(snd, 0, "atlantic-2-0-p2p.atlantic-2.harbor.platform.sei.io", NLBTargetTypeInstance)
+
+	g.Expect(svc.Annotations).To(HaveKeyWithValue(
+		"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type", "instance"))
+
+	// target-type=instance needs a NodePort for the NLB→node→pod hop.
+	// Leaving the field nil lets kube default to true.
+	g.Expect(svc.Spec.AllocateLoadBalancerNodePorts).To(BeNil())
 }


### PR DESCRIPTION
## Summary

The per-pod P2P endpoint Service (PR #365) previously hardcoded `service.beta.kubernetes.io/aws-load-balancer-nlb-target-type=ip`. That's the right call on VPC-CNI clusters (prod, dev) where pod IPs are VPC-routable — but it's a hard blocker on harbor, where Cilium cluster-pool puts pods in `100.64.0.0/14` (CGNAT, unreachable from any NLB in a VPC subnet).

This PR adds a controller-level env var (`SEI_NLB_TARGET_TYPE`) so each overlay picks the right mode without baking cluster-specific logic into the controller.

## Behaviour

- `SEI_NLB_TARGET_TYPE=ip` (default) — pod IPs registered directly with the target group; `AllocateLoadBalancerNodePorts: false` so the limited 30000-32767 NodePort range is preserved.
- `SEI_NLB_TARGET_TYPE=instance` — NLB targets the EC2 node at its NodePort; `kube-proxy` / Cilium socket-LB does the NodePort→pod rewrite locally. `AllocateLoadBalancerNodePorts` left nil so kube allocates one.
- Anything else → controller logs `Invalid SEI_NLB_TARGET_TYPE` and exits 1 at startup.

Per-cluster value lives in each overlay's `manager-patch.yaml`, mirroring how `SEI_P2P_ENDPOINT_DOMAIN`, `SEI_GATEWAY_DOMAIN`, etc. are wired today.

## Validation + default placement

- Validation and default-resolution both happen at controller construction in `cmd/main.go`. The reconciler's `NLBTargetType` field is canonical — by the time any reconcile runs, the field is always either `ip` or `instance`.
- No per-reconcile branching, no "if empty" fallback in the hot path.

## Files

- `cmd/main.go` — env read + validation + default fill-in.
- `internal/controller/nodedeployment/controller.go` — new `NLBTargetType` field on `SeiNodeDeploymentReconciler`.
- `internal/controller/nodedeployment/p2p_endpoint.go` — exported constants `NLBTargetTypeIP`, `NLBTargetTypeInstance`, `DefaultNLBTargetType`. `generateP2PEndpointService` takes target-type as a parameter; `AllocateLoadBalancerNodePorts` gated on it.
- `internal/controller/nodedeployment/p2p_endpoint_test.go` — existing `ip` test asserts NodePort allocation disabled; new `TestGeneratePublishableService_InstanceTargetType` asserts the `instance` shape (annotation + nil-NodePort-allocation).

## Downstream

- **harbor overlay (platform repo)** — separate PR to add `SEI_NLB_TARGET_TYPE: instance` to `clusters/harbor/sei-k8s-controller/manager-patch.yaml`. After that lands and Flux applies, harbor's publishable-P2P Services will emit `target-type: instance` and the per-pod NLB → node:NodePort → Cilium-socket-LB → pod path becomes viable.
- **prod, dev** — no change; defaults to `ip` (current behaviour).

## One-way doors

- Env var name `SEI_NLB_TARGET_TYPE`. Once any overlay sets it, renaming is painful. Convention-matched to existing `SEI_*` env vars.

## Test plan

- [ ] Unit + lint pass on CI.
- [ ] Manual smoke after harbor's overlay PR: harbor syncer-0-0-p2p Service annotation = `instance`, NodePort allocated.
- [ ] Prod/dev unaffected (no overlay change → default `ip` → existing behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)