### PR TITLE
docs(signing-key-lld): dual-audience translate pass — decision-matrix + symbol anchors

### DIFF
--- a/docs/design-seinode-validator-signing-key-lld.md
+++ b/docs/design-seinode-validator-signing-key-lld.md
@@ -253,7 +253,7 @@ const (
 - Set on every reconcile after `validate-signing-key` runs, by the planner (matching the planner-owns-conditions pattern from CLAUDE.md).
 - Removed via `meta.RemoveStatusCondition` when `SigningKey` is unset on the spec.
 - The condition's presence in `.status.conditions` is itself a signal that the node is configured to mount external signing keys.
-- `ObservedGeneration` is set to `node.Generation` on every `meta.SetStatusCondition` call, mirroring `NodeUpdateInProgress` at `internal/planner/planner.go:195`.
+- `ObservedGeneration` is set to `node.Generation` on every `meta.SetStatusCondition` call, mirroring the `NodeUpdateInProgress` setCondition discipline in `internal/planner/planner.go`.
 
 ### Why no `SigningKeyMounted=True/False` condition
 
@@ -277,11 +277,13 @@ if v.SigningKey != nil {
 }
 ```
 
-The `SigningKey ↔ GenesisCeremony` mutual-exclusion check ensures a fresh-chain validator (which generates keys via the genesis ceremony) is not also configured to import keys from a Secret. The CRD-level `XValidation: exactly-one` covers `SigningKeySource` variants but not cross-field exclusion with `GenesisCeremony` — that goes here.
+The CRD-level `XValidation: exactly-one` covers `SigningKeySource` variants but not cross-field exclusion with `GenesisCeremony` — that goes here. The full legality of `SigningKey` against the other validator-source fields:
 
-The `SigningKey + Snapshot.BootstrapImage` combination is **valid and expected** — that's the migration use case (bootstrap-Job sync + signing key on production StatefulSet). No additional validation needed.
-
-The `SigningKey + neither GenesisCeremony nor Snapshot` combination is also valid — it represents a validator joining an existing chain via block-sync from genesis (slow but correct). We do not require a snapshot mechanism alongside `SigningKey`.
+| `SigningKey` combined with… | Verdict | Why |
+|---|---|---|
+| `GenesisCeremony` set | **Rejected** (this check) | A fresh-chain validator generates keys via the genesis ceremony; it must not also import keys from a Secret. |
+| `Snapshot.BootstrapImage` set | **Valid and expected** | The migration use case: bootstrap-Job sync + signing key on the production StatefulSet. No additional validation needed. |
+| neither `GenesisCeremony` nor `Snapshot` | **Valid** | A validator joining an existing chain via block-sync from genesis (slow but correct). A snapshot mechanism is not required alongside `SigningKey`. |
 
 ## 7. Finalizer interaction
 
@@ -419,7 +421,7 @@ No CRD data migration. Applying the new CRD on a cluster with old SeiNode object
 - `docs/design/composable-genesis.md` — sketches `register-validator` for the *new-chain validator joining* case (deferred for migration use case).
 - `api/v1alpha1/validator_types.go` — new fields per §1.
 - `api/v1alpha1/seinode_types.go` — new condition constant per §5.
-- `internal/noderesource/noderesource.go:229-447` — pod-spec changes per §2.
+- `internal/noderesource/noderesource.go` (`buildNodePodSpec`, `buildNodeMainContainer`) — pod-spec changes per §2.
 - `internal/task/validate_signing_key.go` — new task per §4.
-- `internal/planner/validator.go:17-36` — planner Validate additions per §6.
-- `internal/planner/bootstrap.go`, `internal/planner/planner.go:411` — plan integration per §4.
+- `internal/planner/validator.go` (`validatorPlanner.Validate`) — planner Validate additions per §6.
+- `internal/planner/bootstrap.go` (`buildBootstrapPlan`), `internal/planner/planner.go` (`buildBasePlan` validator path) — plan integration per §4.


### PR DESCRIPTION
An **improve-in-place `/lingua` Translate pass** on the validator signing-key LLD — the first production translation from the Sei Agentic Mesh corpus work (Phase 3 pilot). Suggest-only, and because this doc is safety-critical (a validator double-sign is slashable and irreversible), **Guardrail-6** was in force throughout: restructure for clarity, never reword a constraint.

The doc was already strongly conformant, so this is a deliberately small diff — two real improvements, nothing manufactured:

### 1. §6 validator legality → decision-matrix
The three `SigningKey`-combination paragraphs become a `(combination → verdict → why)` table. Every verdict (Rejected / Valid-and-expected / Valid) and every reason is preserved verbatim-in-meaning; the `GenesisCeremony` mutual-exclusion invariant now reads **must not** (was "is not"), corroborated by the `return fmt.Errorf(...)` block directly above it. The win is dual-legibility: a reader scans the verdict column, and an implementing agent reads three typed `(combination, verdict)` facts instead of inferring each verdict from a mid-paragraph adjective.

### 2. File anchors: drifted line numbers → symbols
Three code references had **genuinely rotted** since the doc was written. Re-anchored to symbols that survive refactors (all verified present on `main`):
| was | now |
|---|---|
| `planner.go:195` | the `NodeUpdateInProgress` setCondition discipline |
| `noderesource.go:229-447` | `buildNodePodSpec`, `buildNodeMainContainer` |
| `planner.go:411` | `buildBasePlan` (validator path) |
| `validator.go:17-36` | `validatorPlanner.Validate` |

### What was deliberately *not* changed
Sections that were already conformant were left untouched. §8's cutover is single-shot by construction (no phases), so **no per-phase rollback was invented** — surfaced, not authored.

---
**Review:** `prose-steward` adversarial fidelity pass → DOES NOT BLOCK (clause-by-clause check of the safety-critical §6 matrix; no constraint dropped, weakened, or broadened). · Linear: PLT-496 · Doctrine: [Design 04](https://github.com/sei-protocol/bdchatham-designs/blob/main/designs/sei-agentic-mesh/04-corpus-doctrine-refinement.md) → BG-4 (Tide#146)

🤖 Generated with [Claude Code](https://claude.com/claude-code)