### PR TITLE
fix(planner): skip empty peer sources to unblock cold-start

### DIFF
--- a/internal/planner/archive.go
+++ b/internal/planner/archive.go
@@ -36,7 +36,7 @@ func (p *archiveNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.
 		Mode:      seiconfig.ModeArchive,
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
 	}
-	return buildBasePlan(node, node.Spec.Peers, nil, intent)
+	return buildBasePlan(node, nil, intent)
 }
 
 // buildRunningPlan returns the update plan for a Running archive node.

--- a/internal/planner/bootstrap.go
+++ b/internal/planner/bootstrap.go
@@ -14,7 +14,6 @@ import (
 // post-bootstrap config tasks that run on the production StatefulSet pod.
 func buildBootstrapPlan(
 	node *seiv1alpha1.SeiNode,
-	peers []seiv1alpha1.PeerSource,
 	snap *seiv1alpha1.SnapshotSource,
 	configIntent *seiconfig.ConfigIntent,
 ) (*seiv1alpha1.TaskPlan, error) {
@@ -24,11 +23,11 @@ func buildBootstrapPlan(
 	jobName := task.BootstrapJobName(node)
 	serviceName := node.Name
 
-	bootstrapProg, err := buildSidecarProgression(snap, peers)
+	bootstrapProg, err := buildSidecarProgression(node, snap)
 	if err != nil {
 		return nil, err
 	}
-	postProg, err := buildPostBootstrapProgression(node, peers)
+	postProg, err := buildPostBootstrapProgression(node)
 	if err != nil {
 		return nil, err
 	}
@@ -132,9 +131,9 @@ func buildBootstrapPlan(
 // a separate, hand-written progression — it runs on the production pod
 // after bootstrap teardown and only includes the config tasks needed to
 // prepare the already-restored data directory for production use.
-func buildPostBootstrapProgression(node *seiv1alpha1.SeiNode, peers []seiv1alpha1.PeerSource) ([]string, error) {
+func buildPostBootstrapProgression(node *seiv1alpha1.SeiNode) ([]string, error) {
 	prog := []string{TaskConfigureGenesis, TaskConfigApply}
-	if len(peers) > 0 {
+	if needsDiscoverPeers(node) {
 		prog = append(prog, TaskDiscoverPeers)
 	}
 	prog = append(prog, TaskConfigValidate, TaskMarkReady)

--- a/internal/planner/discover_peers_test.go
+++ b/internal/planner/discover_peers_test.go
@@ -1,0 +1,144 @@
+package planner
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sidecar "github.com/sei-protocol/seictl/sidecar/client"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+)
+
+const (
+	dpChainID  = "arctic-1"
+	dpChainKey = "sei.io/chain"
+	dpStatic   = "peer1@host:26656"
+)
+
+func nodeWithPeers(peers []seiv1alpha1.PeerSource, resolved []string) *seiv1alpha1.SeiNode {
+	return &seiv1alpha1.SeiNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "n-0", Namespace: dpChainID},
+		Spec:       seiv1alpha1.SeiNodeSpec{Peers: peers},
+		Status:     seiv1alpha1.SeiNodeStatus{ResolvedPeers: resolved},
+	}
+}
+
+func labelSource() seiv1alpha1.PeerSource {
+	return seiv1alpha1.PeerSource{Label: &seiv1alpha1.LabelPeerSource{Selector: map[string]string{dpChainKey: dpChainID}}}
+}
+
+func staticSource() seiv1alpha1.PeerSource {
+	return seiv1alpha1.PeerSource{Static: &seiv1alpha1.StaticPeerSource{Addresses: []string{dpStatic}}}
+}
+
+func TestDiscoverPeersTask(t *testing.T) {
+	resolved := []string{"a-0@a:26656", "b-0@b:26656"}
+
+	cases := []struct {
+		name string
+		node *seiv1alpha1.SeiNode
+		want []sidecar.PeerSource
+	}{
+		{
+			name: "no peers configured",
+			node: nodeWithPeers(nil, nil),
+			want: nil,
+		},
+		{
+			name: "label with zero resolved peers is omitted",
+			node: nodeWithPeers([]seiv1alpha1.PeerSource{labelSource()}, nil),
+			want: nil,
+		},
+		{
+			name: "label with resolved peers emits static",
+			node: nodeWithPeers([]seiv1alpha1.PeerSource{labelSource()}, resolved),
+			want: []sidecar.PeerSource{{Type: sidecar.PeerSourceStatic, Addresses: resolved}},
+		},
+		{
+			name: "static with empty addresses is omitted",
+			node: nodeWithPeers(
+				[]seiv1alpha1.PeerSource{{Static: &seiv1alpha1.StaticPeerSource{Addresses: nil}}},
+				nil,
+			),
+			want: nil,
+		},
+		{
+			name: "static with addresses is emitted",
+			node: nodeWithPeers([]seiv1alpha1.PeerSource{staticSource()}, nil),
+			want: []sidecar.PeerSource{{Type: sidecar.PeerSourceStatic, Addresses: []string{dpStatic}}},
+		},
+		{
+			name: "mixed sources skip empty label and preserve order",
+			node: nodeWithPeers(
+				[]seiv1alpha1.PeerSource{
+					{EC2Tags: &seiv1alpha1.EC2TagsPeerSource{Region: "eu-west-1", Tags: map[string]string{"chain": dpChainID}}},
+					labelSource(), // resolves to zero
+					staticSource(),
+				},
+				nil,
+			),
+			want: []sidecar.PeerSource{
+				{Type: sidecar.PeerSourceEC2Tags, Region: "eu-west-1", Tags: map[string]string{"chain": dpChainID}},
+				{Type: sidecar.PeerSourceStatic, Addresses: []string{dpStatic}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := discoverPeersTask(tc.node).Sources
+			if !peerSourcesEqual(got, tc.want) {
+				t.Errorf("discoverPeersTask sources = %+v, want %+v", got, tc.want)
+			}
+
+			// needsDiscoverPeers gates task insertion. When it reports true the
+			// materialized task must pass seictl validation; when false the
+			// task is empty (seictl rejects a zero-source task), so the planner
+			// must omit it rather than wedge discover-peers on a retry loop.
+			err := discoverPeersTask(tc.node).Validate()
+			if needsDiscoverPeers(tc.node) {
+				if err != nil {
+					t.Errorf("needsDiscoverPeers=true but task is invalid: %v", err)
+				}
+			} else if err == nil {
+				t.Error("needsDiscoverPeers=false but empty task unexpectedly validates")
+			}
+		})
+	}
+}
+
+func peerSourcesEqual(a, b []sidecar.PeerSource) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Type != b[i].Type || a[i].Region != b[i].Region {
+			return false
+		}
+		if !stringSlicesEqual(a[i].Addresses, b[i].Addresses) || !stringSlicesEqual(a[i].Endpoints, b[i].Endpoints) {
+			return false
+		}
+		if len(a[i].Tags) != len(b[i].Tags) {
+			return false
+		}
+		for k, v := range a[i].Tags {
+			if b[i].Tags[k] != v {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/planner/full.go
+++ b/internal/planner/full.go
@@ -42,9 +42,9 @@ func (p *fullNodePlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides(node)), node.Spec.Overrides),
 	}
 	if NeedsBootstrap(node) {
-		return buildBootstrapPlan(node, node.Spec.Peers, fn.Snapshot, intent)
+		return buildBootstrapPlan(node, fn.Snapshot, intent)
 	}
-	return buildBasePlan(node, node.Spec.Peers, fn.Snapshot, intent)
+	return buildBasePlan(node, fn.Snapshot, intent)
 }
 
 // buildRunningPlan returns the update plan for a Running full node, or

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -303,7 +303,7 @@ func insertBefore(prog []string, target, taskType string) ([]string, error) {
 // bootstrap mode, inserting optional tasks (genesis, peers, state-sync) at
 // the correct positions. Used by both buildBasePlan and buildBootstrapPlan
 // to ensure they produce consistent sidecar progressions.
-func buildSidecarProgression(snap *seiv1alpha1.SnapshotSource, peers []seiv1alpha1.PeerSource) ([]string, error) {
+func buildSidecarProgression(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.SnapshotSource) ([]string, error) {
 	mode := bootstrapMode(snap)
 	prog := slices.Clone(baseProgression[mode])
 
@@ -311,7 +311,7 @@ func buildSidecarProgression(snap *seiv1alpha1.SnapshotSource, peers []seiv1alph
 	if prog, err = insertBefore(prog, TaskConfigApply, TaskConfigureGenesis); err != nil {
 		return nil, err
 	}
-	if len(peers) > 0 {
+	if needsDiscoverPeers(node) {
 		if prog, err = insertBefore(prog, TaskConfigValidate, TaskDiscoverPeers); err != nil {
 			return nil, err
 		}
@@ -514,11 +514,10 @@ func taskMaxRetries(taskType string) int {
 // then the base sidecar progression for the node's bootstrap mode.
 func buildBasePlan(
 	node *seiv1alpha1.SeiNode,
-	peers []seiv1alpha1.PeerSource,
 	snap *seiv1alpha1.SnapshotSource,
 	configIntent *seiconfig.ConfigIntent,
 ) (*seiv1alpha1.TaskPlan, error) {
-	sidecarProg, err := buildSidecarProgression(snap, peers)
+	sidecarProg, err := buildSidecarProgression(node, snap)
 	if err != nil {
 		return nil, err
 	}
@@ -656,6 +655,16 @@ func snapshotRestoreTask(snap *seiv1alpha1.SnapshotSource) sidecar.SnapshotResto
 	return sidecar.SnapshotRestoreTask{TargetHeight: snap.S3.TargetHeight}
 }
 
+// needsDiscoverPeers reports whether a discover-peers task belongs in the plan.
+// A node whose peer sources currently resolve to zero addresses (the first
+// validator(s) in a fresh cluster, whose label selector matches no running
+// peers yet) gets no task — there is nothing to apply, and seictl's
+// DiscoverPeersTask.Validate rejects an empty Sources list, which would
+// otherwise wedge the node before it can become a resolvable peer.
+func needsDiscoverPeers(node *seiv1alpha1.SeiNode) bool {
+	return len(discoverPeersTask(node).Sources) > 0
+}
+
 func discoverPeersTask(node *seiv1alpha1.SeiNode) sidecar.DiscoverPeersTask {
 	if len(node.Spec.Peers) == 0 {
 		return sidecar.DiscoverPeersTask{}
@@ -670,13 +679,23 @@ func discoverPeersTask(node *seiv1alpha1.SeiNode) sidecar.DiscoverPeersTask {
 				Tags:   s.EC2Tags.Tags,
 			})
 		case s.Static != nil:
+			if len(s.Static.Addresses) == 0 {
+				continue
+			}
 			sources = append(sources, sidecar.PeerSource{
 				Type:      sidecar.PeerSourceStatic,
 				Addresses: s.Static.Addresses,
 			})
 		case s.Label != nil:
-			// ResolvedPeers is pre-composed `<node_id>@<host>:<port>`;
-			// route as static so the sidecar writes them verbatim.
+			// A label selector resolving to zero in-cluster peers (the first
+			// validator(s) in a fresh cluster) is a no-op — emitting an empty
+			// static source trips seictl's missing-Addresses validation and
+			// wedges discover-peers on a retry loop. ResolvedPeers is
+			// pre-composed `<node_id>@<host>:<port>`; route as static so the
+			// sidecar writes them verbatim.
+			if len(node.Status.ResolvedPeers) == 0 {
+				continue
+			}
 			sources = append(sources, sidecar.PeerSource{
 				Type:      sidecar.PeerSourceStatic,
 				Addresses: node.Status.ResolvedPeers,

--- a/internal/planner/replay.go
+++ b/internal/planner/replay.go
@@ -46,9 +46,9 @@ func (p *replayerPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Tas
 		Overrides: mergeOverrides(mergeOverrides(commonOverrides(node), p.controllerOverrides()), node.Spec.Overrides),
 	}
 	if NeedsBootstrap(node) {
-		return buildBootstrapPlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, intent)
+		return buildBootstrapPlan(node, &node.Spec.Replayer.Snapshot, intent)
 	}
-	return buildBasePlan(node, node.Spec.Peers, &node.Spec.Replayer.Snapshot, intent)
+	return buildBasePlan(node, &node.Spec.Replayer.Snapshot, intent)
 }
 
 // buildRunningPlan returns the update plan for a Running replayer node.

--- a/internal/planner/validator.go
+++ b/internal/planner/validator.go
@@ -109,9 +109,9 @@ func (p *validatorPlanner) BuildPlan(node *seiv1alpha1.SeiNode) (*seiv1alpha1.Ta
 		Overrides: mergeOverrides(commonOverrides(node), node.Spec.Overrides),
 	}
 	if NeedsBootstrap(node) {
-		return buildBootstrapPlan(node, node.Spec.Peers, v.Snapshot, intent)
+		return buildBootstrapPlan(node, v.Snapshot, intent)
 	}
-	return buildBasePlan(node, node.Spec.Peers, v.Snapshot, intent)
+	return buildBasePlan(node, v.Snapshot, intent)
 }
 
 // buildRunningPlan returns the update plan for a Running validator. The


### PR DESCRIPTION
## Problem

The first validator(s) in a brand-new cluster deadlock at startup.

A `label` peer source resolves matching SeiNodes to their headless-Service DNS names and tracks them in `status.resolvedPeers`. The very first validator(s) match no running siblings, so `ResolvedPeers` is empty. `discoverPeersTask` still emitted a `static` source with empty `Addresses`, which seictl's `DiscoverPeersTask.Validate` rejects:

```
task execution failed, will retry ... task=discover-peers
  error="validating discover-peers: discover-peers: source[N] static missing required field Addresses"
```

discover-peers never succeeds, so the sidecar never marks the node ready, seid stays in its "waiting for sidecar" gate, the node never starts, and it can never become a resolvable peer. Cold-start deadlock.

Observed live on prod-euw1 arctic-1 validators 28/29 — the only arctic-1 SeiNodes in that cluster, so their `label: {selector: {sei.io/chain: arctic-1}}` resolved to nothing. Other clusters never hit it because the label always matched at least one existing validator.

## Fix

A peer source resolving to zero addresses is a no-op, not an invalid empty source:

- `label` with empty `ResolvedPeers` → skipped.
- `static` with empty `Addresses` → skipped (defensive).
- `ec2Tags` → unchanged (resolved sidecar-side).

When skipping leaves zero sources, the discover-peers task is omitted from the plan entirely (`needsDiscoverPeers`). An empty `Sources` list is itself rejected by `Validate` ("at least one source is required"), so emitting the task would only trade the empty-source wedge for an empty-task wedge. Remaining non-empty sources still drive discovery; order is preserved.

This is graceful degradation aligned with #393 — a source resolving to zero endpoints should degrade, not block.

## Test

`internal/planner/discover_peers_test.go` covers `discoverPeersTask` and the `needsDiscoverPeers` gate: label empty → omitted; label resolved → emitted; static empty → omitted; static non-empty → emitted; mixed (ec2Tags + empty label + non-empty static) → only valid sources in order. Every case also asserts the gate/validation invariant: `needsDiscoverPeers` true iff the materialized task passes `Validate`.

`go build ./...` and `go test ./internal/...` pass.

Related: #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)