### PR TITLE
docs(nodetask): fix stale SeiNodeTaskParamsFor comment after DiscoverPeers removal

### DIFF
--- a/internal/task/seinodetask_params.go
+++ b/internal/task/seinodetask_params.go
@@ -73,8 +73,8 @@ func paramsErr(msg string) error {
 
 // SeiNodeTaskParamsFor resolves a SeiNodeTask kind to its task type and
 // payload. target is the resolved SeiNode; pass nil from the early-validation
-// path (before the SeiNode is fetched) — KeyName/peer-source derivation that
-// needs target is deferred to the driveTask call site.
+// path (before the SeiNode is fetched) — derivation that needs target (e.g.
+// gov-proposal signing identity) is deferred to the driveTask call site.
 func SeiNodeTaskParamsFor(cr *seiv1alpha1.SeiNodeTask, target *seiv1alpha1.SeiNode) (SeiNodeTaskParams, error) {
 	switch cr.Spec.Kind {
 	case seiv1alpha1.SeiNodeTaskKindUpdateNodeImage:


### PR DESCRIPTION
Tidy-up caught by the post-merge Coral cross-review of #398. The `SeiNodeTaskParamsFor` doc said "KeyName/peer-source derivation that needs target" — the peer-source path was the imperative DiscoverPeers emitter removed in #398, so the comment named a mechanism that no longer exists. Now only signing-identity (gov proposal) derivation is target-dependent. Comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)