### PR TITLE
fix(rbac): scope configmaps write off the controller namespace — protect state-sync trust root (PLT-471)

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -7,18 +7,6 @@ metadata:
   name: leader-election-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,15 +8,11 @@ rules:
   - ""
   resources:
   - configmaps
-  - persistentvolumeclaims
-  - services
+  - persistentvolumes
+  - secrets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
@@ -28,11 +24,15 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - persistentvolumes
-  - secrets
+  - persistentvolumeclaims
+  - services
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/internal/controller/node/controller.go
+++ b/internal/controller/node/controller.go
@@ -66,7 +66,8 @@ type SeiNodeReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// configmaps read-only here; write is node-namespace-scoped via platform Roles.
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // Reconcile drives the SeiNode lifecycle. All status mutations after the
 // finalizer are accumulated in-memory and flushed in a single status patch.

--- a/manifests/role.yaml
+++ b/manifests/role.yaml
@@ -8,15 +8,11 @@ rules:
   - ""
   resources:
   - configmaps
-  - persistentvolumeclaims
-  - services
+  - persistentvolumes
+  - secrets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
@@ -28,11 +24,15 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - persistentvolumes
-  - secrets
+  - persistentvolumeclaims
+  - services
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION
## What

Closes PLT-471 (controller side): the controller can no longer rewrite its own state-sync **trust-root** ConfigMap `sei-controller-config` via its ServiceAccount token.

The trust root lives in `sei-k8s-controller-system` and is read via the **mounted file**, not the API — yet the controller held two configmaps-write paths into that namespace:
1. **cluster-wide `configmaps` CRUD** (`manager-role`, from the `controller.go` marker) → narrowed to **`get;list;watch`** (the informer cache needs cluster-wide read; write moves to node namespaces).
2. **a vestigial `configmaps` CRUD rule in `leader-election-role`** → **deleted**. Leader election is Lease-based (controller-runtime default; verified live: lease `bc1f5b0a.sei.io` held, no leader-election ConfigMap), so this grant was dead and was the *only* remaining configmaps-write path in the controller's namespace.

Regenerated `role.yaml` / `manifests/role.yaml` via `make manifests`.

## Why not move the trust root to its own namespace

A pod can only mount a ConfigMap from its **own** namespace, and the controller reads the trust root via a mount — so it must stay in `sei-k8s-controller-system`. In-place scoping (this PR) is the viable path.

## Companion (required before rollout) — platform per-namespace write Roles

The controller still legitimately writes ConfigMaps in **node namespaces** (rbac-proxy config, workflow-vars). A follow-up **platform-repo PR** adds a `Role` + `RoleBinding` (subject `sei-k8s-controller-manager`) granting configmaps write in each chain namespace: prod `{pacific-1, arctic-1, atlantic-2}`, prod-euw1 `{arctic-1}`, prod-use2 `{arctic-1}`, harbor `{staging}`. **Those must reconcile before this controller ref deploys** (else node-namespace configmap writes 403 → reconciles wedge) — additive + safe to land first.

## Security acceptance criteria (from the threat model)

- `kubectl auth can-i {create,update,patch,delete} configmaps -n sei-k8s-controller-system --as=...:sei-k8s-controller-manager` → **no** (both holes closed).
- No ClusterRoleBinding grants configmaps write; write is namespaced-only.
- Leader election still acquires the Lease.
- Node-namespace rbac-proxy/workflow-vars writes still succeed.
- No new rbac/serviceaccounts/deployments grant; no wildcards.

## Verification done

Build clean; `verify-generated` satisfied (fresh `make manifests generate` yields no diff); live harbor confirms Lease-based election + SA name + no other configmaps-write SA in the namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)