### PR TITLE
test(planner): extract repeated literals to satisfy goconst

### DIFF
--- a/internal/controller/nodedeployment/envtest/inplace_rollout_validator_test.go
+++ b/internal/controller/nodedeployment/envtest/inplace_rollout_validator_test.go
@@ -37,6 +37,10 @@ const (
     "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACrHa8J7XPiLun7WZjdXyY7RZfWJT5n5NDnPq8T5Vtf9g=="
   }
 }`
+
+	// reasonRolloutComplete is the RolloutInProgress condition reason the SND
+	// controller stamps on a finished rollout (see nodedeployment/plan.go).
+	reasonRolloutComplete = "RolloutComplete"
 )
 
 // TestInPlaceRollout_BYOValidator_NoOperatorKeyring drives an image bump on
@@ -140,6 +144,6 @@ func TestInPlaceRollout_BYOValidator_NoOperatorKeyring(t *testing.T) {
 			latest.Status.Rollout == nil &&
 			cond != nil &&
 			cond.Status == metav1.ConditionFalse &&
-			cond.Reason == "RolloutComplete"
+			cond.Reason == reasonRolloutComplete
 	}, "SND rollout completes for the BYO validator (no operatorKeyring)")
 }

--- a/internal/planner/node_update_test.go
+++ b/internal/planner/node_update_test.go
@@ -20,6 +20,8 @@ const (
 	testSidecarImageV1   = "ghcr.io/sei-protocol/seictl@sha256:1111"
 	testSidecarImageV2   = "ghcr.io/sei-protocol/seictl@sha256:2222"
 	testSidecarOverrideV = "ghcr.io/sei-protocol/seictl@sha256:3333"
+	testSigningKeySecret = "validator-0-key"
+	testNodeKeySecret    = "validator-0-nodekey"
 )
 
 func platformWithSidecar(image string) platform.Config {
@@ -333,10 +335,10 @@ func TestValidatorPlanner_ImageDrift_GatesOnDeclaredKeysOnly(t *testing.T) {
 	node.Spec.FullNode = nil
 	node.Spec.Validator = &seiv1alpha1.ValidatorSpec{
 		SigningKey: &seiv1alpha1.SigningKeySource{
-			Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: "validator-0-key"},
+			Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: testSigningKeySecret},
 		},
 		NodeKey: &seiv1alpha1.NodeKeySource{
-			Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: "validator-0-nodekey"},
+			Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: testNodeKeySecret},
 		},
 	}
 	node.Spec.Image = testImageV2
@@ -370,10 +372,10 @@ func TestValidatorPlanner_ImageDrift_IncludesOperatorKeyringGateWhenSet(t *testi
 	node.Spec.FullNode = nil
 	node.Spec.Validator = &seiv1alpha1.ValidatorSpec{
 		SigningKey: &seiv1alpha1.SigningKeySource{
-			Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: "validator-0-key"},
+			Secret: &seiv1alpha1.SecretSigningKeySource{SecretName: testSigningKeySecret},
 		},
 		NodeKey: &seiv1alpha1.NodeKeySource{
-			Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: "validator-0-nodekey"},
+			Secret: &seiv1alpha1.SecretNodeKeySource{SecretName: testNodeKeySecret},
 		},
 		OperatorKeyring: &seiv1alpha1.OperatorKeyringSource{
 			Secret: &seiv1alpha1.SecretOperatorKeyringSource{
@@ -419,7 +421,7 @@ func TestValidatorPlanner_ImageDrift_GenesisCeremonyRunning_NoGates(t *testing.T
 		GenesisCeremony: &seiv1alpha1.GenesisCeremonyNodeConfig{
 			ChainID:        "atlantic-2",
 			StakingAmount:  "10000000usei",
-			AccountBalance: "1000000usei",
+			AccountBalance: testAccountBalance,
 		},
 	}
 	node.Spec.Image = testImageV2


### PR DESCRIPTION
Follow-up to #380. The buildRunningPlan-guard tests added new occurrences of `validator-0-key`, `validator-0-nodekey`, and `1000000usei` that pushed those literals over goconst's threshold on the new lines, so the `lint` job went red on main (test / test-integration / verify-generated were green and #380 auto-merged on the required checks).

Fix: hoist the key-secret names to package-level test constants (`testSigningKeySecret`, `testNodeKeySecret`), reuse the existing `testAccountBalance`, and name the `RolloutComplete` reason in the envtest (`reasonRolloutComplete`). No behavior change; planner unit tests and the BYO-validator envtest still pass.