### PR TITLE
feat(planner): per-mode update plans with config-patch

### DIFF
--- a/internal/planner/archive.go
+++ b/internal/planner/archive.go
@@ -36,9 +36,8 @@ func (p *archiveNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.
 	return buildBasePlan(node, node.Spec.Peers, nil, intent)
 }
 
-// buildRunningPlan returns the day-2 plan for a Running archive node.
-// Same shape as full nodes (no extra validation gates) — see full.go's
-// buildRunningPlan for the rationale.
+// buildRunningPlan returns the update plan for a Running archive node.
+// Same shape as full nodes (no extra validation gates).
 func (p *archiveNodePlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if imageDrifted(node) {
 		prog := []string{
@@ -50,7 +49,7 @@ func (p *archiveNodePlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1
 			task.TaskTypeObserveImage,
 			TaskMarkReady,
 		}
-		return assembleDay2Plan(node, prog, externalAddressPatch(node))
+		return assembleUpdatePlan(node, prog, externalAddressPatch(node))
 	}
 	if sidecarNeedsReapproval(node) {
 		return buildMarkReadyPlan(node)

--- a/internal/planner/archive.go
+++ b/internal/planner/archive.go
@@ -28,10 +28,18 @@ func (p *archiveNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.
 	if node.Status.Phase == seiv1alpha1.PhaseRunning {
 		return buildRunningPlan(node)
 	}
-	return buildBasePlan(node, node.Spec.Peers, nil, &seiconfig.ConfigIntent{
+	params, err := p.BuildConfigIntent(node)
+	if err != nil {
+		return nil, err
+	}
+	return buildBasePlan(node, node.Spec.Peers, nil, params)
+}
+
+func (p *archiveNodePlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
+	return &seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeArchive,
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
-	})
+	}, nil
 }
 
 func (p *archiveNodePlanner) controllerOverrides(node *seiv1alpha1.SeiNode) map[string]string {

--- a/internal/planner/archive.go
+++ b/internal/planner/archive.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	seiconfig "github.com/sei-protocol/sei-config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/task"
@@ -40,6 +41,7 @@ func (p *archiveNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.
 // Same shape as full nodes (no extra validation gates).
 func (p *archiveNodePlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if imageDrifted(node) {
+		setNodeUpdateCondition(node, metav1.ConditionTrue, "UpdateStarted", imageDriftMessage(node))
 		prog := []string{
 			task.TaskTypeApplyStatefulSet,
 			task.TaskTypeApplyService,

--- a/internal/planner/archive.go
+++ b/internal/planner/archive.go
@@ -7,6 +7,7 @@ import (
 	seiconfig "github.com/sei-protocol/sei-config"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/task"
 )
 
 type archiveNodePlanner struct {
@@ -26,23 +27,35 @@ func (p *archiveNodePlanner) Validate(node *seiv1alpha1.SeiNode) error {
 
 func (p *archiveNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if node.Status.Phase == seiv1alpha1.PhaseRunning {
-		return buildRunningPlan(node)
+		return p.buildRunningPlan(node)
 	}
-	params, err := p.BuildConfigIntent(node)
-	if err != nil {
-		return nil, err
-	}
-	return buildBasePlan(node, node.Spec.Peers, nil, params)
-}
-
-func (p *archiveNodePlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
-	if node.Spec.Archive == nil {
-		return nil, fmt.Errorf("archive sub-spec is nil")
-	}
-	return &seiconfig.ConfigIntent{
+	intent := &seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeArchive,
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
-	}, nil
+	}
+	return buildBasePlan(node, node.Spec.Peers, nil, intent)
+}
+
+// buildRunningPlan returns the day-2 plan for a Running archive node.
+// Same shape as full nodes (no extra validation gates) — see full.go's
+// buildRunningPlan for the rationale.
+func (p *archiveNodePlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
+	if imageDrifted(node) {
+		prog := []string{
+			task.TaskTypeApplyStatefulSet,
+			task.TaskTypeApplyService,
+			TaskConfigPatch,
+			TaskConfigValidate,
+			task.TaskTypeReplacePod,
+			task.TaskTypeObserveImage,
+			TaskMarkReady,
+		}
+		return assembleDay2Plan(node, prog, externalAddressPatch(node))
+	}
+	if sidecarNeedsReapproval(node) {
+		return buildMarkReadyPlan(node)
+	}
+	return nil, nil
 }
 
 func (p *archiveNodePlanner) controllerOverrides(node *seiv1alpha1.SeiNode) map[string]string {

--- a/internal/planner/archive.go
+++ b/internal/planner/archive.go
@@ -36,6 +36,9 @@ func (p *archiveNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.
 }
 
 func (p *archiveNodePlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
+	if node.Spec.Archive == nil {
+		return nil, fmt.Errorf("archive sub-spec is nil")
+	}
 	return &seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeArchive,
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),

--- a/internal/planner/full.go
+++ b/internal/planner/full.go
@@ -44,6 +44,9 @@ func (p *fullNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 }
 
 func (p *fullNodePlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
+	if node.Spec.FullNode == nil {
+		return nil, fmt.Errorf("fullNode sub-spec is nil")
+	}
 	return &seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeFull,
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),

--- a/internal/planner/full.go
+++ b/internal/planner/full.go
@@ -33,14 +33,21 @@ func (p *fullNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 		return buildRunningPlan(node)
 	}
 	fn := node.Spec.FullNode
-	params := &seiconfig.ConfigIntent{
-		Mode:      seiconfig.ModeFull,
-		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
+	params, err := p.BuildConfigIntent(node)
+	if err != nil {
+		return nil, err
 	}
 	if NeedsBootstrap(node) {
 		return buildBootstrapPlan(node, node.Spec.Peers, fn.Snapshot, params)
 	}
 	return buildBasePlan(node, node.Spec.Peers, fn.Snapshot, params)
+}
+
+func (p *fullNodePlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
+	return &seiconfig.ConfigIntent{
+		Mode:      seiconfig.ModeFull,
+		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
+	}, nil
 }
 
 func (p *fullNodePlanner) controllerOverrides(node *seiv1alpha1.SeiNode) map[string]string {

--- a/internal/planner/full.go
+++ b/internal/planner/full.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	seiconfig "github.com/sei-protocol/sei-config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/task"
@@ -49,6 +50,7 @@ func (p *fullNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 // re-encode — the first config-patch erases operator-added comments.
 func (p *fullNodePlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if imageDrifted(node) {
+		setNodeUpdateCondition(node, metav1.ConditionTrue, "UpdateStarted", imageDriftMessage(node))
 		prog := []string{
 			task.TaskTypeApplyStatefulSet,
 			task.TaskTypeApplyService,

--- a/internal/planner/full.go
+++ b/internal/planner/full.go
@@ -6,6 +6,7 @@ import (
 	seiconfig "github.com/sei-protocol/sei-config"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/task"
 )
 
 type fullNodePlanner struct {
@@ -28,29 +29,53 @@ func (p *fullNodePlanner) Validate(node *seiv1alpha1.SeiNode) error {
 	return nil
 }
 
+// BuildPlan dispatches between startup (init/bootstrap) and existing-resource
+// (day-2) shapes. Reconciler/executor just call this and get a plan; the
+// startup-vs-day-2 distinction stays inside the planner.
 func (p *fullNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if node.Status.Phase == seiv1alpha1.PhaseRunning {
-		return buildRunningPlan(node)
+		return p.buildRunningPlan(node)
 	}
 	fn := node.Spec.FullNode
-	params, err := p.BuildConfigIntent(node)
-	if err != nil {
-		return nil, err
-	}
-	if NeedsBootstrap(node) {
-		return buildBootstrapPlan(node, node.Spec.Peers, fn.Snapshot, params)
-	}
-	return buildBasePlan(node, node.Spec.Peers, fn.Snapshot, params)
-}
-
-func (p *fullNodePlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
-	if node.Spec.FullNode == nil {
-		return nil, fmt.Errorf("fullNode sub-spec is nil")
-	}
-	return &seiconfig.ConfigIntent{
+	intent := &seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeFull,
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
-	}, nil
+	}
+	if NeedsBootstrap(node) {
+		return buildBootstrapPlan(node, node.Spec.Peers, fn.Snapshot, intent)
+	}
+	return buildBasePlan(node, node.Spec.Peers, fn.Snapshot, intent)
+}
+
+// buildRunningPlan returns the day-2 plan for a Running full node, or
+// nil if no drift. Image drift queues a config-patch + pod-cycle plan;
+// sidecar reapproval queues a one-task mark-ready plan.
+//
+// The day-2 patch stamps only the keys the controller directly owns
+// (currently p2p.external-address for publishable P2P). TaskConfigPatch
+// is a generic TOML merge — no sei-config involvement, no forced overrides,
+// no mode-defaulted backfill. TaskConfigValidate after the patch is the
+// parser-level gate.
+//
+// Note: pelletier/go-toml/v2 does not preserve comments or key ordering
+// on re-encode, so the first day-2 patch erases operator-added comments.
+func (p *fullNodePlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
+	if imageDrifted(node) {
+		prog := []string{
+			task.TaskTypeApplyStatefulSet,
+			task.TaskTypeApplyService,
+			TaskConfigPatch,
+			TaskConfigValidate,
+			task.TaskTypeReplacePod,
+			task.TaskTypeObserveImage,
+			TaskMarkReady,
+		}
+		return assembleDay2Plan(node, prog, externalAddressPatch(node))
+	}
+	if sidecarNeedsReapproval(node) {
+		return buildMarkReadyPlan(node)
+	}
+	return nil, nil
 }
 
 func (p *fullNodePlanner) controllerOverrides(node *seiv1alpha1.SeiNode) map[string]string {

--- a/internal/planner/full.go
+++ b/internal/planner/full.go
@@ -29,9 +29,6 @@ func (p *fullNodePlanner) Validate(node *seiv1alpha1.SeiNode) error {
 	return nil
 }
 
-// BuildPlan dispatches between startup (init/bootstrap) and existing-resource
-// (day-2) shapes. Reconciler/executor just call this and get a plan; the
-// startup-vs-day-2 distinction stays inside the planner.
 func (p *fullNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if node.Status.Phase == seiv1alpha1.PhaseRunning {
 		return p.buildRunningPlan(node)
@@ -47,18 +44,9 @@ func (p *fullNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 	return buildBasePlan(node, node.Spec.Peers, fn.Snapshot, intent)
 }
 
-// buildRunningPlan returns the day-2 plan for a Running full node, or
-// nil if no drift. Image drift queues a config-patch + pod-cycle plan;
-// sidecar reapproval queues a one-task mark-ready plan.
-//
-// The day-2 patch stamps only the keys the controller directly owns
-// (currently p2p.external-address for publishable P2P). TaskConfigPatch
-// is a generic TOML merge — no sei-config involvement, no forced overrides,
-// no mode-defaulted backfill. TaskConfigValidate after the patch is the
-// parser-level gate.
-//
-// Note: pelletier/go-toml/v2 does not preserve comments or key ordering
-// on re-encode, so the first day-2 patch erases operator-added comments.
+// buildRunningPlan returns the update plan for a Running full node, or
+// nil if no drift. pelletier/go-toml/v2 does not preserve comments on
+// re-encode — the first config-patch erases operator-added comments.
 func (p *fullNodePlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if imageDrifted(node) {
 		prog := []string{
@@ -70,7 +58,7 @@ func (p *fullNodePlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alp
 			task.TaskTypeObserveImage,
 			TaskMarkReady,
 		}
-		return assembleDay2Plan(node, prog, externalAddressPatch(node))
+		return assembleUpdatePlan(node, prog, externalAddressPatch(node))
 	}
 	if sidecarNeedsReapproval(node) {
 		return buildMarkReadyPlan(node)

--- a/internal/planner/node_update_test.go
+++ b/internal/planner/node_update_test.go
@@ -1,10 +1,12 @@
 package planner
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	seiconfig "github.com/sei-protocol/sei-config"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -68,6 +70,8 @@ func TestBuildRunningPlan_ImageDrift_ReturnsNodeUpdatePlan(t *testing.T) {
 	want := []string{
 		task.TaskTypeApplyStatefulSet,
 		task.TaskTypeApplyService,
+		TaskConfigApply,
+		TaskConfigValidate,
 		task.TaskTypeReplacePod,
 		task.TaskTypeObserveImage,
 		TaskMarkReady,
@@ -79,6 +83,114 @@ func TestBuildRunningPlan_ImageDrift_ReturnsNodeUpdatePlan(t *testing.T) {
 		g.Expect(pt.Status).To(Equal(seiv1alpha1.TaskPending), "task %s should start Pending", pt.Type)
 		g.Expect(pt.ID).NotTo(BeEmpty(), "task %s should have an ID", pt.Type)
 		g.Expect(pt.Params).NotTo(BeNil(), "task %s should have params", pt.Type)
+	}
+}
+
+// configIntentFromPlan finds the config-apply task and unmarshals its
+// params back into a ConfigIntent for inspection.
+func configIntentFromPlan(t *testing.T, plan *seiv1alpha1.TaskPlan) *seiconfig.ConfigIntent {
+	t.Helper()
+	g := NewWithT(t)
+	for _, pt := range plan.Tasks {
+		if pt.Type != TaskConfigApply {
+			continue
+		}
+		g.Expect(pt.Params).NotTo(BeNil())
+		var intent seiconfig.ConfigIntent
+		g.Expect(json.Unmarshal(pt.Params.Raw, &intent)).To(Succeed())
+		return &intent
+	}
+	t.Fatal("plan has no config-apply task")
+	return nil
+}
+
+// The day-2 config-apply must carry the mode planner's full ConfigIntent —
+// non-empty Mode, Overrides containing the controller-managed keys —
+// otherwise sei-config's ResolveIntent rejects the empty-Mode and
+// TaskConfigApply fails at runtime.
+func TestBuildNodeUpdatePlan_ConfigApplyHasIntentWithMode(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	node.Spec.ExternalAddress = "syncer-0-0-p2p.atlantic-2.harbor.platform.sei.io:26656"
+	node.Spec.Image = testImageV2
+
+	plan, err := buildRunningPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).NotTo(BeNil())
+
+	intent := configIntentFromPlan(t, plan)
+	g.Expect(intent.Mode).To(Equal(seiconfig.ModeFull), "Mode must be set so ResolveIntent accepts the intent")
+	g.Expect(intent.Overrides).To(HaveKeyWithValue(
+		seiconfig.KeyP2PExternalAddress,
+		"syncer-0-0-p2p.atlantic-2.harbor.platform.sei.io:26656",
+	), "commonOverrides should propagate Spec.ExternalAddress")
+}
+
+// Day-2 must set Incremental=true. The init path uses applyFull which
+// regenerates config from mode defaults — running that on a running node
+// would wipe persistent-peers, state-sync trust point, and operator-managed
+// TOML keys outside the controller's overrides set. Incremental reads
+// on-disk config and patches only the keys we own.
+func TestBuildNodeUpdatePlan_ConfigApplyIsIncremental(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	node.Spec.Image = testImageV2
+
+	plan, err := buildRunningPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).NotTo(BeNil())
+
+	intent := configIntentFromPlan(t, plan)
+	g.Expect(intent.Incremental).To(BeTrue(),
+		"day-2 ConfigIntent must be incremental to avoid clobbering on-disk state")
+}
+
+// Per-mode coverage: the day-2 intent should match the mode planner's
+// Mode value. Catches future drift if a new mode lands and isn't wired
+// into BuildConfigIntent.
+func TestBuildNodeUpdatePlan_ConfigApplyIntentMatchesModePlanner(t *testing.T) {
+	cases := []struct {
+		name     string
+		mutate   func(*seiv1alpha1.SeiNode)
+		wantMode seiconfig.NodeMode
+	}{
+		{
+			name:     "full",
+			mutate:   func(_ *seiv1alpha1.SeiNode) {},
+			wantMode: seiconfig.ModeFull,
+		},
+		{
+			name: "archive",
+			mutate: func(n *seiv1alpha1.SeiNode) {
+				n.Spec.FullNode = nil
+				n.Spec.Archive = &seiv1alpha1.ArchiveSpec{}
+			},
+			wantMode: seiconfig.ModeArchive,
+		},
+		{
+			name: "validator",
+			mutate: func(n *seiv1alpha1.SeiNode) {
+				n.Spec.FullNode = nil
+				n.Spec.Validator = &seiv1alpha1.ValidatorSpec{}
+			},
+			wantMode: seiconfig.ModeValidator,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			node := runningFullNode()
+			tc.mutate(node)
+			node.Spec.Image = testImageV2
+
+			plan, err := buildRunningPlan(node)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(plan).NotTo(BeNil())
+
+			intent := configIntentFromPlan(t, plan)
+			g.Expect(intent.Mode).To(Equal(tc.wantMode))
+			g.Expect(intent.Incremental).To(BeTrue())
+		})
 	}
 }
 
@@ -381,10 +493,12 @@ func TestBuildRunningPlan_ImageDriftWinsOverSidecar(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(plan).NotTo(BeNil())
 	// Image update plan ends with MarkReady, which also resolves the sidecar.
-	g.Expect(plan.Tasks).To(HaveLen(5), "should be full node-update plan, not one-task mark-ready")
+	g.Expect(plan.Tasks).To(HaveLen(7), "should be full node-update plan, not one-task mark-ready")
 	g.Expect(planTaskTypes(plan)).To(Equal([]string{
 		task.TaskTypeApplyStatefulSet,
 		task.TaskTypeApplyService,
+		TaskConfigApply,
+		TaskConfigValidate,
 		task.TaskTypeReplacePod,
 		task.TaskTypeObserveImage,
 		TaskMarkReady,

--- a/internal/planner/node_update_test.go
+++ b/internal/planner/node_update_test.go
@@ -165,6 +165,59 @@ func TestArchivePlanner_ImageDrift_UpdateProgression(t *testing.T) {
 	}))
 }
 
+// Replayer shares the full/archive update shape — symmetry test.
+func TestReplayerPlanner_ImageDrift_UpdateProgression(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	node.Spec.FullNode = nil
+	node.Spec.Replayer = &seiv1alpha1.ReplayerSpec{}
+	node.Spec.Image = testImageV2
+
+	plan, err := (&replayerPlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).NotTo(BeNil())
+
+	g.Expect(planTaskTypes(plan)).To(Equal([]string{
+		task.TaskTypeApplyStatefulSet,
+		task.TaskTypeApplyService,
+		TaskConfigPatch,
+		TaskConfigValidate,
+		task.TaskTypeReplacePod,
+		task.TaskTypeObserveImage,
+		TaskMarkReady,
+	}))
+}
+
+// Convention: init writes the whole config via TaskConfigApply; a Running
+// node's update plan patches via TaskConfigPatch. Never both in one plan.
+// Stated as a doc rule on NodePlanner; this test enforces it.
+func TestPlannerConvention_InitUsesApply_UpdateUsesPatch(t *testing.T) {
+	g := NewWithT(t)
+
+	// Init: empty phase, empty currentImage.
+	initNode := runningFullNode()
+	initNode.Status.Phase = ""
+	initNode.Status.CurrentImage = ""
+
+	initPlan, err := (&fullNodePlanner{}).BuildPlan(initNode)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(initPlan).NotTo(BeNil())
+	initTypes := planTaskTypes(initPlan)
+	g.Expect(initTypes).To(ContainElement(TaskConfigApply), "init must include config-apply")
+	g.Expect(initTypes).NotTo(ContainElement(TaskConfigPatch), "init must NOT include config-patch")
+
+	// Running update: spec.image diverges from status.currentImage.
+	updateNode := runningFullNode()
+	updateNode.Spec.Image = testImageV2
+
+	updatePlan, err := (&fullNodePlanner{}).BuildPlan(updateNode)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(updatePlan).NotTo(BeNil())
+	updateTypes := planTaskTypes(updatePlan)
+	g.Expect(updateTypes).To(ContainElement(TaskConfigPatch), "update must include config-patch")
+	g.Expect(updateTypes).NotTo(ContainElement(TaskConfigApply), "update must NOT include config-apply")
+}
+
 // Validator's update progression prepends the three key-validation gates
 // so a missing/malformed secret aborts before any STS mutation.
 func TestValidatorPlanner_ImageDrift_PrependsValidationGates(t *testing.T) {

--- a/internal/planner/node_update_test.go
+++ b/internal/planner/node_update_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	seiconfig "github.com/sei-protocol/sei-config"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -14,7 +13,10 @@ import (
 	"github.com/sei-protocol/sei-k8s-controller/internal/task"
 )
 
-const testImageV2 = "sei:v2.0.0"
+const (
+	testImageV2         = "sei:v2.0.0"
+	testExternalAddrAtl = "syncer-0-0-p2p.atlantic-2.harbor.platform.sei.io:26656"
+)
 
 // runningFullNode returns a SeiNode in the Running phase with currentImage matching spec.image.
 func runningFullNode() *seiv1alpha1.SeiNode {
@@ -41,44 +43,60 @@ func planTaskTypes(plan *seiv1alpha1.TaskPlan) []string {
 	return types
 }
 
-// --- buildRunningPlan tests ---
+// configPatchFromPlan finds the config-patch task in a plan and unmarshals
+// its params back into a ConfigPatchTask for inspection.
+func configPatchFromPlan(t *testing.T, plan *seiv1alpha1.TaskPlan) task.ConfigPatchTask {
+	t.Helper()
+	g := NewWithT(t)
+	for _, pt := range plan.Tasks {
+		if pt.Type != TaskConfigPatch {
+			continue
+		}
+		g.Expect(pt.Params).NotTo(BeNil())
+		var p task.ConfigPatchTask
+		g.Expect(json.Unmarshal(pt.Params.Raw, &p)).To(Succeed())
+		return p
+	}
+	t.Fatal("plan has no config-patch task")
+	return task.ConfigPatchTask{}
+}
 
-func TestBuildRunningPlan_NoDrift_ReturnsNil(t *testing.T) {
+// --- fullNodePlanner running-plan tests ---
+
+func TestFullPlanner_NoDrift_ReturnsNil(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
-	// spec.image == status.currentImage — no drift
-	plan, err := buildRunningPlan(node)
+	plan, err := (&fullNodePlanner{}).BuildPlan(node)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(plan).To(BeNil(), "no plan should be built when there is no image drift")
 }
 
-func TestBuildRunningPlan_ImageDrift_ReturnsNodeUpdatePlan(t *testing.T) {
+func TestFullPlanner_ImageDrift_Day2Progression(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
-	node.Spec.Image = testImageV2 // drift: spec != status.currentImage
+	node.Spec.Image = testImageV2
 
-	plan, err := buildRunningPlan(node)
+	plan, err := (&fullNodePlanner{}).BuildPlan(node)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(plan).NotTo(BeNil(), "plan should be built for image drift")
 
 	g.Expect(plan.Phase).To(Equal(seiv1alpha1.TaskPlanActive))
 	g.Expect(plan.TargetPhase).To(Equal(seiv1alpha1.PhaseRunning))
-	// FailedPhase should be empty — failure retries rather than transitioning out of Running.
+	// FailedPhase deliberately empty — failure retries on next reconcile.
 	g.Expect(string(plan.FailedPhase)).To(BeEmpty())
 
-	got := planTaskTypes(plan)
 	want := []string{
 		task.TaskTypeApplyStatefulSet,
 		task.TaskTypeApplyService,
-		TaskConfigApply,
+		TaskConfigPatch,
 		TaskConfigValidate,
 		task.TaskTypeReplacePod,
 		task.TaskTypeObserveImage,
 		TaskMarkReady,
 	}
-	g.Expect(got).To(Equal(want), "NodeUpdate plan should have exactly these tasks in order")
+	g.Expect(planTaskTypes(plan)).To(Equal(want))
 
-	// All tasks should start Pending with non-empty IDs and params.
+	// Tasks start Pending with non-empty IDs and params.
 	for _, pt := range plan.Tasks {
 		g.Expect(pt.Status).To(Equal(seiv1alpha1.TaskPending), "task %s should start Pending", pt.Type)
 		g.Expect(pt.ID).NotTo(BeEmpty(), "task %s should have an ID", pt.Type)
@@ -86,135 +104,208 @@ func TestBuildRunningPlan_ImageDrift_ReturnsNodeUpdatePlan(t *testing.T) {
 	}
 }
 
-// configIntentFromPlan finds the config-apply task and unmarshals its
-// params back into a ConfigIntent for inspection.
-func configIntentFromPlan(t *testing.T, plan *seiv1alpha1.TaskPlan) *seiconfig.ConfigIntent {
-	t.Helper()
-	g := NewWithT(t)
-	for _, pt := range plan.Tasks {
-		if pt.Type != TaskConfigApply {
-			continue
-		}
-		g.Expect(pt.Params).NotTo(BeNil())
-		var intent seiconfig.ConfigIntent
-		g.Expect(json.Unmarshal(pt.Params.Raw, &intent)).To(Succeed())
-		return &intent
-	}
-	t.Fatal("plan has no config-apply task")
-	return nil
-}
-
-// The day-2 config-apply must carry the mode planner's full ConfigIntent —
-// non-empty Mode, Overrides containing the controller-managed keys —
-// otherwise sei-config's ResolveIntent rejects the empty-Mode and
-// TaskConfigApply fails at runtime.
-func TestBuildNodeUpdatePlan_ConfigApplyHasIntentWithMode(t *testing.T) {
+// The day-2 config-patch must carry the external-address from
+// Spec.ExternalAddress. This is the publishable-P2P propagation contract.
+func TestFullPlanner_ConfigPatchCarriesExternalAddress(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
-	node.Spec.ExternalAddress = "syncer-0-0-p2p.atlantic-2.harbor.platform.sei.io:26656"
+	node.Spec.ExternalAddress = testExternalAddrAtl
 	node.Spec.Image = testImageV2
-
-	plan, err := buildRunningPlan(node)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(plan).NotTo(BeNil())
-
-	intent := configIntentFromPlan(t, plan)
-	g.Expect(intent.Mode).To(Equal(seiconfig.ModeFull), "Mode must be set so ResolveIntent accepts the intent")
-	g.Expect(intent.Overrides).To(HaveKeyWithValue(
-		seiconfig.KeyP2PExternalAddress,
-		"syncer-0-0-p2p.atlantic-2.harbor.platform.sei.io:26656",
-	), "commonOverrides should propagate Spec.ExternalAddress")
-}
-
-// Day-2 must set Incremental=true. The init path uses applyFull which
-// regenerates config from mode defaults — running that on a running node
-// would wipe persistent-peers, state-sync trust point, and operator-managed
-// TOML keys outside the controller's overrides set. Incremental reads
-// on-disk config and patches only the keys we own.
-func TestBuildNodeUpdatePlan_ConfigApplyIsIncremental(t *testing.T) {
-	g := NewWithT(t)
-	node := runningFullNode()
-	node.Spec.Image = testImageV2
-
-	plan, err := buildRunningPlan(node)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(plan).NotTo(BeNil())
-
-	intent := configIntentFromPlan(t, plan)
-	g.Expect(intent.Incremental).To(BeTrue(),
-		"day-2 ConfigIntent must be incremental to avoid clobbering on-disk state")
-}
-
-// Init plans must NOT set Incremental — the init path uses applyFull
-// (regenerate config from mode defaults + overrides). Pinning this here
-// makes accidental flips during future refactors a loud failure.
-func TestBuildPlan_InitPlanConfigIntentNotIncremental(t *testing.T) {
-	g := NewWithT(t)
-	node := &seiv1alpha1.SeiNode{
-		ObjectMeta: metav1.ObjectMeta{Name: "full-init", Namespace: "default", Generation: 1},
-		Spec: seiv1alpha1.SeiNodeSpec{
-			ChainID:  "atlantic-2",
-			Image:    "sei:v1.0.0",
-			FullNode: &seiv1alpha1.FullNodeSpec{},
-		},
-		// No phase — defaults to "" (init path).
-	}
 
 	plan, err := (&fullNodePlanner{}).BuildPlan(node)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(plan).NotTo(BeNil())
 
-	intent := configIntentFromPlan(t, plan)
-	g.Expect(intent.Incremental).To(BeFalse(),
-		"init ConfigIntent must NOT be incremental — applyFull regenerates from mode defaults")
+	patch := configPatchFromPlan(t, plan)
+	g.Expect(patch.Files).To(HaveKey("config.toml"))
+	p2p, ok := patch.Files["config.toml"]["p2p"].(map[string]any)
+	g.Expect(ok).To(BeTrue(), "config.toml.p2p should be a nested map")
+	g.Expect(p2p).To(HaveKeyWithValue("external-address", testExternalAddrAtl))
 }
 
-// Per-mode coverage: the day-2 intent should match the mode planner's
-// Mode value. Catches future drift if a new mode lands and isn't wired
-// into BuildConfigIntent.
-func TestBuildNodeUpdatePlan_ConfigApplyIntentMatchesModePlanner(t *testing.T) {
-	cases := []struct {
-		name     string
-		mutate   func(*seiv1alpha1.SeiNode)
-		wantMode seiconfig.NodeMode
-	}{
-		{
-			name:     "full",
-			mutate:   func(_ *seiv1alpha1.SeiNode) {},
-			wantMode: seiconfig.ModeFull,
-		},
-		{
-			name: "archive",
-			mutate: func(n *seiv1alpha1.SeiNode) {
-				n.Spec.FullNode = nil
-				n.Spec.Archive = &seiv1alpha1.ArchiveSpec{}
-			},
-			wantMode: seiconfig.ModeArchive,
-		},
-		{
-			name: "validator",
-			mutate: func(n *seiv1alpha1.SeiNode) {
-				n.Spec.FullNode = nil
-				n.Spec.Validator = &seiv1alpha1.ValidatorSpec{}
-			},
-			wantMode: seiconfig.ModeValidator,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewWithT(t)
-			node := runningFullNode()
-			tc.mutate(node)
-			node.Spec.Image = testImageV2
+// Two builds of the same spec must produce identical patch payloads
+// (plan-construction is deterministic w.r.t. spec).
+func TestFullPlanner_ConfigPatchIsDeterministic(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	node.Spec.ExternalAddress = testExternalAddrAtl
+	node.Spec.Image = testImageV2
 
-			plan, err := buildRunningPlan(node)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(plan).NotTo(BeNil())
+	plan1, err := (&fullNodePlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	plan2, err := (&fullNodePlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
 
-			intent := configIntentFromPlan(t, plan)
-			g.Expect(intent.Mode).To(Equal(tc.wantMode))
-			g.Expect(intent.Incremental).To(BeTrue())
-		})
+	p1 := configPatchFromPlan(t, plan1)
+	p2 := configPatchFromPlan(t, plan2)
+	g.Expect(p1.Files).To(Equal(p2.Files), "same spec must produce same patch payload")
+}
+
+// --- archive and replay planners share the full progression ---
+
+func TestArchivePlanner_ImageDrift_Day2Progression(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	node.Spec.FullNode = nil
+	node.Spec.Archive = &seiv1alpha1.ArchiveSpec{}
+	node.Spec.Image = testImageV2
+
+	plan, err := (&archiveNodePlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).NotTo(BeNil())
+
+	g.Expect(planTaskTypes(plan)).To(Equal([]string{
+		task.TaskTypeApplyStatefulSet,
+		task.TaskTypeApplyService,
+		TaskConfigPatch,
+		TaskConfigValidate,
+		task.TaskTypeReplacePod,
+		task.TaskTypeObserveImage,
+		TaskMarkReady,
+	}))
+}
+
+// Validator's day-2 progression prepends the three key-validation gates
+// so a missing/malformed secret aborts before any STS mutation.
+func TestValidatorPlanner_ImageDrift_PrependsValidationGates(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	node.Spec.FullNode = nil
+	node.Spec.Validator = &seiv1alpha1.ValidatorSpec{}
+	node.Spec.Image = testImageV2
+
+	plan, err := (&validatorPlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).NotTo(BeNil())
+
+	g.Expect(planTaskTypes(plan)).To(Equal([]string{
+		task.TaskTypeValidateSigningKey,
+		task.TaskTypeValidateNodeKey,
+		task.TaskTypeValidateOperatorKeyring,
+		task.TaskTypeApplyStatefulSet,
+		task.TaskTypeApplyService,
+		TaskConfigPatch,
+		TaskConfigValidate,
+		task.TaskTypeReplacePod,
+		task.TaskTypeObserveImage,
+		TaskMarkReady,
+	}))
+}
+
+// --- sidecar mark-ready re-apply ---
+
+func setSidecarReady(node *seiv1alpha1.SeiNode, status metav1.ConditionStatus, reason string) {
+	meta.SetStatusCondition(&node.Status.Conditions, metav1.Condition{
+		Type:    seiv1alpha1.ConditionSidecarReady,
+		Status:  status,
+		Reason:  reason,
+		Message: "test",
+	})
+}
+
+func TestFullPlanner_SidecarReady_NoPlan(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	setSidecarReady(node, metav1.ConditionTrue, "Ready")
+
+	plan, err := (&fullNodePlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).To(BeNil())
+}
+
+func TestFullPlanner_SidecarNotReady_ReturnsMarkReadyPlan(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	setSidecarReady(node, metav1.ConditionFalse, "NotReady")
+
+	plan, err := (&fullNodePlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).NotTo(BeNil())
+	g.Expect(plan.Phase).To(Equal(seiv1alpha1.TaskPlanActive))
+	g.Expect(plan.TargetPhase).To(Equal(seiv1alpha1.PhaseRunning))
+	g.Expect(string(plan.FailedPhase)).To(BeEmpty())
+	g.Expect(planTaskTypes(plan)).To(Equal([]string{TaskMarkReady}))
+}
+
+func TestFullPlanner_SidecarUnknown_NoPlan(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	setSidecarReady(node, metav1.ConditionUnknown, "Unreachable")
+
+	plan, err := (&fullNodePlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).To(BeNil(), "Unknown should not trigger a plan — re-probe next tick")
+}
+
+func TestFullPlanner_ImageDriftWinsOverSidecar(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	node.Spec.Image = testImageV2
+	setSidecarReady(node, metav1.ConditionFalse, "NotReady")
+
+	plan, err := (&fullNodePlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).NotTo(BeNil())
+	g.Expect(plan.Tasks).To(HaveLen(7), "should be full day-2 plan, not one-task mark-ready")
+	g.Expect(planTaskTypes(plan)).To(Equal([]string{
+		task.TaskTypeApplyStatefulSet,
+		task.TaskTypeApplyService,
+		TaskConfigPatch,
+		TaskConfigValidate,
+		task.TaskTypeReplacePod,
+		task.TaskTypeObserveImage,
+		TaskMarkReady,
+	}))
+}
+
+func TestBuildMarkReadyPlan_FreshIDEveryCall(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+
+	p1, err := buildMarkReadyPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	p2, err := buildMarkReadyPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(p1.ID).NotTo(Equal(p2.ID))
+	g.Expect(p1.Tasks[0].ID).NotTo(Equal(p2.Tasks[0].ID))
+}
+
+func TestSidecarNeedsReapproval(t *testing.T) {
+	g := NewWithT(t)
+
+	node := runningFullNode()
+	g.Expect(sidecarNeedsReapproval(node)).To(BeFalse())
+
+	setSidecarReady(node, metav1.ConditionTrue, "Ready")
+	g.Expect(sidecarNeedsReapproval(node)).To(BeFalse())
+
+	setSidecarReady(node, metav1.ConditionUnknown, "Unreachable")
+	g.Expect(sidecarNeedsReapproval(node)).To(BeFalse())
+
+	setSidecarReady(node, metav1.ConditionFalse, "SomethingElse")
+	g.Expect(sidecarNeedsReapproval(node)).To(BeFalse())
+
+	setSidecarReady(node, metav1.ConditionFalse, "NotReady")
+	g.Expect(sidecarNeedsReapproval(node)).To(BeTrue())
+}
+
+func TestBuildRunningPlan_UniqueIDs(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	node.Spec.Image = testImageV2
+
+	plan1, err := (&fullNodePlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	plan2, err := (&fullNodePlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(plan1.ID).NotTo(Equal(plan2.ID), "separate plan builds should have unique IDs")
+
+	seen := map[string]bool{}
+	for _, tsk := range plan1.Tasks {
+		g.Expect(seen[tsk.ID]).To(BeFalse(), "duplicate task ID: %s", tsk.ID)
+		seen[tsk.ID] = true
 	}
 }
 
@@ -223,7 +314,7 @@ func TestBuildNodeUpdatePlan_ConfigApplyIntentMatchesModePlanner(t *testing.T) {
 func TestResolvePlan_NodeUpdate_SetsCondition(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
-	node.Spec.Image = testImageV2 // drift triggers NodeUpdate plan
+	node.Spec.Image = testImageV2
 
 	err := (&NodeResolver{}).ResolvePlan(t.Context(), node)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -241,22 +332,17 @@ func TestResolvePlan_CompletedPlan_ClearsCondition(t *testing.T) {
 	node := runningFullNode()
 	node.Spec.Image = testImageV2
 
-	// Build a NodeUpdate plan and simulate completion.
 	err := (&NodeResolver{}).ResolvePlan(t.Context(), node)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(node.Status.Plan).NotTo(BeNil())
 
-	// Verify the condition was set.
 	cond := meta.FindStatusCondition(node.Status.Conditions, seiv1alpha1.ConditionNodeUpdateInProgress)
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 
-	// Mark the plan completed.
 	node.Status.Plan.Phase = seiv1alpha1.TaskPlanComplete
-	// Also converge currentImage so a new plan is not built.
 	node.Status.CurrentImage = testImageV2
 
-	// ResolvePlan should clear the completed plan and the condition.
 	err = (&NodeResolver{}).ResolvePlan(t.Context(), node)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -272,7 +358,6 @@ func TestResolvePlan_FailedPlan_ClearsCondition(t *testing.T) {
 	node := runningFullNode()
 	node.Spec.Image = testImageV2
 
-	// Build a NodeUpdate plan and simulate failure.
 	err := (&NodeResolver{}).ResolvePlan(t.Context(), node)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(node.Status.Plan).NotTo(BeNil())
@@ -286,13 +371,9 @@ func TestResolvePlan_FailedPlan_ClearsCondition(t *testing.T) {
 		Error: "apply error",
 	}
 
-	// ResolvePlan should clear the failed plan. Since drift still exists,
-	// it immediately builds a new NodeUpdate plan and sets the condition
-	// back to True. This is correct — automatic retry on failure.
 	err = (&NodeResolver{}).ResolvePlan(t.Context(), node)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// A new plan was built because drift still exists.
 	g.Expect(node.Status.Plan).NotTo(BeNil(), "new plan should be built because drift persists")
 	g.Expect(node.Status.Plan.Phase).To(Equal(seiv1alpha1.TaskPlanActive))
 
@@ -304,7 +385,7 @@ func TestResolvePlan_FailedPlan_ClearsCondition(t *testing.T) {
 func TestResolvePlan_ResumesActivePlan(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
-	node.Spec.Image = testImageV2 // drift exists
+	node.Spec.Image = testImageV2
 
 	existingPlan := &seiv1alpha1.TaskPlan{
 		ID:    "existing-plan-123",
@@ -321,19 +402,15 @@ func TestResolvePlan_ResumesActivePlan(t *testing.T) {
 		"active plan should be resumed, not replaced")
 }
 
-// --- Additional edge cases ---
-
 func TestResolvePlan_CompletedNonUpdatePlan_DoesNotClearCondition(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
-	// Manually set the condition (as if a previous NodeUpdate plan set it).
 	meta.SetStatusCondition(&node.Status.Conditions, metav1.Condition{
 		Type:   seiv1alpha1.ConditionNodeUpdateInProgress,
 		Status: metav1.ConditionFalse,
 		Reason: "UpdateComplete",
 	})
 
-	// Create a completed plan without observe-image (not a NodeUpdate plan).
 	node.Status.Plan = &seiv1alpha1.TaskPlan{
 		ID:    "non-update-plan",
 		Phase: seiv1alpha1.TaskPlanComplete,
@@ -345,7 +422,6 @@ func TestResolvePlan_CompletedNonUpdatePlan_DoesNotClearCondition(t *testing.T) 
 	err := (&NodeResolver{}).ResolvePlan(t.Context(), node)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// The condition should remain unchanged (already False from before).
 	cond := meta.FindStatusCondition(node.Status.Conditions, seiv1alpha1.ConditionNodeUpdateInProgress)
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
@@ -353,26 +429,7 @@ func TestResolvePlan_CompletedNonUpdatePlan_DoesNotClearCondition(t *testing.T) 
 		"reason should not be overwritten by a non-update plan completion")
 }
 
-func TestBuildRunningPlan_UniqueIDs(t *testing.T) {
-	g := NewWithT(t)
-	node := runningFullNode()
-	node.Spec.Image = testImageV2
-
-	plan1, err := buildRunningPlan(node)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	plan2, err := buildRunningPlan(node)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	g.Expect(plan1.ID).NotTo(Equal(plan2.ID), "separate plan builds should have unique IDs")
-
-	// Task IDs within a single plan should all be unique.
-	seen := map[string]bool{}
-	for _, tsk := range plan1.Tasks {
-		g.Expect(seen[tsk.ID]).To(BeFalse(), "duplicate task ID: %s", tsk.ID)
-		seen[tsk.ID] = true
-	}
-}
+// --- handleTerminalPlan tests (unchanged) ---
 
 func TestHandleTerminalPlan_CompletedWithUpdateCondition(t *testing.T) {
 	g := NewWithT(t)
@@ -427,7 +484,6 @@ func TestHandleTerminalPlan_NilPlan(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
 	node.Status.Plan = nil
-	// Should be a no-op — no panic.
 	handleTerminalPlan(t.Context(), node)
 	g.Expect(node.Status.Plan).To(BeNil())
 }
@@ -460,108 +516,4 @@ func TestPlanFailureMessage_NoDetail(t *testing.T) {
 	g := NewWithT(t)
 	plan := &seiv1alpha1.TaskPlan{}
 	g.Expect(planFailureMessage(plan)).To(Equal("unknown"))
-}
-
-// --- sidecar mark-ready re-apply tests ---
-
-func setSidecarReady(node *seiv1alpha1.SeiNode, status metav1.ConditionStatus, reason string) {
-	meta.SetStatusCondition(&node.Status.Conditions, metav1.Condition{
-		Type:    seiv1alpha1.ConditionSidecarReady,
-		Status:  status,
-		Reason:  reason,
-		Message: "test",
-	})
-}
-
-func TestBuildRunningPlan_SidecarReady_NoPlan(t *testing.T) {
-	g := NewWithT(t)
-	node := runningFullNode()
-	setSidecarReady(node, metav1.ConditionTrue, "Ready")
-
-	plan, err := buildRunningPlan(node)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(plan).To(BeNil())
-}
-
-func TestBuildRunningPlan_SidecarNotReady_ReturnsMarkReadyPlan(t *testing.T) {
-	g := NewWithT(t)
-	node := runningFullNode()
-	setSidecarReady(node, metav1.ConditionFalse, "NotReady")
-
-	plan, err := buildRunningPlan(node)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(plan).NotTo(BeNil())
-	g.Expect(plan.Phase).To(Equal(seiv1alpha1.TaskPlanActive))
-	g.Expect(plan.TargetPhase).To(Equal(seiv1alpha1.PhaseRunning))
-	g.Expect(string(plan.FailedPhase)).To(BeEmpty())
-	g.Expect(planTaskTypes(plan)).To(Equal([]string{TaskMarkReady}))
-}
-
-func TestBuildRunningPlan_SidecarUnknown_NoPlan(t *testing.T) {
-	g := NewWithT(t)
-	node := runningFullNode()
-	setSidecarReady(node, metav1.ConditionUnknown, "Unreachable")
-
-	plan, err := buildRunningPlan(node)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(plan).To(BeNil(), "Unknown should not trigger a plan — re-probe next tick")
-}
-
-func TestBuildRunningPlan_ImageDriftWinsOverSidecar(t *testing.T) {
-	g := NewWithT(t)
-	node := runningFullNode()
-	node.Spec.Image = testImageV2 // image drift
-	setSidecarReady(node, metav1.ConditionFalse, "NotReady")
-
-	plan, err := buildRunningPlan(node)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(plan).NotTo(BeNil())
-	// Image update plan ends with MarkReady, which also resolves the sidecar.
-	g.Expect(plan.Tasks).To(HaveLen(7), "should be full node-update plan, not one-task mark-ready")
-	g.Expect(planTaskTypes(plan)).To(Equal([]string{
-		task.TaskTypeApplyStatefulSet,
-		task.TaskTypeApplyService,
-		TaskConfigApply,
-		TaskConfigValidate,
-		task.TaskTypeReplacePod,
-		task.TaskTypeObserveImage,
-		TaskMarkReady,
-	}))
-}
-
-func TestBuildMarkReadyPlan_FreshIDEveryCall(t *testing.T) {
-	g := NewWithT(t)
-	node := runningFullNode()
-
-	p1, err := buildMarkReadyPlan(node)
-	g.Expect(err).NotTo(HaveOccurred())
-	p2, err := buildMarkReadyPlan(node)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	g.Expect(p1.ID).NotTo(Equal(p2.ID))
-	g.Expect(p1.Tasks[0].ID).NotTo(Equal(p2.Tasks[0].ID))
-}
-
-func TestSidecarNeedsReapproval(t *testing.T) {
-	g := NewWithT(t)
-
-	// missing condition
-	node := runningFullNode()
-	g.Expect(sidecarNeedsReapproval(node)).To(BeFalse())
-
-	// True
-	setSidecarReady(node, metav1.ConditionTrue, "Ready")
-	g.Expect(sidecarNeedsReapproval(node)).To(BeFalse())
-
-	// Unknown
-	setSidecarReady(node, metav1.ConditionUnknown, "Unreachable")
-	g.Expect(sidecarNeedsReapproval(node)).To(BeFalse())
-
-	// False + wrong reason
-	setSidecarReady(node, metav1.ConditionFalse, "SomethingElse")
-	g.Expect(sidecarNeedsReapproval(node)).To(BeFalse())
-
-	// False + NotReady
-	setSidecarReady(node, metav1.ConditionFalse, "NotReady")
-	g.Expect(sidecarNeedsReapproval(node)).To(BeTrue())
 }

--- a/internal/planner/node_update_test.go
+++ b/internal/planner/node_update_test.go
@@ -145,6 +145,30 @@ func TestBuildNodeUpdatePlan_ConfigApplyIsIncremental(t *testing.T) {
 		"day-2 ConfigIntent must be incremental to avoid clobbering on-disk state")
 }
 
+// Init plans must NOT set Incremental — the init path uses applyFull
+// (regenerate config from mode defaults + overrides). Pinning this here
+// makes accidental flips during future refactors a loud failure.
+func TestBuildPlan_InitPlanConfigIntentNotIncremental(t *testing.T) {
+	g := NewWithT(t)
+	node := &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "full-init", Namespace: "default", Generation: 1},
+		Spec: seiv1alpha1.SeiNodeSpec{
+			ChainID:  "atlantic-2",
+			Image:    "sei:v1.0.0",
+			FullNode: &seiv1alpha1.FullNodeSpec{},
+		},
+		// No phase — defaults to "" (init path).
+	}
+
+	plan, err := (&fullNodePlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).NotTo(BeNil())
+
+	intent := configIntentFromPlan(t, plan)
+	g.Expect(intent.Incremental).To(BeFalse(),
+		"init ConfigIntent must NOT be incremental — applyFull regenerates from mode defaults")
+}
+
 // Per-mode coverage: the day-2 intent should match the mode planner's
 // Mode value. Catches future drift if a new mode lands and isn't wired
 // into BuildConfigIntent.

--- a/internal/planner/node_update_test.go
+++ b/internal/planner/node_update_test.go
@@ -71,7 +71,7 @@ func TestFullPlanner_NoDrift_ReturnsNil(t *testing.T) {
 	g.Expect(plan).To(BeNil(), "no plan should be built when there is no image drift")
 }
 
-func TestFullPlanner_ImageDrift_Day2Progression(t *testing.T) {
+func TestFullPlanner_ImageDrift_UpdateProgression(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
 	node.Spec.Image = testImageV2
@@ -104,8 +104,8 @@ func TestFullPlanner_ImageDrift_Day2Progression(t *testing.T) {
 	}
 }
 
-// The day-2 config-patch must carry the external-address from
-// Spec.ExternalAddress. This is the publishable-P2P propagation contract.
+// The update plan's config-patch must carry the external-address from
+// Spec.ExternalAddress — the publishable-P2P propagation contract.
 func TestFullPlanner_ConfigPatchCarriesExternalAddress(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
@@ -143,7 +143,7 @@ func TestFullPlanner_ConfigPatchIsDeterministic(t *testing.T) {
 
 // --- archive and replay planners share the full progression ---
 
-func TestArchivePlanner_ImageDrift_Day2Progression(t *testing.T) {
+func TestArchivePlanner_ImageDrift_UpdateProgression(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
 	node.Spec.FullNode = nil
@@ -165,7 +165,7 @@ func TestArchivePlanner_ImageDrift_Day2Progression(t *testing.T) {
 	}))
 }
 
-// Validator's day-2 progression prepends the three key-validation gates
+// Validator's update progression prepends the three key-validation gates
 // so a missing/malformed secret aborts before any STS mutation.
 func TestValidatorPlanner_ImageDrift_PrependsValidationGates(t *testing.T) {
 	g := NewWithT(t)
@@ -246,7 +246,7 @@ func TestFullPlanner_ImageDriftWinsOverSidecar(t *testing.T) {
 	plan, err := (&fullNodePlanner{}).BuildPlan(node)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(plan).NotTo(BeNil())
-	g.Expect(plan.Tasks).To(HaveLen(7), "should be full day-2 plan, not one-task mark-ready")
+	g.Expect(plan.Tasks).To(HaveLen(7), "should be full update plan, not one-task mark-ready")
 	g.Expect(planTaskTypes(plan)).To(Equal([]string{
 		task.TaskTypeApplyStatefulSet,
 		task.TaskTypeApplyService,

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -733,6 +733,13 @@ func imageDrifted(node *seiv1alpha1.SeiNode) bool {
 	return node.Spec.Image != node.Status.CurrentImage
 }
 
+// imageDriftMessage formats the standard NodeUpdateInProgress message
+// for image-drift-triggered plans, used by every mode planner's
+// buildRunningPlan before calling assembleUpdatePlan.
+func imageDriftMessage(node *seiv1alpha1.SeiNode) string {
+	return fmt.Sprintf("image drift detected: spec=%s current=%s", node.Spec.Image, node.Status.CurrentImage)
+}
+
 // externalAddressPatch is the config.toml patch that stamps the
 // publishable-P2P external address. An empty Spec.ExternalAddress
 // stamps an empty value so opt-out reaches the pod symmetrically.
@@ -747,16 +754,14 @@ func externalAddressPatch(node *seiv1alpha1.SeiNode) map[string]map[string]any {
 }
 
 // assembleUpdatePlan composes a task progression for a Running node into
-// a TaskPlan. The progression slice is the per-mode authorship — each
-// planner decides which tasks it needs (e.g. validator prepends
-// key-validation gates).
+// a TaskPlan. Pure boilerplate (planID, task ordering, param marshaling,
+// phase fields) — the progression slice is the per-mode authorship.
+// Callers own the NodeUpdateInProgress condition: stamp it before calling
+// so the reason/message reflects the actual trigger.
 //
 // FailedPhase is deliberately empty: a failure retries on the next reconcile
 // rather than transitioning the node out of Running.
 func assembleUpdatePlan(node *seiv1alpha1.SeiNode, prog []string, patch map[string]map[string]any) (*seiv1alpha1.TaskPlan, error) {
-	setNodeUpdateCondition(node, metav1.ConditionTrue, "UpdateStarted",
-		fmt.Sprintf("image drift detected: spec=%s current=%s", node.Spec.Image, node.Status.CurrentImage))
-
 	planID := uuid.New().String()
 	tasks := make([]seiv1alpha1.PlannedTask, len(prog))
 	for i, taskType := range prog {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -32,6 +32,7 @@ const (
 	TaskConfigureGenesis   = sidecar.TaskTypeConfigureGenesis
 	TaskConfigureStateSync = sidecar.TaskTypeConfigureStateSync
 	TaskConfigApply        = sidecar.TaskTypeConfigApply
+	TaskConfigPatch        = sidecar.TaskTypeConfigPatch
 	TaskConfigValidate     = sidecar.TaskTypeConfigValidate
 	TaskMarkReady          = sidecar.TaskTypeMarkReady
 	TaskSnapshotUpload     = sidecar.TaskTypeSnapshotUpload
@@ -58,18 +59,19 @@ var baseProgression = map[string][]string{
 }
 
 // NodePlanner encapsulates mode-specific logic for validating a SeiNode
-// and building its initialization task plan with fully embedded params.
+// and building its task plan. BuildPlan dispatches internally between
+// startup (init) and existing-resource (day-2) shapes — callers don't
+// see the distinction and the interface stays narrow.
+//
+// Rule of thumb for implementations: init plans write the whole config
+// file via TaskConfigApply (sei-config mode-defaulted resolution).
+// Day-2 plans patch only the keys the controller directly owns via
+// TaskConfigPatch (generic TOML merge, no sei-config involvement).
+// Never mix the two in one plan.
 type NodePlanner interface {
 	Validate(node *seiv1alpha1.SeiNode) error
 	BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error)
 	Mode() string
-
-	// BuildConfigIntent returns the ConfigIntent the mode's plan would feed
-	// to TaskConfigApply (mode + merged controller / spec overrides). Shared
-	// by BuildPlan (init) and buildNodeUpdatePlan (day-2) so they emit
-	// identical config payloads for the same spec. Day-2 callers set
-	// Incremental on the returned value before passing it through.
-	BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error)
 }
 
 // GroupPlanner encapsulates logic for building a group-level task plan.
@@ -709,24 +711,17 @@ func commonOverrides(node *seiv1alpha1.SeiNode) map[string]string {
 	return out
 }
 
-// buildRunningPlan returns a steady-state drift plan, or nil if no drift.
-// Image drift is checked first — its plan ends with MarkReady, so it also
-// resolves any stale sidecar.
-func buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
-	if node.Spec.Image != node.Status.CurrentImage {
-		return buildNodeUpdatePlan(node)
-	}
-	if sidecarNeedsReapproval(node) {
-		return buildMarkReadyPlan(node)
-	}
-	return nil, nil
-}
-
+// sidecarNeedsReapproval reports whether the sidecar has been observed
+// to have lost readiness. Mode-agnostic — any mode planner that's in
+// the running phase checks this and routes to buildMarkReadyPlan.
 func sidecarNeedsReapproval(node *seiv1alpha1.SeiNode) bool {
 	cond := meta.FindStatusCondition(node.Status.Conditions, seiv1alpha1.ConditionSidecarReady)
 	return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == "NotReady"
 }
 
+// buildMarkReadyPlan is the single-task plan used to re-mark sidecar
+// readiness. Mode-agnostic — kept as a free helper so each mode planner
+// can call it directly from its running-phase branch.
 func buildMarkReadyPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	planID := uuid.New().String()
 	t, err := buildPlannedTask(planID, sidecar.TaskTypeMarkReady, 0, paramsForTaskType(node, sidecar.TaskTypeMarkReady, nil, nil))
@@ -741,54 +736,48 @@ func buildMarkReadyPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error
 	}, nil
 }
 
-// buildNodeUpdatePlan constructs a plan to roll out an image update on a
-// Running node. The plan applies the new StatefulSet spec, re-applies
-// config.toml (incremental — only the keys the controller owns), then
-// cycles the pod and re-initializes the sidecar.
+// imageDrifted reports whether the running pod's currently-observed
+// image diverges from the spec'd image. Mode-agnostic check; the
+// returned task list is mode-specific (each planner assembles its own).
+func imageDrifted(node *seiv1alpha1.SeiNode) bool {
+	return node.Spec.Image != node.Status.CurrentImage
+}
+
+// externalAddressPatch returns the day-2 config.toml patch that stamps
+// the publishable P2P external address. Empty Spec.ExternalAddress means
+// the SND is not opted into publishable P2P; emit an empty-string patch
+// so opt-out reaches the pod symmetrically with opt-in.
+func externalAddressPatch(node *seiv1alpha1.SeiNode) map[string]map[string]any {
+	return map[string]map[string]any{
+		"config.toml": {
+			"p2p": map[string]any{
+				"external-address": node.Spec.ExternalAddress,
+			},
+		},
+	}
+}
+
+// assembleDay2Plan composes a day-2 task progression into a TaskPlan,
+// shared by every mode planner so the boilerplate (planID, ordering,
+// param marshaling, phase fields) lives in one place. The progression
+// slice IS the per-mode authorship — each planner decides which tasks
+// it needs (e.g. validator prepends key-validation gates).
+//
+// patch carries the TOML fragments the controller wants stamped into
+// named files for TaskConfigPatch; pass nil if the planner's progression
+// doesn't include a config-patch step (none today).
 //
 // FailedPhase is deliberately empty: a failure retries on the next reconcile
 // rather than transitioning the node out of Running.
-//
-// TaskConfigApply is placed before ReplacePod so the old pod's sidecar
-// writes the new config.toml to the PVC; the new pod then mounts the
-// PVC and reads the fresh file at seid start. external_address has no
-// hot-reload path in seid today (see seictl config_reload.go), so the
-// pod restart is the trigger that makes new values take effect.
-//
-// Incremental=true is mandatory on the day-2 intent. The init path uses
-// the non-incremental applyFull, which regenerates config from mode
-// defaults + overrides; running that on day 2 would wipe persistent-peers,
-// state-sync trust point, and any operator-managed TOML keys that the
-// controller doesn't track in overrides. applyIncremental reads on-disk
-// config and patches only the overrides we own.
-func buildNodeUpdatePlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
+func assembleDay2Plan(node *seiv1alpha1.SeiNode, prog []string, patch map[string]map[string]any) (*seiv1alpha1.TaskPlan, error) {
 	setNodeUpdateCondition(node, metav1.ConditionTrue, "UpdateStarted",
 		fmt.Sprintf("image drift detected: spec=%s current=%s", node.Spec.Image, node.Status.CurrentImage))
-
-	mode, err := plannerForMode(node)
-	if err != nil {
-		return nil, fmt.Errorf("resolving mode planner: %w", err)
-	}
-	intent, err := mode.BuildConfigIntent(node)
-	if err != nil {
-		return nil, fmt.Errorf("building config intent: %w", err)
-	}
-	intent.Incremental = true
-
-	prog := []string{
-		task.TaskTypeApplyStatefulSet,
-		task.TaskTypeApplyService,
-		TaskConfigApply,
-		TaskConfigValidate,
-		task.TaskTypeReplacePod,
-		task.TaskTypeObserveImage,
-		sidecar.TaskTypeMarkReady,
-	}
 
 	planID := uuid.New().String()
 	tasks := make([]seiv1alpha1.PlannedTask, len(prog))
 	for i, taskType := range prog {
-		t, err := buildPlannedTask(planID, taskType, i, paramsForTaskType(node, taskType, nil, intent))
+		params := paramsForDay2Task(node, taskType, patch)
+		t, err := buildPlannedTask(planID, taskType, i, params)
 		if err != nil {
 			return nil, err
 		}
@@ -800,6 +789,17 @@ func buildNodeUpdatePlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, erro
 		Tasks:       tasks,
 		TargetPhase: seiv1alpha1.PhaseRunning,
 	}, nil
+}
+
+// paramsForDay2Task is a thin wrapper around paramsForTaskType that
+// returns the config-patch params when the task type is TaskConfigPatch.
+// All other task types delegate to paramsForTaskType with nil intent —
+// day-2 plans never carry a ConfigIntent.
+func paramsForDay2Task(node *seiv1alpha1.SeiNode, taskType string, patch map[string]map[string]any) any {
+	if taskType == TaskConfigPatch {
+		return task.ConfigPatchTask{Files: patch}
+	}
+	return paramsForTaskType(node, taskType, nil, nil)
 }
 
 // mergeOverrides combines controller-generated overrides with user-specified

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -63,6 +63,13 @@ type NodePlanner interface {
 	Validate(node *seiv1alpha1.SeiNode) error
 	BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error)
 	Mode() string
+
+	// BuildConfigIntent returns the ConfigIntent the mode's plan would feed
+	// to TaskConfigApply (mode + merged controller / spec overrides). Shared
+	// by BuildPlan (init) and buildNodeUpdatePlan (day-2) so they emit
+	// identical config payloads for the same spec. Day-2 callers set
+	// Incremental on the returned value before passing it through.
+	BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error)
 }
 
 // GroupPlanner encapsulates logic for building a group-level task plan.
@@ -735,18 +742,44 @@ func buildMarkReadyPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error
 }
 
 // buildNodeUpdatePlan constructs a plan to roll out an image update on a
-// Running node. The plan applies the new StatefulSet spec, waits for the
-// rollout to complete, then re-initializes the sidecar.
+// Running node. The plan applies the new StatefulSet spec, re-applies
+// config.toml (incremental — only the keys the controller owns), then
+// cycles the pod and re-initializes the sidecar.
 //
 // FailedPhase is deliberately empty: a failure retries on the next reconcile
 // rather than transitioning the node out of Running.
+//
+// TaskConfigApply is placed before ReplacePod so the old pod's sidecar
+// writes the new config.toml to the PVC; the new pod then mounts the
+// PVC and reads the fresh file at seid start. external_address has no
+// hot-reload path in seid today (see seictl config_reload.go), so the
+// pod restart is the trigger that makes new values take effect.
+//
+// Incremental=true is mandatory on the day-2 intent. The init path uses
+// the non-incremental applyFull, which regenerates config from mode
+// defaults + overrides; running that on day 2 would wipe persistent-peers,
+// state-sync trust point, and any operator-managed TOML keys that the
+// controller doesn't track in overrides. applyIncremental reads on-disk
+// config and patches only the overrides we own.
 func buildNodeUpdatePlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	setNodeUpdateCondition(node, metav1.ConditionTrue, "UpdateStarted",
 		fmt.Sprintf("image drift detected: spec=%s current=%s", node.Spec.Image, node.Status.CurrentImage))
 
+	mode, err := plannerForMode(node)
+	if err != nil {
+		return nil, fmt.Errorf("resolving mode planner: %w", err)
+	}
+	intent, err := mode.BuildConfigIntent(node)
+	if err != nil {
+		return nil, fmt.Errorf("building config intent: %w", err)
+	}
+	intent.Incremental = true
+
 	prog := []string{
 		task.TaskTypeApplyStatefulSet,
 		task.TaskTypeApplyService,
+		TaskConfigApply,
+		TaskConfigValidate,
 		task.TaskTypeReplacePod,
 		task.TaskTypeObserveImage,
 		sidecar.TaskTypeMarkReady,
@@ -755,7 +788,7 @@ func buildNodeUpdatePlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, erro
 	planID := uuid.New().String()
 	tasks := make([]seiv1alpha1.PlannedTask, len(prog))
 	for i, taskType := range prog {
-		t, err := buildPlannedTask(planID, taskType, i, paramsForTaskType(node, taskType, nil, nil))
+		t, err := buildPlannedTask(planID, taskType, i, paramsForTaskType(node, taskType, nil, intent))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -58,16 +58,12 @@ var baseProgression = map[string][]string{
 	"genesis":    {TaskConfigApply, TaskConfigValidate, TaskMarkReady},
 }
 
-// NodePlanner encapsulates mode-specific logic for validating a SeiNode
-// and building its task plan. BuildPlan dispatches internally between
-// startup (init) and existing-resource (day-2) shapes — callers don't
-// see the distinction and the interface stays narrow.
+// NodePlanner encapsulates mode-specific plan construction. BuildPlan
+// dispatches internally between startup (init) and an existing
+// running resource — callers don't see the distinction.
 //
-// Rule of thumb for implementations: init plans write the whole config
-// file via TaskConfigApply (sei-config mode-defaulted resolution).
-// Day-2 plans patch only the keys the controller directly owns via
-// TaskConfigPatch (generic TOML merge, no sei-config involvement).
-// Never mix the two in one plan.
+// Convention: init writes the whole config via TaskConfigApply; an
+// existing resource patches only controller-owned keys via TaskConfigPatch.
 type NodePlanner interface {
 	Validate(node *seiv1alpha1.SeiNode) error
 	BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error)
@@ -712,16 +708,13 @@ func commonOverrides(node *seiv1alpha1.SeiNode) map[string]string {
 }
 
 // sidecarNeedsReapproval reports whether the sidecar has been observed
-// to have lost readiness. Mode-agnostic — any mode planner that's in
-// the running phase checks this and routes to buildMarkReadyPlan.
+// to have lost readiness. Mode-agnostic.
 func sidecarNeedsReapproval(node *seiv1alpha1.SeiNode) bool {
 	cond := meta.FindStatusCondition(node.Status.Conditions, seiv1alpha1.ConditionSidecarReady)
 	return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == "NotReady"
 }
 
-// buildMarkReadyPlan is the single-task plan used to re-mark sidecar
-// readiness. Mode-agnostic — kept as a free helper so each mode planner
-// can call it directly from its running-phase branch.
+// buildMarkReadyPlan is the single-task plan that re-marks sidecar readiness.
 func buildMarkReadyPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	planID := uuid.New().String()
 	t, err := buildPlannedTask(planID, sidecar.TaskTypeMarkReady, 0, paramsForTaskType(node, sidecar.TaskTypeMarkReady, nil, nil))
@@ -736,17 +729,13 @@ func buildMarkReadyPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error
 	}, nil
 }
 
-// imageDrifted reports whether the running pod's currently-observed
-// image diverges from the spec'd image. Mode-agnostic check; the
-// returned task list is mode-specific (each planner assembles its own).
 func imageDrifted(node *seiv1alpha1.SeiNode) bool {
 	return node.Spec.Image != node.Status.CurrentImage
 }
 
-// externalAddressPatch returns the day-2 config.toml patch that stamps
-// the publishable P2P external address. Empty Spec.ExternalAddress means
-// the SND is not opted into publishable P2P; emit an empty-string patch
-// so opt-out reaches the pod symmetrically with opt-in.
+// externalAddressPatch is the config.toml patch that stamps the
+// publishable-P2P external address. An empty Spec.ExternalAddress
+// stamps an empty value so opt-out reaches the pod symmetrically.
 func externalAddressPatch(node *seiv1alpha1.SeiNode) map[string]map[string]any {
 	return map[string]map[string]any{
 		"config.toml": {
@@ -757,26 +746,21 @@ func externalAddressPatch(node *seiv1alpha1.SeiNode) map[string]map[string]any {
 	}
 }
 
-// assembleDay2Plan composes a day-2 task progression into a TaskPlan,
-// shared by every mode planner so the boilerplate (planID, ordering,
-// param marshaling, phase fields) lives in one place. The progression
-// slice IS the per-mode authorship — each planner decides which tasks
-// it needs (e.g. validator prepends key-validation gates).
-//
-// patch carries the TOML fragments the controller wants stamped into
-// named files for TaskConfigPatch; pass nil if the planner's progression
-// doesn't include a config-patch step (none today).
+// assembleUpdatePlan composes a task progression for a Running node into
+// a TaskPlan. The progression slice is the per-mode authorship — each
+// planner decides which tasks it needs (e.g. validator prepends
+// key-validation gates).
 //
 // FailedPhase is deliberately empty: a failure retries on the next reconcile
 // rather than transitioning the node out of Running.
-func assembleDay2Plan(node *seiv1alpha1.SeiNode, prog []string, patch map[string]map[string]any) (*seiv1alpha1.TaskPlan, error) {
+func assembleUpdatePlan(node *seiv1alpha1.SeiNode, prog []string, patch map[string]map[string]any) (*seiv1alpha1.TaskPlan, error) {
 	setNodeUpdateCondition(node, metav1.ConditionTrue, "UpdateStarted",
 		fmt.Sprintf("image drift detected: spec=%s current=%s", node.Spec.Image, node.Status.CurrentImage))
 
 	planID := uuid.New().String()
 	tasks := make([]seiv1alpha1.PlannedTask, len(prog))
 	for i, taskType := range prog {
-		params := paramsForDay2Task(node, taskType, patch)
+		params := paramsForUpdateTask(node, taskType, patch)
 		t, err := buildPlannedTask(planID, taskType, i, params)
 		if err != nil {
 			return nil, err
@@ -791,11 +775,10 @@ func assembleDay2Plan(node *seiv1alpha1.SeiNode, prog []string, patch map[string
 	}, nil
 }
 
-// paramsForDay2Task is a thin wrapper around paramsForTaskType that
-// returns the config-patch params when the task type is TaskConfigPatch.
-// All other task types delegate to paramsForTaskType with nil intent —
-// day-2 plans never carry a ConfigIntent.
-func paramsForDay2Task(node *seiv1alpha1.SeiNode, taskType string, patch map[string]map[string]any) any {
+// paramsForUpdateTask returns the config-patch params for TaskConfigPatch
+// and delegates everything else to paramsForTaskType with nil intent —
+// update plans on a Running node never carry a ConfigIntent.
+func paramsForUpdateTask(node *seiv1alpha1.SeiNode, taskType string, patch map[string]map[string]any) any {
 	if taskType == TaskConfigPatch {
 		return task.ConfigPatchTask{Files: patch}
 	}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -733,9 +733,8 @@ func imageDrifted(node *seiv1alpha1.SeiNode) bool {
 	return node.Spec.Image != node.Status.CurrentImage
 }
 
-// imageDriftMessage formats the standard NodeUpdateInProgress message
-// for image-drift-triggered plans, used by every mode planner's
-// buildRunningPlan before calling assembleUpdatePlan.
+// imageDriftMessage formats the NodeUpdateInProgress message every mode
+// planner stamps before an image-drift-triggered assembleUpdatePlan call.
 func imageDriftMessage(node *seiv1alpha1.SeiNode) string {
 	return fmt.Sprintf("image drift detected: spec=%s current=%s", node.Spec.Image, node.Status.CurrentImage)
 }
@@ -753,14 +752,10 @@ func externalAddressPatch(node *seiv1alpha1.SeiNode) map[string]map[string]any {
 	}
 }
 
-// assembleUpdatePlan composes a task progression for a Running node into
-// a TaskPlan. Pure boilerplate (planID, task ordering, param marshaling,
-// phase fields) — the progression slice is the per-mode authorship.
-// Callers own the NodeUpdateInProgress condition: stamp it before calling
-// so the reason/message reflects the actual trigger.
-//
-// FailedPhase is deliberately empty: a failure retries on the next reconcile
-// rather than transitioning the node out of Running.
+// assembleUpdatePlan composes a per-mode task progression into a TaskPlan.
+// Callers own the NodeUpdateInProgress condition — stamp it before calling
+// so the reason/message reflects the actual trigger. FailedPhase stays
+// empty so a failure retries on next reconcile.
 func assembleUpdatePlan(node *seiv1alpha1.SeiNode, prog []string, patch map[string]map[string]any) (*seiv1alpha1.TaskPlan, error) {
 	planID := uuid.New().String()
 	tasks := make([]seiv1alpha1.PlannedTask, len(prog))
@@ -780,9 +775,9 @@ func assembleUpdatePlan(node *seiv1alpha1.SeiNode, prog []string, patch map[stri
 	}, nil
 }
 
-// paramsForUpdateTask returns the config-patch params for TaskConfigPatch
-// and delegates everything else to paramsForTaskType with nil intent —
-// update plans on a Running node never carry a ConfigIntent.
+// paramsForUpdateTask returns ConfigPatchTask params for TaskConfigPatch
+// and delegates everything else to paramsForTaskType. Update plans never
+// carry a ConfigIntent — those are init-path only.
 func paramsForUpdateTask(node *seiv1alpha1.SeiNode, taskType string, patch map[string]map[string]any) any {
 	if taskType == TaskConfigPatch {
 		return task.ConfigPatchTask{Files: patch}

--- a/internal/planner/replay.go
+++ b/internal/planner/replay.go
@@ -48,6 +48,9 @@ func (p *replayerPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 }
 
 func (p *replayerPlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
+	if node.Spec.Replayer == nil {
+		return nil, fmt.Errorf("replayer sub-spec is nil")
+	}
 	return &seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeFull,
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides()), node.Spec.Overrides),

--- a/internal/planner/replay.go
+++ b/internal/planner/replay.go
@@ -37,14 +37,21 @@ func (p *replayerPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 	if node.Status.Phase == seiv1alpha1.PhaseRunning {
 		return buildRunningPlan(node)
 	}
-	params := &seiconfig.ConfigIntent{
-		Mode:      seiconfig.ModeFull,
-		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides()), node.Spec.Overrides),
+	params, err := p.BuildConfigIntent(node)
+	if err != nil {
+		return nil, err
 	}
 	if NeedsBootstrap(node) {
 		return buildBootstrapPlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, params)
 	}
 	return buildBasePlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, params)
+}
+
+func (p *replayerPlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
+	return &seiconfig.ConfigIntent{
+		Mode:      seiconfig.ModeFull,
+		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides()), node.Spec.Overrides),
+	}, nil
 }
 
 func (p *replayerPlanner) controllerOverrides() map[string]string {

--- a/internal/planner/replay.go
+++ b/internal/planner/replay.go
@@ -48,8 +48,8 @@ func (p *replayerPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 	return buildBasePlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, intent)
 }
 
-// buildRunningPlan returns the day-2 plan for a Running replayer node.
-// Same shape as full/archive — see full.go's buildRunningPlan.
+// buildRunningPlan returns the update plan for a Running replayer node.
+// Same shape as full and archive.
 func (p *replayerPlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if imageDrifted(node) {
 		prog := []string{
@@ -61,7 +61,7 @@ func (p *replayerPlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alp
 			task.TaskTypeObserveImage,
 			TaskMarkReady,
 		}
-		return assembleDay2Plan(node, prog, externalAddressPatch(node))
+		return assembleUpdatePlan(node, prog, externalAddressPatch(node))
 	}
 	if sidecarNeedsReapproval(node) {
 		return buildMarkReadyPlan(node)

--- a/internal/planner/replay.go
+++ b/internal/planner/replay.go
@@ -6,6 +6,7 @@ import (
 	seiconfig "github.com/sei-protocol/sei-config"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/task"
 )
 
 type replayerPlanner struct {
@@ -35,26 +36,37 @@ func (p *replayerPlanner) Validate(node *seiv1alpha1.SeiNode) error {
 
 func (p *replayerPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if node.Status.Phase == seiv1alpha1.PhaseRunning {
-		return buildRunningPlan(node)
+		return p.buildRunningPlan(node)
 	}
-	params, err := p.BuildConfigIntent(node)
-	if err != nil {
-		return nil, err
-	}
-	if NeedsBootstrap(node) {
-		return buildBootstrapPlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, params)
-	}
-	return buildBasePlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, params)
-}
-
-func (p *replayerPlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
-	if node.Spec.Replayer == nil {
-		return nil, fmt.Errorf("replayer sub-spec is nil")
-	}
-	return &seiconfig.ConfigIntent{
+	intent := &seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeFull,
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides()), node.Spec.Overrides),
-	}, nil
+	}
+	if NeedsBootstrap(node) {
+		return buildBootstrapPlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, intent)
+	}
+	return buildBasePlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, intent)
+}
+
+// buildRunningPlan returns the day-2 plan for a Running replayer node.
+// Same shape as full/archive — see full.go's buildRunningPlan.
+func (p *replayerPlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
+	if imageDrifted(node) {
+		prog := []string{
+			task.TaskTypeApplyStatefulSet,
+			task.TaskTypeApplyService,
+			TaskConfigPatch,
+			TaskConfigValidate,
+			task.TaskTypeReplacePod,
+			task.TaskTypeObserveImage,
+			TaskMarkReady,
+		}
+		return assembleDay2Plan(node, prog, externalAddressPatch(node))
+	}
+	if sidecarNeedsReapproval(node) {
+		return buildMarkReadyPlan(node)
+	}
+	return nil, nil
 }
 
 func (p *replayerPlanner) controllerOverrides() map[string]string {

--- a/internal/planner/replay.go
+++ b/internal/planner/replay.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	seiconfig "github.com/sei-protocol/sei-config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/task"
@@ -52,6 +53,7 @@ func (p *replayerPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 // Same shape as full and archive.
 func (p *replayerPlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if imageDrifted(node) {
+		setNodeUpdateCondition(node, metav1.ConditionTrue, "UpdateStarted", imageDriftMessage(node))
 		prog := []string{
 			task.TaskTypeApplyStatefulSet,
 			task.TaskTypeApplyService,

--- a/internal/planner/validator.go
+++ b/internal/planner/validator.go
@@ -111,6 +111,9 @@ func (p *validatorPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Ta
 }
 
 func (p *validatorPlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
+	if node.Spec.Validator == nil {
+		return nil, fmt.Errorf("validator sub-spec is nil")
+	}
 	return &seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeValidator,
 		Overrides: mergeOverrides(commonOverrides(node), node.Spec.Overrides),

--- a/internal/planner/validator.go
+++ b/internal/planner/validator.go
@@ -6,6 +6,7 @@ import (
 	seiconfig "github.com/sei-protocol/sei-config"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/task"
 )
 
 type validatorPlanner struct {
@@ -94,28 +95,47 @@ func validateOperatorKeyringDistinctness(v *seiv1alpha1.ValidatorSpec) error {
 
 func (p *validatorPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if node.Status.Phase == seiv1alpha1.PhaseRunning {
-		return buildRunningPlan(node)
+		return p.buildRunningPlan(node)
 	}
 	if isGenesisCeremonyNode(node) {
 		return buildGenesisPlan(node)
 	}
 	v := node.Spec.Validator
-	params, err := p.BuildConfigIntent(node)
-	if err != nil {
-		return nil, err
-	}
-	if NeedsBootstrap(node) {
-		return buildBootstrapPlan(node, node.Spec.Peers, v.Snapshot, params)
-	}
-	return buildBasePlan(node, node.Spec.Peers, v.Snapshot, params)
-}
-
-func (p *validatorPlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
-	if node.Spec.Validator == nil {
-		return nil, fmt.Errorf("validator sub-spec is nil")
-	}
-	return &seiconfig.ConfigIntent{
+	intent := &seiconfig.ConfigIntent{
 		Mode:      seiconfig.ModeValidator,
 		Overrides: mergeOverrides(commonOverrides(node), node.Spec.Overrides),
-	}, nil
+	}
+	if NeedsBootstrap(node) {
+		return buildBootstrapPlan(node, node.Spec.Peers, v.Snapshot, intent)
+	}
+	return buildBasePlan(node, node.Spec.Peers, v.Snapshot, intent)
+}
+
+// buildRunningPlan returns the day-2 plan for a Running validator. The
+// progression prepends ValidateSigningKey / ValidateNodeKey /
+// ValidateOperatorKeyring before any STS or pod mutation: a missing or
+// malformed key secret must abort *before* we touch the StatefulSet
+// (which would otherwise schedule a pod that fails its kubelet volume
+// mount with no controller-side error context). Mirrors the same
+// readiness gates the validator's init plan applies in buildBasePlan.
+func (p *validatorPlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
+	if imageDrifted(node) {
+		prog := []string{
+			task.TaskTypeValidateSigningKey,
+			task.TaskTypeValidateNodeKey,
+			task.TaskTypeValidateOperatorKeyring,
+			task.TaskTypeApplyStatefulSet,
+			task.TaskTypeApplyService,
+			TaskConfigPatch,
+			TaskConfigValidate,
+			task.TaskTypeReplacePod,
+			task.TaskTypeObserveImage,
+			TaskMarkReady,
+		}
+		return assembleDay2Plan(node, prog, externalAddressPatch(node))
+	}
+	if sidecarNeedsReapproval(node) {
+		return buildMarkReadyPlan(node)
+	}
+	return nil, nil
 }

--- a/internal/planner/validator.go
+++ b/internal/planner/validator.go
@@ -111,13 +111,10 @@ func (p *validatorPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Ta
 	return buildBasePlan(node, node.Spec.Peers, v.Snapshot, intent)
 }
 
-// buildRunningPlan returns the day-2 plan for a Running validator. The
-// progression prepends ValidateSigningKey / ValidateNodeKey /
-// ValidateOperatorKeyring before any STS or pod mutation: a missing or
-// malformed key secret must abort *before* we touch the StatefulSet
-// (which would otherwise schedule a pod that fails its kubelet volume
-// mount with no controller-side error context). Mirrors the same
-// readiness gates the validator's init plan applies in buildBasePlan.
+// buildRunningPlan returns the update plan for a Running validator. The
+// key-validation gates run before any STS mutation so a missing or
+// malformed secret aborts with a clear controller-side error rather than
+// a kubelet volume-mount failure on the recreated pod.
 func (p *validatorPlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if imageDrifted(node) {
 		prog := []string{
@@ -132,7 +129,7 @@ func (p *validatorPlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1al
 			task.TaskTypeObserveImage,
 			TaskMarkReady,
 		}
-		return assembleDay2Plan(node, prog, externalAddressPatch(node))
+		return assembleUpdatePlan(node, prog, externalAddressPatch(node))
 	}
 	if sidecarNeedsReapproval(node) {
 		return buildMarkReadyPlan(node)

--- a/internal/planner/validator.go
+++ b/internal/planner/validator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	seiconfig "github.com/sei-protocol/sei-config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/task"
@@ -117,6 +118,7 @@ func (p *validatorPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Ta
 // a kubelet volume-mount failure on the recreated pod.
 func (p *validatorPlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if imageDrifted(node) {
+		setNodeUpdateCondition(node, metav1.ConditionTrue, "UpdateStarted", imageDriftMessage(node))
 		prog := []string{
 			task.TaskTypeValidateSigningKey,
 			task.TaskTypeValidateNodeKey,

--- a/internal/planner/validator.go
+++ b/internal/planner/validator.go
@@ -100,12 +100,19 @@ func (p *validatorPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Ta
 		return buildGenesisPlan(node)
 	}
 	v := node.Spec.Validator
-	params := &seiconfig.ConfigIntent{
-		Mode:      seiconfig.ModeValidator,
-		Overrides: mergeOverrides(commonOverrides(node), node.Spec.Overrides),
+	params, err := p.BuildConfigIntent(node)
+	if err != nil {
+		return nil, err
 	}
 	if NeedsBootstrap(node) {
 		return buildBootstrapPlan(node, node.Spec.Peers, v.Snapshot, params)
 	}
 	return buildBasePlan(node, node.Spec.Peers, v.Snapshot, params)
+}
+
+func (p *validatorPlanner) BuildConfigIntent(node *seiv1alpha1.SeiNode) (*seiconfig.ConfigIntent, error) {
+	return &seiconfig.ConfigIntent{
+		Mode:      seiconfig.ModeValidator,
+		Overrides: mergeOverrides(commonOverrides(node), node.Spec.Overrides),
+	}, nil
 }

--- a/internal/task/config_patch.go
+++ b/internal/task/config_patch.go
@@ -1,0 +1,28 @@
+package task
+
+import (
+	sidecar "github.com/sei-protocol/seictl/sidecar/client"
+)
+
+// ConfigPatchTask satisfies sidecar.TaskBuilder for config-patch. The
+// controller stamps a subset of TOML keys it directly owns into named
+// files; the sidecar handler is a generic merge-and-write per file with
+// no sei-config involvement. Used for day-2 reconvergence where the
+// controller wants surgical authority over operational fields without
+// re-running the typed mode-defaulted resolver.
+//
+// JSON tag matches the wire format sidecar.ConfigPatchTask serializes
+// (sidecar handler expects {"files": {...}}).
+type ConfigPatchTask struct {
+	Files map[string]map[string]any `json:"files"`
+}
+
+func (t ConfigPatchTask) TaskType() string { return sidecar.TaskTypeConfigPatch }
+
+func (t ConfigPatchTask) Validate() error {
+	return sidecar.ConfigPatchTask{Files: t.Files}.Validate()
+}
+
+func (t ConfigPatchTask) ToTaskRequest() sidecar.TaskRequest {
+	return sidecar.ConfigPatchTask{Files: t.Files}.ToTaskRequest()
+}

--- a/internal/task/config_patch.go
+++ b/internal/task/config_patch.go
@@ -4,15 +4,10 @@ import (
 	sidecar "github.com/sei-protocol/seictl/sidecar/client"
 )
 
-// ConfigPatchTask satisfies sidecar.TaskBuilder for config-patch. The
-// controller stamps a subset of TOML keys it directly owns into named
-// files; the sidecar handler is a generic merge-and-write per file with
-// no sei-config involvement. Used for day-2 reconvergence where the
-// controller wants surgical authority over operational fields without
-// re-running the typed mode-defaulted resolver.
-//
-// JSON tag matches the wire format sidecar.ConfigPatchTask serializes
-// (sidecar handler expects {"files": {...}}).
+// ConfigPatchTask stamps controller-owned TOML keys into named seid
+// config files via a generic merge-and-write on the sidecar — no
+// sei-config involvement. JSON tag matches the wire format
+// sidecar.ConfigPatchTask emits.
 type ConfigPatchTask struct {
 	Files map[string]map[string]any `json:"files"`
 }

--- a/internal/task/config_patch.go
+++ b/internal/task/config_patch.go
@@ -5,9 +5,8 @@ import (
 )
 
 // ConfigPatchTask stamps controller-owned TOML keys into named seid
-// config files via a generic merge-and-write on the sidecar — no
-// sei-config involvement. JSON tag matches the wire format
-// sidecar.ConfigPatchTask emits.
+// config files via the sidecar's generic merge-and-write. The json tag
+// matches the wire format the sidecar deserializes.
 type ConfigPatchTask struct {
 	Files map[string]map[string]any `json:"files"`
 }

--- a/internal/task/config_patch_test.go
+++ b/internal/task/config_patch_test.go
@@ -1,0 +1,34 @@
+package task
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// The sidecar handler keys its deserialization on a literal "files" JSON
+// field (sidecar/tasks/config.go ConfigPatchRequest). Dropping the json
+// tag on ConfigPatchTask.Files would silently break every patch at
+// runtime — Go's default would emit "Files" capitalized and the sidecar
+// would see an empty params block. Pin the wire format here so a
+// regression in the tag fails fast at unit-test time.
+func TestConfigPatchTask_JSONWireFormatUsesFilesKey(t *testing.T) {
+	g := NewWithT(t)
+	in := ConfigPatchTask{Files: map[string]map[string]any{
+		"config.toml": {"p2p": map[string]any{"external-address": "host:26656"}},
+	}}
+
+	raw, err := json.Marshal(in)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var asMap map[string]any
+	g.Expect(json.Unmarshal(raw, &asMap)).To(Succeed())
+	g.Expect(asMap).To(HaveKey("files"), "sidecar deserializes by 'files' key — drop the json tag and patches silently no-op")
+	g.Expect(asMap).NotTo(HaveKey("Files"), "capitalised 'Files' would mean the json tag was dropped")
+
+	// Roundtrip back into the controller-side type.
+	var out ConfigPatchTask
+	g.Expect(json.Unmarshal(raw, &out)).To(Succeed())
+	g.Expect(out.Files).To(Equal(in.Files))
+}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -204,6 +204,7 @@ var registry = map[string]taskDeserializer{
 	sidecar.TaskTypeConfigureStateSync:     sidecarTask[sidecar.ConfigureStateSyncTask](false),
 	sidecar.TaskTypeAwaitCondition:         sidecarTask[sidecar.AwaitConditionTask](false),
 	sidecar.TaskTypeConfigApply:            sidecarTask[configApplyTask](false),
+	sidecar.TaskTypeConfigPatch:            sidecarTask[ConfigPatchTask](false),
 	sidecar.TaskTypeConfigValidate:         sidecarTask[sidecar.ConfigValidateTask](true),
 	sidecar.TaskTypeConfigureGenesis:       sidecarTask[sidecar.ConfigureGenesisTask](false),
 	sidecar.TaskTypeDiscoverPeers:          sidecarTask[sidecar.DiscoverPeersTask](false),


### PR DESCRIPTION
## Problem

When a SeiNode is in `Running` phase, the controller's update plan rolls the pod but never re-applies `config.toml`. Any controller-owned field that flips after init — `Spec.ExternalAddress` from the publishable-P2P feature being the load-bearing example — stays empty on the pod. Inbound NLB → pod works; outbound advertising (NodeInfo / PEX) doesn't, because seid reads `external-address = ''` from the stale config.

Caught during the arctic-1 canary rollout (platform#764–771). With AWS LBC + harbor `SEI_NLB_TARGET_TYPE=instance` in place, the NLB path is live, but seid still doesn't tell other peers how to reach it.

## Fix

Each mode planner's `BuildPlan` now dispatches internally between init and a Running node. The Running branch emits an update plan with a `TaskConfigPatch` between `ApplyService` and `ReplacePod`:

```
[validator only: ValidateSigningKey → ValidateNodeKey → ValidateOperatorKeyring →]
ApplyStatefulSet → ApplyService → TaskConfigPatch → TaskConfigValidate →
ReplacePod → ObserveImage → MarkReady
```

`TaskConfigPatch` is a generic TOML merge — read the file, merge the controller-named keys, write back. No sei-config involvement. The patch the controller emits today is literally `{"config.toml": {"p2p": {"external-address": Spec.ExternalAddress}}}`. `TaskConfigValidate` after the patch is the parser-level gate (sei-config's typed Diagnostics are deliberately not re-run on the day-2 path — keeps the controller decoupled from sei-config's typed registry).

The validator's progression prepends the three key-validation gates so a missing or malformed secret aborts before any STS mutation (Cursor Bugbot finding).

## Design notes the iteration converged on

- **`NodePlanner` interface unchanged** from main: `Validate`, `BuildPlan`, `Mode`. Reconciler/executor just call `BuildPlan` and get a plan. Earlier iterations lifted `BuildConfigIntent` onto the interface; user feedback was that lifting config-intent out made it a special case. Each mode planner now owns its full update progression inline.
- **Init writes the whole config via `TaskConfigApply` (sei-config mode-defaulted). An existing running resource patches only controller-owned keys via `TaskConfigPatch`.** Never both in one plan. Stated as a doc rule on `NodePlanner` and pinned by `TestPlannerConvention_InitUsesApply_UpdateUsesPatch`.
- **`assembleUpdatePlan` is pure boilerplate** (planID, task ordering, param marshaling, phase fields). Callers own the `NodeUpdateInProgress` condition — they stamp it with the reason/message that reflects their trigger before calling. Keeps the helper generic for future Running-phase triggers without a misleading "image drift detected" message.
- **`pelletier/go-toml/v2` does not preserve comments** on re-encode. First config-patch on a PVC erases operator-added comments. Acknowledged in `fullNodePlanner.buildRunningPlan`.

## Tests

- `TestFullPlanner_ImageDrift_UpdateProgression` — 7-task ordering for full nodes.
- `TestArchivePlanner_ImageDrift_UpdateProgression`, `TestReplayerPlanner_ImageDrift_UpdateProgression` — symmetry coverage.
- `TestValidatorPlanner_ImageDrift_PrependsValidationGates` — 10-task ordering with the three validation gates.
- `TestFullPlanner_ConfigPatchCarriesExternalAddress` — patch payload propagates `Spec.ExternalAddress`.
- `TestFullPlanner_ConfigPatchIsDeterministic` — same spec → same patch.
- `TestPlannerConvention_InitUsesApply_UpdateUsesPatch` — init=Apply, update=Patch, never both.
- `TestConfigPatchTask_JSONWireFormatUsesFilesKey` — pins the `json:\"files\"` tag (drop it and every patch silently no-ops at the sidecar).
- Existing `TestFullPlanner_Sidecar*`, `TestFullPlanner_ImageDriftWinsOverSidecar`, condition-lifecycle tests adapted to the new shape.

Unit + envtest + lint all green.

## Out of scope

Autonomous `Spec.ExternalAddress` drift detection on a Running node. Today the patch propagates on the next trigger of `buildRunningPlan` (image drift; operator can SHA-pin to force one). If NLB hostname rotation or `Spec.Overrides` drift become operationally painful, a follow-up adds an external-address drift check that routes to the same update progression.

## Test plan

- [x] CI green (unit, envtest, lint).
- [x] After merge + ECR build + harbor controller image bump: SHA-pinning arctic-1 syncer image triggers `buildRunningPlan` → `config.toml` on the new pod shows `external-address = \"syncer-0-0-p2p.arctic-1.harbor.platform.sei.io:26656\"` → seid logs show PEX advertising the NLB hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)