### PR TITLE
fix(snd): skip non-owned objects in networking delete paths (PLT-505 safety rail)

### DIFF
--- a/internal/controller/nodedeployment/envtest/networking_orphan_test.go
+++ b/internal/controller/nodedeployment/envtest/networking_orphan_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/internal/controller/nodedeployment/envtest/fixtures"
@@ -171,4 +172,91 @@ func TestNetworking_Orphaned_StripsOwnerRefs(t *testing.T) {
 		c := apimeta.FindStatusCondition(latest.Status.Conditions, seiv1alpha1.ConditionNetworkingReady)
 		return c != nil && c.Status == metav1.ConditionFalse && c.Reason == "NetworkingOrphaned"
 	}, "ConditionNetworkingReady=False/NetworkingOrphaned after orphan transition")
+}
+
+// TestNetworking_Delete_SkipsOrphanedObjects is the rollback/footgun guard.
+// Once networking is orphaned (owner-refs stripped, objects handed to GitOps),
+// the controller's delete path must skip those objects. Otherwise unsetting the
+// annotation, a re-rendered SND, or a rollback to a gate-less controller would
+// reach the spec.networking==nil delete branch and delete live GitOps-owned
+// networking. The per-pod P2P LB already had this guard; the external Service
+// and HTTPRoutes did not — this exercises both.
+func TestNetworking_Delete_SkipsOrphanedObjects(t *testing.T) {
+	g := NewWithT(t)
+	withP2PEndpointDomain(t, p2pEndpointTestDomain)
+	ns := makeNamespace(t)
+
+	snd := fixtures.NewSND(ns, "orphan-delete-guard",
+		fixtures.WithReplicas(1),
+		fixtures.WithNetworking(),
+	)
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	extSvcKey := types.NamespacedName{Name: snd.Name + "-external", Namespace: ns}
+
+	// Converge: external Service + 4 HTTPRoutes created and owned by the SND.
+	waitFor(t, func() bool {
+		svc := &corev1.Service{}
+		if err := testCli.Get(testCtx, extSvcKey, svc); err != nil {
+			return false
+		}
+		return metav1.IsControlledBy(svc, snd) && len(listHTTPRoutes(t, snd)) == 4
+	}, "external Service + 4 HTTPRoutes owned by SND before orphan")
+
+	// Orphan: stamp the annotation so the controller strips owner-refs from the
+	// external Service + HTTPRoutes. The template-label edit bumps generation so
+	// the generation-gated watch reticks promptly (orthogonal to the guard).
+	latest := getSND(t, client.ObjectKeyFromObject(snd))
+	patch := client.MergeFrom(latest.DeepCopy())
+	if latest.Annotations == nil {
+		latest.Annotations = map[string]string{}
+	}
+	latest.Annotations[networkingOrphanedAnnotation] = "true"
+	if latest.Spec.Template.Metadata == nil {
+		latest.Spec.Template.Metadata = &seiv1alpha1.SeiNodeTemplateMeta{}
+	}
+	if latest.Spec.Template.Metadata.Labels == nil {
+		latest.Spec.Template.Metadata.Labels = map[string]string{}
+	}
+	latest.Spec.Template.Metadata.Labels["test.sei.io/orphan-retick"] = "1"
+	g.Expect(testCli.Patch(testCtx, latest, patch)).To(Succeed())
+
+	// External Service owner-ref stripped — now GitOps-owned, still present.
+	waitFor(t, func() bool {
+		svc := &corev1.Service{}
+		if err := testCli.Get(testCtx, extSvcKey, svc); err != nil {
+			return false
+		}
+		return len(svc.GetOwnerReferences()) == 0
+	}, "external Service owner-ref stripped after orphan")
+
+	// The footgun: unset the annotation AND remove spec.networking together.
+	// The gate is now off, so reconcileNetworking runs and reaches the
+	// networking==nil delete branch — against objects the SND no longer owns.
+	latest = getSND(t, client.ObjectKeyFromObject(snd))
+	patch = client.MergeFrom(latest.DeepCopy())
+	delete(latest.Annotations, networkingOrphanedAnnotation)
+	latest.Spec.Networking = nil
+	g.Expect(testCli.Patch(testCtx, latest, patch)).To(Succeed())
+
+	// The delete path ran (condition flips to NetworkingDisabled)...
+	waitForStatus(t, client.ObjectKeyFromObject(snd), func(l *seiv1alpha1.SeiNodeDeployment) bool {
+		c := apimeta.FindStatusCondition(l.Status.Conditions, seiv1alpha1.ConditionNetworkingReady)
+		return c != nil && c.Status == metav1.ConditionFalse && c.Reason == "NetworkingDisabled"
+	}, "delete branch reached (ConditionNetworkingReady=False/NetworkingDisabled)")
+
+	// ...but the orphaned objects SURVIVE: the delete helpers skip what the SND
+	// no longer controls. Without the guard, the Service + routes vanish here.
+	g.Consistently(func() bool {
+		if err := testCli.Get(testCtx, extSvcKey, &corev1.Service{}); err != nil {
+			return false
+		}
+		routes := &gatewayv1.HTTPRouteList{}
+		if err := testCli.List(testCtx, routes, client.InNamespace(ns),
+			client.MatchingLabels{"sei.io/nodedeployment": snd.Name}); err != nil {
+			return false
+		}
+		return len(routes.Items) == 4
+	}, 2*time.Second, 200*time.Millisecond).Should(BeTrue(),
+		"orphaned external Service + HTTPRoutes survive the controller delete path")
 }

--- a/internal/controller/nodedeployment/envtest/networking_orphan_test.go
+++ b/internal/controller/nodedeployment/envtest/networking_orphan_test.go
@@ -251,6 +251,9 @@ func TestNetworking_Delete_SkipsOrphanedObjects(t *testing.T) {
 		if err := testCli.Get(testCtx, extSvcKey, &corev1.Service{}); err != nil {
 			return false
 		}
+		// List by label, not listHTTPRoutes (which filters on IsControlledBy):
+		// post-orphan the routes are deliberately un-owned, so the helper would
+		// return 0 and defeat the survival assertion.
 		routes := &gatewayv1.HTTPRouteList{}
 		if err := testCli.List(testCtx, routes, client.InNamespace(ns),
 			client.MatchingLabels{"sei.io/nodedeployment": snd.Name}); err != nil {

--- a/internal/controller/nodedeployment/networking.go
+++ b/internal/controller/nodedeployment/networking.go
@@ -198,6 +198,11 @@ func (r *SeiNodeDeploymentReconciler) deleteHTTPRoutesByLabel(ctx context.Contex
 		return fmt.Errorf("listing HTTPRoutes for deletion: %w", err)
 	}
 	for i := range list.Items {
+		// Once owner-refs are stripped for GitOps adoption, the route is no
+		// longer ours to delete — leave it to its new owner.
+		if !metav1.IsControlledBy(&list.Items[i], group) {
+			continue
+		}
 		if err := r.Delete(ctx, &list.Items[i]); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("deleting HTTPRoute %s: %w", list.Items[i].Name, err)
 		}
@@ -381,6 +386,11 @@ func (r *SeiNodeDeploymentReconciler) deleteExternalService(ctx context.Context,
 	}
 	if err != nil {
 		return fmt.Errorf("fetching external Service for deletion: %w", err)
+	}
+	// Once owner-refs are stripped for GitOps adoption, the object is no
+	// longer ours to delete — leave it to its new owner.
+	if !metav1.IsControlledBy(svc, group) {
+		return nil
 	}
 	if err := r.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
 		return err

--- a/internal/controller/nodedeployment/networking.go
+++ b/internal/controller/nodedeployment/networking.go
@@ -198,8 +198,7 @@ func (r *SeiNodeDeploymentReconciler) deleteHTTPRoutesByLabel(ctx context.Contex
 		return fmt.Errorf("listing HTTPRoutes for deletion: %w", err)
 	}
 	for i := range list.Items {
-		// Once owner-refs are stripped for GitOps adoption, the route is no
-		// longer ours to delete — leave it to its new owner.
+		// Skip what we no longer own: orphaned to GitOps.
 		if !metav1.IsControlledBy(&list.Items[i], group) {
 			continue
 		}
@@ -387,8 +386,7 @@ func (r *SeiNodeDeploymentReconciler) deleteExternalService(ctx context.Context,
 	if err != nil {
 		return fmt.Errorf("fetching external Service for deletion: %w", err)
 	}
-	// Once owner-refs are stripped for GitOps adoption, the object is no
-	// longer ours to delete — leave it to its new owner.
+	// Skip what we no longer own: orphaned to GitOps.
 	if !metav1.IsControlledBy(svc, group) {
 		return nil
 	}


### PR DESCRIPTION
## Why
PLT-505 moves SeiNodeDeployment networking to GitOps via orphan-and-adopt. The prod-rollout cross-review (platform/sei-network/security/SRE) surfaced a CRITICAL asymmetry: of the three delete helpers reached by the `spec.networking==nil` branch, only `deleteOrphanP2PEndpoints` checks `IsControlledBy`. `deleteExternalService` and `deleteHTTPRoutesByLabel` delete by name/label unconditionally.

So while the orphan **annotation gate** protects the happy path, the safety of an *adopted* (owner-ref-stripped, GitOps-owned) Service/HTTPRoute rested entirely on that annotation staying present forever. Three realistic paths reach the delete branch and would delete live GitOps-owned networking:
- unsetting `sei.io/networking-orphaned` while `spec.networking` is already gone,
- re-rendering the SND from a source that drops the annotation,
- rolling the controller back to gate-less `73701f1` after the CRD handoff.

## What
Guard both delete paths on `metav1.IsControlledBy(obj, group)` — mirroring the existing P2P guard. The controller now physically cannot delete a networking object it no longer owns, independent of the annotation. This turns the invariant from "an annotation must live forever" into "the controller can't delete what it doesn't own" — and makes a controller rollback safe by construction.

Temporary safety rail: PLT-451 removes the controller's networking delete paths entirely.

## Test
`TestNetworking_Delete_SkipsOrphanedObjects` (envtest) reproduces the disarmed footgun end-to-end: converge external Service + 4 HTTPRoutes → orphan (owner-refs stripped) → unset the annotation **and** remove `spec.networking` together (reaching the delete branch) → assert the objects survive. Verified it **fails without the guard, passes with it**. Full nodedeployment envtest package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Intended semantic (cross-review note)
An SND that is `networking-orphaned` **and then hard-deleted under `DeletionPolicyDelete`** now leaves its orphaned Service/HTTPRoutes surviving finalizer cleanup, instead of deleting them. This is intended and symmetric with the pre-existing P2P guard: orphaned = handed to GitOps = not ours to delete on teardown.