### PR TITLE
feat(snd): annotation-gated networking orphan for GitOps adoption (PLT-451 Phase-0)

### DIFF
--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -105,10 +105,10 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("reconciling internal RPC service: %w", err)
 	}
 
-	// When networking is orphaned, external objects are GitOps-managed:
-	// strip owner-refs (idempotent) and stop applying. The DNS-resolvability
-	// gate is skipped too — it would otherwise return before reconcileSeiNodes
-	// writes ExternalAddress, which must keep flowing during the handoff.
+	// External networking is GitOps-managed when orphaned: strip owner-refs
+	// (idempotent) and stop applying. ExternalAddress for children still flows
+	// through reconcileSeiNodes below, so the DNS-resolvability gate is skipped
+	// rather than allowed to short-circuit it.
 	if networkingOrphaned(group) {
 		if err := r.orphanNetworkingResources(ctx, group); err != nil {
 			logger.Error(err, "orphaning networking resources")

--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -105,18 +105,31 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("reconciling internal RPC service: %w", err)
 	}
 
-	if err := r.reconcileNetworking(ctx, group); err != nil {
-		logger.Error(err, "reconciling networking")
-		return ctrl.Result{}, fmt.Errorf("reconciling networking: %w", err)
-	}
-
-	if !r.routeHostnameResolvable(ctx, group) {
-		setCondition(group, seiv1alpha1.ConditionNetworkingReady, metav1.ConditionFalse,
-			"DNSPending", "waiting for route hostname to resolve in DNS")
-		if err := r.updateStatus(ctx, group, statusBase); err != nil {
-			return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
+	// When networking is orphaned, external objects are GitOps-managed:
+	// strip owner-refs (idempotent) and stop applying. The DNS-resolvability
+	// gate is skipped too — it would otherwise return before reconcileSeiNodes
+	// writes ExternalAddress, which must keep flowing during the handoff.
+	if networkingOrphaned(group) {
+		if err := r.orphanNetworkingResources(ctx, group); err != nil {
+			logger.Error(err, "orphaning networking resources")
+			return ctrl.Result{}, fmt.Errorf("orphaning networking resources: %w", err)
 		}
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		setCondition(group, seiv1alpha1.ConditionNetworkingReady, metav1.ConditionFalse,
+			"NetworkingOrphaned", "external networking is GitOps-managed; owner-refs stripped")
+	} else {
+		if err := r.reconcileNetworking(ctx, group); err != nil {
+			logger.Error(err, "reconciling networking")
+			return ctrl.Result{}, fmt.Errorf("reconciling networking: %w", err)
+		}
+
+		if !r.routeHostnameResolvable(ctx, group) {
+			setCondition(group, seiv1alpha1.ConditionNetworkingReady, metav1.ConditionFalse,
+				"DNSPending", "waiting for route hostname to resolve in DNS")
+			if err := r.updateStatus(ctx, group, statusBase); err != nil {
+				return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
+			}
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
 	}
 
 	if err := r.reconcileSeiNodes(ctx, group); err != nil {

--- a/internal/controller/nodedeployment/envtest/networking_orphan_test.go
+++ b/internal/controller/nodedeployment/envtest/networking_orphan_test.go
@@ -1,0 +1,174 @@
+//go:build envtest
+
+package envtest_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
+)
+
+const networkingOrphanedAnnotation = "sei.io/networking-orphaned"
+
+// withNetworkingOrphaned stamps the orphan annotation on a fixtures-built SND.
+func withNetworkingOrphaned() fixtures.Option {
+	return func(snd *seiv1alpha1.SeiNodeDeployment) {
+		if snd.Annotations == nil {
+			snd.Annotations = map[string]string{}
+		}
+		snd.Annotations[networkingOrphanedAnnotation] = "true"
+	}
+}
+
+// TestNetworking_Orphaned_FreezesExternalButKeepsExternalAddress is the
+// PLT-451 Phase-0 controller gate. An SND annotated networking-orphaned hands
+// the external Service / HTTPRoutes / per-pod P2P LB to GitOps: the controller
+// stops applying them. The load-bearing guarantee is that the children's
+// Spec.ExternalAddress write is NOT gated by the annotation — a blanket freeze
+// would blank ExternalAddress and partition P2P. The fixture sets both TCP and
+// a non-empty P2PEndpointDomain so the ungated child-address path is exercised.
+func TestNetworking_Orphaned_FreezesExternalButKeepsExternalAddress(t *testing.T) {
+	g := NewWithT(t)
+	withP2PEndpointDomain(t, p2pEndpointTestDomain)
+	ns := makeNamespace(t)
+
+	// Created already orphaned: the controller must never apply external
+	// networking for this group, so no per-pod LB is ever created.
+	snd := fixtures.NewSND(ns, "orphan-create",
+		fixtures.WithReplicas(1),
+		withTCP(),
+		withNetworkingOrphaned(),
+	)
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	const chainID = "pacific-1" // fixtures default
+	wantAddr := expectedP2PEndpointAddr(snd.Name, chainID, 0)
+
+	// (b) Child still gets Spec.ExternalAddress — ensureSeiNode /
+	//     p2pEndpointAddressForChild are not gated by the annotation.
+	childKey := types.NamespacedName{Name: snd.Name + "-0", Namespace: ns}
+	waitFor(t, func() bool {
+		child := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, childKey, child); err != nil {
+			return false
+		}
+		return child.Spec.ExternalAddress == wantAddr
+	}, "orphaned SND still stamps child Spec.ExternalAddress")
+
+	// (c) ConditionNetworkingReady=False/NetworkingOrphaned (always-present;
+	//     a stable reason, not a removed condition).
+	waitForStatus(t, client.ObjectKeyFromObject(snd), func(latest *seiv1alpha1.SeiNodeDeployment) bool {
+		c := apimeta.FindStatusCondition(latest.Status.Conditions, seiv1alpha1.ConditionNetworkingReady)
+		return c != nil && c.Status == metav1.ConditionFalse && c.Reason == "NetworkingOrphaned"
+	}, "ConditionNetworkingReady=False/NetworkingOrphaned for orphaned SND")
+
+	// (a) reconcileNetworking did not run: no per-pod P2P LB Service exists.
+	//     The condition + child address above confirm the reconcile reached
+	//     reconcileSeiNodes, so this is a true negative (the reconcile ran but
+	//     skipped the external sub-reconcilers), not a not-yet-converged read.
+	svcKey := types.NamespacedName{Name: snd.Name + "-0-p2p", Namespace: ns}
+	g.Consistently(func() bool {
+		err := testCli.Get(testCtx, svcKey, &corev1.Service{})
+		return err != nil
+	}, 2*time.Second, 200*time.Millisecond).Should(BeTrue(),
+		"orphaned SND must not create a per-pod P2P LB Service")
+}
+
+// TestNetworking_Orphaned_StripsOwnerRefs covers the orphan transition on a
+// live group: an SND converges with the controller owning its per-pod P2P LB,
+// then gets the orphan annotation. The controller strips its owner-ref
+// (handing the object to Flux for adopt-in-place) without deleting it, and
+// the child keeps its ExternalAddress throughout.
+func TestNetworking_Orphaned_StripsOwnerRefs(t *testing.T) {
+	g := NewWithT(t)
+	withP2PEndpointDomain(t, p2pEndpointTestDomain)
+	ns := makeNamespace(t)
+
+	snd := fixtures.NewSND(ns, "orphan-transition",
+		fixtures.WithReplicas(1),
+		withTCP(),
+	)
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	const chainID = "pacific-1"
+	wantAddr := expectedP2PEndpointAddr(snd.Name, chainID, 0)
+	childKey := types.NamespacedName{Name: snd.Name + "-0", Namespace: ns}
+	svcKey := types.NamespacedName{Name: snd.Name + "-0-p2p", Namespace: ns}
+
+	// Converge: child address set and per-pod LB owned by the SND.
+	waitFor(t, func() bool {
+		child := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, childKey, child); err != nil {
+			return false
+		}
+		return child.Spec.ExternalAddress == wantAddr
+	}, "child has publishable address before orphan")
+	waitFor(t, func() bool {
+		svc := &corev1.Service{}
+		if err := testCli.Get(testCtx, svcKey, svc); err != nil {
+			return false
+		}
+		return metav1.IsControlledBy(svc, snd)
+	}, "per-pod P2P LB owned by SND before orphan")
+
+	// Orphan: stamp the annotation. The SND watch uses
+	// GenerationChangedPredicate, so an annotation-only edit isn't picked up
+	// until the next statusPollInterval requeue (~30s) — operationally fine
+	// (the design gates on a multi-interval freeze) but slow for a test. Bump
+	// generation with a benign template-metadata edit so a reconcile fires
+	// promptly; this is orthogonal to the orphan gate under test.
+	latest := getSND(t, client.ObjectKeyFromObject(snd))
+	patch := client.MergeFrom(latest.DeepCopy())
+	if latest.Annotations == nil {
+		latest.Annotations = map[string]string{}
+	}
+	latest.Annotations[networkingOrphanedAnnotation] = "true"
+	if latest.Spec.Template.Metadata == nil {
+		latest.Spec.Template.Metadata = &seiv1alpha1.SeiNodeTemplateMeta{}
+	}
+	if latest.Spec.Template.Metadata.Labels == nil {
+		latest.Spec.Template.Metadata.Labels = map[string]string{}
+	}
+	latest.Spec.Template.Metadata.Labels["test.sei.io/orphan-retick"] = "1"
+	g.Expect(testCli.Patch(testCtx, latest, patch)).To(Succeed())
+
+	// Owner-ref is stripped — the Service survives, now GitOps-owned.
+	waitFor(t, func() bool {
+		svc := &corev1.Service{}
+		if err := testCli.Get(testCtx, svcKey, svc); err != nil {
+			return false
+		}
+		return len(svc.GetOwnerReferences()) == 0
+	}, "per-pod P2P LB owner-ref stripped after orphan")
+
+	// Service is not deleted (orphan is metadata-only, not a delete).
+	svc := &corev1.Service{}
+	g.Expect(testCli.Get(testCtx, svcKey, svc)).To(Succeed())
+	g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+
+	// Child keeps its ExternalAddress across the transition.
+	g.Consistently(func() string {
+		child := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, childKey, child); err != nil {
+			return ""
+		}
+		return child.Spec.ExternalAddress
+	}, 2*time.Second, 200*time.Millisecond).Should(Equal(wantAddr),
+		"child ExternalAddress preserved across orphan transition")
+
+	// Condition reflects the orphaned state.
+	waitForStatus(t, client.ObjectKeyFromObject(snd), func(latest *seiv1alpha1.SeiNodeDeployment) bool {
+		c := apimeta.FindStatusCondition(latest.Status.Conditions, seiv1alpha1.ConditionNetworkingReady)
+		return c != nil && c.Status == metav1.ConditionFalse && c.Reason == "NetworkingOrphaned"
+	}, "ConditionNetworkingReady=False/NetworkingOrphaned after orphan transition")
+}

--- a/internal/controller/nodedeployment/labels.go
+++ b/internal/controller/nodedeployment/labels.go
@@ -16,7 +16,20 @@ const (
 	revisionLabel       = "sei.io/revision"
 	chainLabel          = "sei.io/chain"
 	managedByAnnotation = "sei.io/managed-by"
+
+	// networkingOrphanedAnnotation freezes the external networking
+	// sub-reconcilers and strips SND owner-refs from the external Service,
+	// HTTPRoutes, and per-pod P2P LBs, handing those objects to GitOps
+	// (Flux) for adopt-in-place. The internal ClusterIP and the children's
+	// ExternalAddress write stay controller-owned.
+	networkingOrphanedAnnotation = "sei.io/networking-orphaned"
 )
+
+// networkingOrphaned reports whether external networking has been handed
+// off to GitOps for this group.
+func networkingOrphaned(group *seiv1alpha1.SeiNodeDeployment) bool {
+	return group.Annotations[networkingOrphanedAnnotation] == "true"
+}
 
 // seiNodeName is published as Status.PerPodServices[].Name and equals the
 // headless Service name; the format is part of the public interface.

--- a/internal/controller/nodedeployment/plan.go
+++ b/internal/controller/nodedeployment/plan.go
@@ -79,8 +79,13 @@ func (r *SeiNodeDeploymentReconciler) completePlan(ctx context.Context, group *s
 
 	if isDeploymentPlan {
 		group.Status.ObservedGeneration = group.Generation
-		if err := r.reconcileNetworking(ctx, group); err != nil {
-			logger.Error(err, "reconciling networking after deployment")
+		// Same orphan gate as the main reconcile: re-running reconcileNetworking
+		// here on an orphaned group would re-create the GitOps-owned objects and
+		// force-steal field ownership mid-handoff.
+		if !networkingOrphaned(group) {
+			if err := r.reconcileNetworking(ctx, group); err != nil {
+				logger.Error(err, "reconciling networking after deployment")
+			}
 		}
 		group.Status.Rollout = nil
 		setCondition(group, seiv1alpha1.ConditionRolloutInProgress, metav1.ConditionFalse,

--- a/internal/controller/nodedeployment/plan.go
+++ b/internal/controller/nodedeployment/plan.go
@@ -79,9 +79,7 @@ func (r *SeiNodeDeploymentReconciler) completePlan(ctx context.Context, group *s
 
 	if isDeploymentPlan {
 		group.Status.ObservedGeneration = group.Generation
-		// Same orphan gate as the main reconcile: re-running reconcileNetworking
-		// here on an orphaned group would re-create the GitOps-owned objects and
-		// force-steal field ownership mid-handoff.
+		// Skip networking re-apply when orphaned — those objects are GitOps-owned.
 		if !networkingOrphaned(group) {
 			if err := r.reconcileNetworking(ctx, group); err != nil {
 				logger.Error(err, "reconciling networking after deployment")

--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -140,9 +140,9 @@ func ResourceLabels(node *seiv1alpha1.SeiNode) map[string]string {
 // deriveRole returns the role label value for the node's mode. Stamped
 // onto the pod template as `sei.io/role` and lifted into the `sei_role`
 // metric label by the platform PodMonitor (see
-// platform/clusters/*/monitoring/podmonitor-seid.yaml). Total: a node with
-// no mode sub-spec defaults to full-node, mirroring NodeMode's ModeFull
-// fallback, so `sei.io/role` is always present and metric series never drop.
+// platform/clusters/*/monitoring/podmonitor-seid.yaml). Total — a node with
+// no mode sub-spec is a full node — so `sei.io/role` is never empty and the
+// metric series never drops.
 func deriveRole(node *seiv1alpha1.SeiNode) string {
 	switch {
 	case node.Spec.Validator != nil:

--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -133,16 +133,16 @@ func ResourceLabels(node *seiv1alpha1.SeiNode) map[string]string {
 	if node.Spec.ChainID != "" {
 		labels[chainLabel] = node.Spec.ChainID
 	}
-	if role := deriveRole(node); role != "" {
-		labels[roleLabel] = role
-	}
+	labels[roleLabel] = deriveRole(node)
 	return labels
 }
 
 // deriveRole returns the role label value for the node's mode. Stamped
 // onto the pod template as `sei.io/role` and lifted into the `sei_role`
 // metric label by the platform PodMonitor (see
-// platform/clusters/*/monitoring/podmonitor-seid.yaml).
+// platform/clusters/*/monitoring/podmonitor-seid.yaml). Total: a node with
+// no mode sub-spec defaults to full-node, mirroring NodeMode's ModeFull
+// fallback, so `sei.io/role` is always present and metric series never drop.
 func deriveRole(node *seiv1alpha1.SeiNode) string {
 	switch {
 	case node.Spec.Validator != nil:
@@ -151,10 +151,9 @@ func deriveRole(node *seiv1alpha1.SeiNode) string {
 		return roleArchive
 	case node.Spec.Replayer != nil:
 		return roleReplayer
-	case node.Spec.FullNode != nil:
+	default:
 		return roleFullNode
 	}
-	return ""
 }
 
 // NodeMode returns the sei-config mode string for the node based on which

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -1455,8 +1455,7 @@ func TestResourceLabels_ChainAndRoleStampedUnconditionally(t *testing.T) {
 		{"archive", func(n *seiv1alpha1.SeiNode) { n.Spec.Archive = &seiv1alpha1.ArchiveSpec{} }, roleArchive},
 		{"replayer", func(n *seiv1alpha1.SeiNode) { n.Spec.Replayer = &seiv1alpha1.ReplayerSpec{} }, roleReplayer},
 		{"fullNode", func(n *seiv1alpha1.SeiNode) { n.Spec.FullNode = &seiv1alpha1.FullNodeSpec{} }, roleFullNode},
-		// No mode sub-spec: deriveRole defaults to node, mirroring NodeMode's
-		// ModeFull fallback, so the metric label is never empty.
+		// No mode sub-spec: deriveRole defaults to full node.
 		{"noModeSet", func(_ *seiv1alpha1.SeiNode) {}, roleFullNode},
 	}
 	for _, tt := range tests {

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -1453,7 +1453,11 @@ func TestResourceLabels_ChainAndRoleStampedUnconditionally(t *testing.T) {
 	}{
 		{"validator", func(n *seiv1alpha1.SeiNode) { n.Spec.Validator = &seiv1alpha1.ValidatorSpec{} }, roleValidator},
 		{"archive", func(n *seiv1alpha1.SeiNode) { n.Spec.Archive = &seiv1alpha1.ArchiveSpec{} }, roleArchive},
+		{"replayer", func(n *seiv1alpha1.SeiNode) { n.Spec.Replayer = &seiv1alpha1.ReplayerSpec{} }, roleReplayer},
 		{"fullNode", func(n *seiv1alpha1.SeiNode) { n.Spec.FullNode = &seiv1alpha1.FullNodeSpec{} }, roleFullNode},
+		// No mode sub-spec: deriveRole defaults to node, mirroring NodeMode's
+		// ModeFull fallback, so the metric label is never empty.
+		{"noModeSet", func(_ *seiv1alpha1.SeiNode) {}, roleFullNode},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**PLT-503** — controller-side of PLT-451 Phase-0 (networking→GitOps via orphan-and-adopt). Implements LLD §0/§1/§3 (bdchatham-designs #27).

## What
- `sei.io/networking-orphaned` annotation + `networkingOrphaned()` helper.
- Gate `reconcileNetworking` (controller.go) — orphaned → `orphanNetworkingResources` + `NetworkingReady=False/NetworkingOrphaned`; else unchanged. The `routeHostnameResolvable` early-return moved into the non-orphaned branch (load-bearing: an orphaned SND must still reach `reconcileSeiNodes` to keep writing `external_address`).
- Gate the post-deployment `reconcileNetworking` re-run (plan.go) the same way, **in this same change** (else a rollout re-creates orphaned networking + force-steals field ownership).
- `deriveRole` made total (default→node); `sei.io/role` stamped unconditionally — inert under `OnDelete` (no pod churn).
- `reconcileInternalService` untouched (internal ClusterIP stays controller-owned, out of scope); `orphanChildSeiNodes` not used (SeiNode re-adoption deferred).

## Invariant (tested)
An orphaned SND **still writes a non-empty `Spec.ExternalAddress`** on its children. Two new envtest tests: (1) created-pre-orphaned → no P2P LB created, child gets `ExternalAddress`, condition=`NetworkingOrphaned`; (2) converge-then-orphan → owner-refs stripped (not deleted), `ExternalAddress` preserved.

## Verified
`go build`/`vet` ok · `make manifests generate` zero drift · `make test-integration` green (both orphan tests included).

## Runbook note for PLT-505
The orphan annotation is metadata + the SND watch uses `GenerationChangedPredicate`, so the freeze takes effect on the next ~30s poll requeue, not instantly — consistent with the §5 "verify managedFields frozen ≥2 intervals" gate.