### PR TITLE
fix(planner): guard validation gates in buildRunningPlan

### DIFF
--- a/internal/controller/nodedeployment/envtest/inplace_rollout_validator_test.go
+++ b/internal/controller/nodedeployment/envtest/inplace_rollout_validator_test.go
@@ -1,0 +1,145 @@
+//go:build envtest
+
+package envtest_test
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
+)
+
+// Structural-only validator key blobs — validate-signing-key /
+// validate-node-key check JSON shape, not cryptographic validity.
+const (
+	rolloutSigningKeyJSON = `{
+  "address": "1B2C3D4E5F60718293A4B5C6D7E8F90112345678",
+  "pub_key": {
+    "type": "tendermint/PubKeyEd25519",
+    "value": "qx2vCe1z4i7p+1mY3V8mO0WX1iU+Z+TQ5z6vE+VbX/Y="
+  },
+  "priv_key": {
+    "type": "tendermint/PrivKeyEd25519",
+    "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACrHa8J7XPiLun7WZjdXyY7RZfWJT5n5NDnPq8T5Vtf9g=="
+  }
+}`
+	rolloutNodeKeyJSON = `{
+  "priv_key": {
+    "type": "tendermint/PrivKeyEd25519",
+    "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACrHa8J7XPiLun7WZjdXyY7RZfWJT5n5NDnPq8T5Vtf9g=="
+  }
+}`
+)
+
+// TestInPlaceRollout_BYOValidator_NoOperatorKeyring drives an image bump on
+// a Running validator that has signingKey+nodeKey but no operatorKeyring —
+// the arctic-1 node-19 migration shape — against a real apiserver with the
+// SeiNode controller, stub sidecar, and StatefulSet faker wired in.
+//
+// Before the buildRunningPlan guard fix, the update path emitted an
+// unconditional validate-operator-keyring task whose params carried an empty
+// secretName, so the child's update plan latched Failed with
+// "validate-operator-keyring: secretName is empty" and the new image never
+// propagated — this test would time out at the second waitFor. With the fix,
+// the unset operatorKeyring is skipped and the rollout completes.
+func TestInPlaceRollout_BYOValidator_NoOperatorKeyring(t *testing.T) {
+	g := NewWithT(t)
+	ns := makeNamespace(t)
+
+	const (
+		oldImage      = "ghcr.io/sei-protocol/seid:v1.0.0"
+		newImage      = "ghcr.io/sei-protocol/seid:v2.0.0"
+		signingSecret = "byo-signing-key"
+		nodeSecret    = "byo-node-key"
+	)
+
+	// Seed the BYO key Secrets so the validate-signing-key /
+	// validate-node-key gates pass on both the create and update plans.
+	g.Expect(testCli.Create(testCtx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: signingSecret, Namespace: ns},
+		Data:       map[string][]byte{"priv_validator_key.json": []byte(rolloutSigningKeyJSON)},
+	})).To(Succeed())
+	g.Expect(testCli.Create(testCtx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeSecret, Namespace: ns},
+		Data:       map[string][]byte{"node_key.json": []byte(rolloutNodeKeyJSON)},
+	})).To(Succeed())
+
+	// Validator with signingKey+nodeKey and NO operatorKeyring. replicas:1
+	// satisfies the signingKey CEL guard.
+	snd := fixtures.NewSND(ns, "byo-val-rollout",
+		fixtures.WithValidator(),
+		fixtures.WithReplicas(1),
+		fixtures.WithImage(oldImage),
+	)
+	snd.Spec.Template.Spec.Validator.SigningKey = &seiv1alpha1.SigningKeySource{
+		Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: signingSecret},
+	}
+	snd.Spec.Template.Spec.Validator.NodeKey = &seiv1alpha1.NodeKeySource{
+		Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: nodeSecret},
+	}
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+	key := client.ObjectKeyFromObject(snd)
+
+	// 1. The create plan completes: the single child reaches Running at the
+	//    old image. The child MUST be Running before the bump so the bump
+	//    routes through buildRunningPlan (the fixed path) rather than the
+	//    create plan.
+	waitFor(t, func() bool {
+		kids := listChildren(t, getSND(t, key))
+		if len(kids) != 1 {
+			return false
+		}
+		return kids[0].Status.Phase == seiv1alpha1.PhaseRunning &&
+			kids[0].Status.CurrentImage == oldImage
+	}, "BYO validator child reaches Running at the old image")
+
+	// 2. Bump the image — drives the running-plan update.
+	patchSNDImage(t, getSND(t, key), newImage)
+
+	// 3. The update plan completes and the new image propagates. Pre-fix
+	//    this never happened: the plan wedged on the operator-keyring gate.
+	waitFor(t, func() bool {
+		kids := listChildren(t, getSND(t, key))
+		if len(kids) != 1 {
+			return false
+		}
+		return kids[0].Status.CurrentImage == newImage
+	}, "BYO validator rolls to the new image via the running-plan update")
+
+	// 4. Regression-specific: the child's update plan never failed on the
+	//    operator-keyring gate (the precise pre-fix failure mode).
+	for _, kid := range listChildren(t, getSND(t, key)) {
+		if kid.Status.Plan != nil && kid.Status.Plan.FailedTaskDetail != nil {
+			g.Expect(kid.Status.Plan.FailedTaskDetail.Error).NotTo(
+				ContainSubstring("operator-keyring"),
+				"child %s must not fail its update plan on the operator-keyring gate", kid.Name)
+		}
+	}
+	for _, kid := range listChildren(t, getSND(t, key)) {
+		if kid.Status.Plan == nil {
+			continue
+		}
+		for _, task := range kid.Status.Plan.Tasks {
+			g.Expect(strings.Contains(task.Type, "operator-keyring")).To(BeFalse(),
+				"child %s plan must not include an operator-keyring task when operatorKeyring is unset", kid.Name)
+		}
+	}
+
+	// 5. The SND-side rollout completes cleanly.
+	waitForStatus(t, key, func(latest *seiv1alpha1.SeiNodeDeployment) bool {
+		cond := apimeta.FindStatusCondition(latest.Status.Conditions, seiv1alpha1.ConditionRolloutInProgress)
+		return latest.Status.Plan == nil &&
+			latest.Status.Rollout == nil &&
+			cond != nil &&
+			cond.Status == metav1.ConditionFalse &&
+			cond.Reason == "RolloutComplete"
+	}, "SND rollout completes for the BYO validator (no operatorKeyring)")
+}

--- a/internal/planner/node_update_test.go
+++ b/internal/planner/node_update_test.go
@@ -320,13 +320,71 @@ func TestPlannerConvention_InitUsesApply_UpdateUsesPatch(t *testing.T) {
 	g.Expect(updateTypes).NotTo(ContainElement(TaskConfigApply), "update must NOT include config-apply")
 }
 
-// Validator's update progression prepends the three key-validation gates
-// so a missing/malformed secret aborts before any STS mutation.
-func TestValidatorPlanner_ImageDrift_PrependsValidationGates(t *testing.T) {
+// Validator's update progression prepends a key-validation gate per
+// declared key source so a missing/malformed secret aborts before any STS
+// mutation. Each gate is guarded by its needs* predicate: a BYO validator
+// with signingKey+nodeKey but no operatorKeyring (the arctic-1 migration
+// shape) gates on signing + node keys only. operatorKeyring is
+// independently optional and must not be validated when unset — otherwise
+// the very first image/sidecar update fails with "secretName is empty".
+func TestValidatorPlanner_ImageDrift_GatesOnDeclaredKeysOnly(t *testing.T) {
 	g := NewWithT(t)
 	node := runningFullNode()
 	node.Spec.FullNode = nil
-	node.Spec.Validator = &seiv1alpha1.ValidatorSpec{}
+	node.Spec.Validator = &seiv1alpha1.ValidatorSpec{
+		SigningKey: &seiv1alpha1.SigningKeySource{
+			Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: "validator-0-key"},
+		},
+		NodeKey: &seiv1alpha1.NodeKeySource{
+			Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: "validator-0-nodekey"},
+		},
+	}
+	node.Spec.Image = testImageV2
+
+	plan, err := (&validatorPlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).NotTo(BeNil())
+
+	g.Expect(planTaskTypes(plan)).To(Equal([]string{
+		task.TaskTypeValidateSigningKey,
+		task.TaskTypeValidateNodeKey,
+		task.TaskTypeApplyStatefulSet,
+		task.TaskTypeApplyService,
+		TaskConfigPatch,
+		TaskConfigValidate,
+		task.TaskTypeReplacePod,
+		task.TaskTypeObserveImage,
+		TaskMarkReady,
+	}))
+	g.Expect(planTaskTypes(plan)).NotTo(
+		ContainElement(task.TaskTypeValidateOperatorKeyring),
+		"unset operatorKeyring must not produce a validation gate",
+	)
+}
+
+// When operatorKeyring IS declared, its validation gate is included
+// alongside the signing and node key gates.
+func TestValidatorPlanner_ImageDrift_IncludesOperatorKeyringGateWhenSet(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	node.Spec.FullNode = nil
+	node.Spec.Validator = &seiv1alpha1.ValidatorSpec{
+		SigningKey: &seiv1alpha1.SigningKeySource{
+			Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: "validator-0-key"},
+		},
+		NodeKey: &seiv1alpha1.NodeKeySource{
+			Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: "validator-0-nodekey"},
+		},
+		OperatorKeyring: &seiv1alpha1.OperatorKeyringSource{
+			Secret: &seiv1alpha1.SecretOperatorKeyringSource{
+				SecretName: "validator-0-operator",
+				PassphraseSecretRef: seiv1alpha1.PassphraseSecretRef{
+					SecretName: "validator-0-operator-pass",
+					Key:        "passphrase",
+				},
+			},
+		},
+	}
 	node.Spec.Image = testImageV2
 
 	plan, err := (&validatorPlanner{}).BuildPlan(node)
@@ -337,6 +395,40 @@ func TestValidatorPlanner_ImageDrift_PrependsValidationGates(t *testing.T) {
 		task.TaskTypeValidateSigningKey,
 		task.TaskTypeValidateNodeKey,
 		task.TaskTypeValidateOperatorKeyring,
+		task.TaskTypeApplyStatefulSet,
+		task.TaskTypeApplyService,
+		TaskConfigPatch,
+		TaskConfigValidate,
+		task.TaskTypeReplacePod,
+		task.TaskTypeObserveImage,
+		TaskMarkReady,
+	}))
+}
+
+// A genesis-ceremony validator that has reached Running routes through
+// buildRunningPlan (the Phase==Running check precedes the ceremony check),
+// and carries none of signingKey/nodeKey/operatorKeyring — so its update
+// plan must emit no validation gates. The old hardcoded slice would have
+// failed these nodes on the empty signing-key gate; the needs* guards fix
+// that latent path too.
+func TestValidatorPlanner_ImageDrift_GenesisCeremonyRunning_NoGates(t *testing.T) {
+	g := NewWithT(t)
+	node := runningFullNode()
+	node.Spec.FullNode = nil
+	node.Spec.Validator = &seiv1alpha1.ValidatorSpec{
+		GenesisCeremony: &seiv1alpha1.GenesisCeremonyNodeConfig{
+			ChainID:        "atlantic-2",
+			StakingAmount:  "10000000usei",
+			AccountBalance: "1000000usei",
+		},
+	}
+	node.Spec.Image = testImageV2
+
+	plan, err := (&validatorPlanner{}).BuildPlan(node)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(plan).NotTo(BeNil())
+
+	g.Expect(planTaskTypes(plan)).To(Equal([]string{
 		task.TaskTypeApplyStatefulSet,
 		task.TaskTypeApplyService,
 		TaskConfigPatch,

--- a/internal/planner/validator.go
+++ b/internal/planner/validator.go
@@ -117,14 +117,25 @@ func (p *validatorPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Ta
 // buildRunningPlan returns the update plan for a Running validator. The
 // key-validation gates run before any STS mutation so a missing or
 // malformed secret aborts with a clear controller-side error rather than
-// a kubelet volume-mount failure on the recreated pod.
+// a kubelet volume-mount failure on the recreated pod. Each gate is
+// guarded by its needs* predicate so an unset field is skipped rather
+// than validated as empty — operatorKeyring is independently optional, so
+// a signingKey+nodeKey validator with no operatorKeyring must not gate on
+// it. Mirrors buildBasePlan's guards.
 func (p *validatorPlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.TaskPlan, error) {
 	if imageDrifted(node) || sidecarImageDrifted(node, p.platform) {
 		setNodeUpdateCondition(node, metav1.ConditionTrue, "UpdateStarted", imageDriftMessage(node, p.platform))
-		prog := []string{
-			task.TaskTypeValidateSigningKey,
-			task.TaskTypeValidateNodeKey,
-			task.TaskTypeValidateOperatorKeyring,
+		prog := make([]string, 0, 10)
+		if needsValidateSigningKey(node) {
+			prog = append(prog, task.TaskTypeValidateSigningKey)
+		}
+		if needsValidateNodeKey(node) {
+			prog = append(prog, task.TaskTypeValidateNodeKey)
+		}
+		if needsValidateOperatorKeyring(node) {
+			prog = append(prog, task.TaskTypeValidateOperatorKeyring)
+		}
+		prog = append(prog,
 			task.TaskTypeApplyStatefulSet,
 			task.TaskTypeApplyService,
 			TaskConfigPatch,
@@ -132,7 +143,7 @@ func (p *validatorPlanner) buildRunningPlan(node *seiv1alpha1.SeiNode) (*seiv1al
 			task.TaskTypeReplacePod,
 			task.TaskTypeObserveImage,
 			TaskMarkReady,
-		}
+		)
 		return assembleUpdatePlan(node, prog, externalAddressPatch(node))
 	}
 	if sidecarNeedsReapproval(node) {


### PR DESCRIPTION
## Problem

A SeiNode validator with `signingKey`+`nodeKey` set but `operatorKeyring` **unset** comes up fine via the create path (`buildBasePlan`), but once it reaches `Status.Phase == Running`, the InPlace update path `buildRunningPlan` (`internal/planner/validator.go`) fails every reconcile that detects image/sidecar drift with:

```
validate-operator-keyring: secretName is empty
```

`buildBasePlan` builds its program incrementally and guards each validation gate with its `needs*` predicate (`needsValidateSigningKey` / `needsValidateNodeKey` / `needsValidateOperatorKeyring`). `buildRunningPlan` instead hardcoded all three into a fixed slice, so a Running validator with no operatorKeyring emits a `validate-operator-keyring` task whose params carry an empty `secretName`, and the task handler fails terminally.

This is a production blocker for the **arctic-1 node-19 migration**: validator-19 has `signingKey`+`nodeKey` and no `operatorKeyring`, so it would bring up cleanly but **brick on its first image upgrade** — the update plan would wedge before `apply-statefulset`/`replace-pod`. It was caught during a harbor dry-run of the migration.

## Fix

Build the running-plan program incrementally with the same `needs*` guards as `buildBasePlan`, so an unset key source is skipped rather than validated as empty. This also repairs the genesis-ceremony-Running path (no key sources), which the old hardcoded slice would have failed on the empty signing-key gate.

## Tests

- **Unit** (`internal/planner/node_update_test.go`): replaced the test that encoded the buggy behavior (empty `ValidatorSpec{}` asserting all three gates) with three cases — declared-keys-only (BYO, no operatorKeyring → operator-keyring gate absent), operatorKeyring-set (all three gates), and genesis-ceremony-Running (no gates).
- **Integration** (`internal/controller/nodedeployment/envtest/inplace_rollout_validator_test.go`): end-to-end against a real apiserver — seeds BYO key Secrets, brings a `replicas:1` no-operatorKeyring validator to Running, bumps the image, and asserts the rollout completes (new image propagates, no child plan fails on the operator-keyring gate, SND reaches `RolloutComplete`). **Verified it fails against the pre-fix code**: the child plan latches `validate-operator-keyring: secretName is empty` and the test times out.

## Review

Cross-reviewed by the kubernetes-specialist: verdict COMPATIBLE. Confirmed the fix mirrors `buildBasePlan`, audited every other program-builder path (`buildBootstrapPlan`, `buildGenesisPlan`, full/archive/replay planners, post-bootstrap progression) — none carries the same bug — and confirmed no skip-regression and no `assembleUpdatePlan` side effects from a variable-length program.