### PR TITLE
chore(peering): retire discover-peers execution path (PLT-452 PR-C)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.39.1
 	github.com/sei-protocol/sei-config v0.0.19
-	github.com/sei-protocol/seictl v0.0.56
+	github.com/sei-protocol/seictl v0.0.57
 	github.com/urfave/cli/v3 v3.6.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -1788,6 +1788,8 @@ github.com/sei-protocol/seictl v0.0.55 h1:JZ15hoAS7ft3LL85SeYtkP3Gr/oMlEQnBjhefb
 github.com/sei-protocol/seictl v0.0.55/go.mod h1:sDWY/llzQPnblG/WS6uQ7vqDtshNQ0WJTJzRUgmfFpg=
 github.com/sei-protocol/seictl v0.0.56 h1:zRCZdGiRrvP+zv/DYhmfP570MOR9nO6o9VWncABkJSo=
 github.com/sei-protocol/seictl v0.0.56/go.mod h1:sDWY/llzQPnblG/WS6uQ7vqDtshNQ0WJTJzRUgmfFpg=
+github.com/sei-protocol/seictl v0.0.57 h1:qyWpv5Iznlp7tQiAU0TYzlFZYHOohfmbVXn/AJp1Co8=
+github.com/sei-protocol/seictl v0.0.57/go.mod h1:EnEHAT5/egP4aIB4Ir4tg5eK2150RfB9Ohw5xmpZQGE=
 github.com/sei-protocol/seilog v0.0.3 h1:Zi7oWXdX5jv92dY8n482xH032LtNebC89Y+qYZlBn0Y=
 github.com/sei-protocol/seilog v0.0.3/go.mod h1:CKg58wraWnB3gRxWQ0v1rIVr0gmDHjkfP1bM2giKFFU=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/internal/planner/archive_test.go
+++ b/internal/planner/archive_test.go
@@ -49,10 +49,10 @@ func TestArchivePlanner_BlockSyncProgression(t *testing.T) {
 	}
 }
 
-// Peers now reach config via the config-apply override
-// (network.p2p.persistent_peers), not a sidecar discover-peers task. The
-// controller resolves spec.peers into status.resolvedPeers before plan build;
-// the planner reads that set. The plan must NOT contain a discover-peers task.
+// Peers reach config via the config-apply override
+// (network.p2p.persistent_peers): the controller resolves spec.peers into
+// status.resolvedPeers before plan build, and the planner folds that set into
+// the override.
 func TestArchivePlanner_WithPeers(t *testing.T) {
 	node := &seiv1alpha1.SeiNode{
 		ObjectMeta: metav1.ObjectMeta{Name: "archive-0", Namespace: "pacific-1"},
@@ -73,15 +73,6 @@ func TestArchivePlanner_WithPeers(t *testing.T) {
 	plan, err := p.BuildPlan(node)
 	if err != nil {
 		t.Fatalf("BuildPlan: %v", err)
-	}
-
-	types := make([]string, 0, len(plan.Tasks))
-	for _, task := range plan.Tasks {
-		types = append(types, task.Type)
-	}
-
-	if slices.Contains(types, TaskDiscoverPeers) {
-		t.Errorf("archive plan must not contain discover-peers (controller-owned peering), got %v", types)
 	}
 
 	intent := configApplyIntent(t, plan)

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -30,7 +30,6 @@ const unknownValue = "unknown"
 
 const (
 	TaskSnapshotRestore    = sidecar.TaskTypeSnapshotRestore
-	TaskDiscoverPeers      = sidecar.TaskTypeDiscoverPeers
 	TaskConfigureGenesis   = sidecar.TaskTypeConfigureGenesis
 	TaskConfigureStateSync = sidecar.TaskTypeConfigureStateSync
 	TaskConfigApply        = sidecar.TaskTypeConfigApply

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -207,7 +207,6 @@ var registry = map[string]taskDeserializer{
 	sidecar.TaskTypeConfigPatch:            sidecarTask[ConfigPatchTask](false),
 	sidecar.TaskTypeConfigValidate:         sidecarTask[sidecar.ConfigValidateTask](true),
 	sidecar.TaskTypeConfigureGenesis:       sidecarTask[sidecar.ConfigureGenesisTask](false),
-	sidecar.TaskTypeDiscoverPeers:          sidecarTask[sidecar.DiscoverPeersTask](false),
 	sidecar.TaskTypeRestartSeid:            sidecarTask[sidecar.RestartSeidTask](false),
 	sidecar.TaskTypeMarkReady:              sidecarTask[sidecar.MarkReadyTask](true),
 	sidecar.TaskTypeSnapshotUpload:         sidecarTask[sidecar.SnapshotUploadTask](true),


### PR DESCRIPTION
## What

The final step of the discover-peers retirement (PLT-452). Bumps the seictl pin to **v0.0.57** — the first release without the sidecar discover-peers task handler (removed in [seictl#201](https://github.com/sei-protocol/seictl/pull/201)) — and drops the two controller-side references the bump leaves dangling:

- **`internal/task/task.go`** — the discover-peers execution registration (`sidecar.TaskTypeDiscoverPeers: sidecarTask[sidecar.DiscoverPeersTask]`). Deliberately **kept** through PR-A/PR-B so any in-flight persisted plan could still drive its task to completion against an older sidecar; removable now that the controller stopped emitting them (#398, live) and those tasks have drained.
- **`internal/planner/planner.go`** — the `TaskDiscoverPeers` alias over the now-removed sidecar task-type constant.

Both reference symbols that no longer exist in seictl v0.0.57, so they go *with* the bump.

## Test

- `internal/planner/archive_test.go` — drops the `TestArchivePlanner_WithPeers` "must not contain discover-peers" assertion (and the `types` slice that fed it). It's structurally unreachable now: no enum value, no registry entry, no planner can emit that task type. The test keeps its meaningful assertion — peers reach config via the `persistent_peers` override — and the comment is refocused accordingly.

## Sequencing

This is **PR-C** of the three-PR cross-repo retirement:
- **PR-A** (#398, merged) — controller stops *emitting* discover-peers tasks.
- **PR-B** (seictl#201, merged → v0.0.57) — sidecar drops the *handler* + client API.
- **PR-C** (this) — controller bumps to v0.0.57 and drops the kept *execution registration* + alias.

Peering is now wholly controller-owned via the config-apply `persistent_peers` override; no discover-peers task type exists anywhere in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)