### PR TITLE
fix(envtest): default NLBTargetType to ip in suite reconciler

### DIFF
--- a/internal/controller/nodedeployment/envtest/suite_test.go
+++ b/internal/controller/nodedeployment/envtest/suite_test.go
@@ -208,6 +208,7 @@ func run(m *testing.M) (int, error) {
 		GatewayDomain:           "test.local",
 		GatewayPublicDomain:     "",
 		P2PEndpointDomain:       "",
+		NLBTargetType:           nodedeploymentcontroller.DefaultNLBTargetType,
 		PlanExecutor: &planner.Executor[*seiv1alpha1.SeiNodeDeployment]{
 			ConfigFor: func(_ context.Context, group *seiv1alpha1.SeiNodeDeployment) task.ExecutionConfig {
 				return task.ExecutionConfig{


### PR DESCRIPTION
## Summary

PR #372 introduced `SEI_NLB_TARGET_TYPE` with default-resolution centralised in `cmd/main.go` — the reconciler's `NLBTargetType` field is canonical, no per-reconcile fallback. The envtest suite (`internal/controller/nodedeployment/envtest/suite_test.go`) is a parallel "main" that constructs its own `SeiNodeDeploymentReconciler` and doesn't read the env var, so it landed with `NLBTargetType: ""`.

Result: `generateP2PEndpointService` stamped the target-type annotation with the empty string, and `TestP2PEndpointP2P_CreateWithTCP_ChildHasAddressAndServiceExists` failed asserting `aws-load-balancer-nlb-target-type=ip`.

## Fix

One-line: set `NLBTargetType: nodedeploymentcontroller.DefaultNLBTargetType` in the envtest suite, mirroring the cmd/main.go invariant.

## Verification

`make test-integration` passes locally with this change.

## Note on the ECR image at 6a4334e (PR #372 merge commit)

The ECR workflow built successfully despite the CI failure (separate workflow, doesn't gate on tests). The production code path is unaffected — cmd/main.go correctly defaults to `ip`. Only the envtest scaffolding was missing the same default. The image `6a4334e184ddbd34f183611b8824ad29559c19e3` is safe to deploy as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)