### PR TITLE
fix(snd): preserve child ExternalAddress when networking is orphaned

### DIFF
--- a/internal/controller/nodedeployment/controller.go
+++ b/internal/controller/nodedeployment/controller.go
@@ -106,9 +106,9 @@ func (r *SeiNodeDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// External networking is GitOps-managed when orphaned: strip owner-refs
-	// (idempotent) and stop applying. ExternalAddress for children still flows
-	// through reconcileSeiNodes below, so the DNS-resolvability gate is skipped
-	// rather than allowed to short-circuit it.
+	// (idempotent) and stop applying. The children's ExternalAddress is
+	// preserved (not recomputed) while orphaned — see ensureSeiNode — so the
+	// node keeps advertising its P2P address after spec.networking is removed.
 	if networkingOrphaned(group) {
 		if err := r.orphanNetworkingResources(ctx, group); err != nil {
 			logger.Error(err, "orphaning networking resources")

--- a/internal/controller/nodedeployment/envtest/networking_orphan_test.go
+++ b/internal/controller/nodedeployment/envtest/networking_orphan_test.go
@@ -263,3 +263,60 @@ func TestNetworking_Delete_SkipsOrphanedObjects(t *testing.T) {
 	}, 2*time.Second, 200*time.Millisecond).Should(BeTrue(),
 		"orphaned external Service + HTTPRoutes survive the controller delete path")
 }
+
+// TestNetworking_Orphaned_PreservesExternalAddressAfterNetworkingRemoved is the
+// regression guard for the Step-C ExternalAddress trap. Removing spec.networking
+// flips TCPEnabled() false; without the orphan guard in ensureSeiNode the
+// controller would recompute the child's publishable P2P address to "" and clear
+// it — silently un-advertising the node. Once orphaned, the controller must
+// preserve the address it (or an operator) set, not recompute it.
+func TestNetworking_Orphaned_PreservesExternalAddressAfterNetworkingRemoved(t *testing.T) {
+	g := NewWithT(t)
+	withP2PEndpointDomain(t, p2pEndpointTestDomain)
+	ns := makeNamespace(t)
+
+	// Converge with TCP networking so the controller sets the child's address.
+	snd := fixtures.NewSND(ns, "orphan-extaddr",
+		fixtures.WithReplicas(1),
+		withTCP(),
+	)
+	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
+
+	const chainID = "pacific-1" // fixtures default
+	wantAddr := expectedP2PEndpointAddr(snd.Name, chainID, 0)
+	childKey := types.NamespacedName{Name: snd.Name + "-0", Namespace: ns}
+	waitFor(t, func() bool {
+		child := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, childKey, child); err != nil {
+			return false
+		}
+		return child.Spec.ExternalAddress == wantAddr
+	}, "child has publishable address before orphan")
+
+	// The Step-A + Step-C end state in one edit: orphan AND remove networking.
+	// Removing spec.networking bumps generation, so the reconcile fires promptly.
+	latest := getSND(t, client.ObjectKeyFromObject(snd))
+	patch := client.MergeFrom(latest.DeepCopy())
+	if latest.Annotations == nil {
+		latest.Annotations = map[string]string{}
+	}
+	latest.Annotations[networkingOrphanedAnnotation] = "true"
+	latest.Spec.Networking = nil
+	g.Expect(testCli.Patch(testCtx, latest, patch)).To(Succeed())
+
+	waitForStatus(t, client.ObjectKeyFromObject(snd), func(l *seiv1alpha1.SeiNodeDeployment) bool {
+		c := apimeta.FindStatusCondition(l.Status.Conditions, seiv1alpha1.ConditionNetworkingReady)
+		return c != nil && c.Reason == "NetworkingOrphaned"
+	}, "ConditionNetworkingReady=NetworkingOrphaned after orphan + networking removal")
+
+	// The child's ExternalAddress is PRESERVED, not cleared — across multiple
+	// reconciles — even though spec.networking is gone (TCPEnabled false).
+	g.Consistently(func() string {
+		child := &seiv1alpha1.SeiNode{}
+		if err := testCli.Get(testCtx, childKey, child); err != nil {
+			return ""
+		}
+		return child.Spec.ExternalAddress
+	}, 3*time.Second, 200*time.Millisecond).Should(Equal(wantAddr),
+		"orphaned SND preserves child ExternalAddress after spec.networking removed")
+}

--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -227,7 +227,8 @@ func (r *SeiNodeDeploymentReconciler) ensureSeiNode(ctx context.Context, group *
 	// ExternalAddress: preserve whatever is on the SeiNode rather than
 	// recomputing it from spec.networking. Removing spec.networking flips
 	// TCPEnabled() false, which would otherwise clear the publishable P2P
-	// address and stop the node advertising it.
+	// address and stop the node advertising it. Un-orphaning resumes
+	// recomputation — restore spec.networking too, or it recomputes to "".
 	if !networkingOrphaned(group) && existing.Spec.ExternalAddress != desired.Spec.ExternalAddress {
 		existing.Spec.ExternalAddress = desired.Spec.ExternalAddress
 		updated = true

--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -284,7 +284,10 @@ func generateSeiNode(group *seiv1alpha1.SeiNodeDeployment, ordinal int) *seiv1al
 }
 
 // p2pEndpointAddressForChild returns the vanity host:port when the
-// SND opts into TCP networking, "" otherwise.
+// SND opts into TCP networking, "" otherwise — including for an orphaned
+// group (networking removed). ensureSeiNode preserves the existing value on
+// update while orphaned, but a deleted-and-recreated orphaned child won't
+// re-derive: the operator/GitOps re-pins its ExternalAddress.
 func (r *SeiNodeDeploymentReconciler) p2pEndpointAddressForChild(group *seiv1alpha1.SeiNodeDeployment, ordinal int) string {
 	if !group.Spec.Networking.TCPEnabled() {
 		return ""

--- a/internal/controller/nodedeployment/nodes.go
+++ b/internal/controller/nodedeployment/nodes.go
@@ -223,7 +223,12 @@ func (r *SeiNodeDeploymentReconciler) ensureSeiNode(ctx context.Context, group *
 		existing.Spec.Peers = desired.Spec.Peers
 		updated = true
 	}
-	if existing.Spec.ExternalAddress != desired.Spec.ExternalAddress {
+	// Once networking is orphaned (handed to GitOps), stop managing
+	// ExternalAddress: preserve whatever is on the SeiNode rather than
+	// recomputing it from spec.networking. Removing spec.networking flips
+	// TCPEnabled() false, which would otherwise clear the publishable P2P
+	// address and stop the node advertising it.
+	if !networkingOrphaned(group) && existing.Spec.ExternalAddress != desired.Spec.ExternalAddress {
 		existing.Spec.ExternalAddress = desired.Spec.ExternalAddress
 		updated = true
 	}


### PR DESCRIPTION
## Why
The PLT-505 cutover's Step C (remove `spec.networking` from the SND) flips `TCPEnabled()` false. `ensureSeiNode` then recomputed the child's publishable P2P address as `""` (p2pEndpointAddressForChild → "") and **cleared `SeiNode.Spec.ExternalAddress`** — silently un-advertising the node's stable inbound P2P address, contradicting the design intent that the controller keeps writing `external_address`. Confirmed live: arctic-1 syncer-0/archive-0/node-wave-0 + harbor syncer-0 all had `ExternalAddress=""` post-Step-C. (Latent today — `config-apply` only pushes it on a fresh container deploy — but it would bake `""` into the next redeploy.)

## What
Once a group is `networking-orphaned`, `ensureSeiNode` preserves the existing `ExternalAddress` rather than recomputing it from `spec.networking`. The address (set by the controller while networking was live, or operator-pinned) survives the `spec.networking` removal. This makes the orphan→adopt→remove-networking cutover preserve the P2P address, and is the controller half of "pin ExternalAddress on the SeiNode spec" as a migration step.

## Test
`TestNetworking_Orphaned_PreservesExternalAddressAfterNetworkingRemoved` (envtest): converge with TCP networking → orphan + remove `spec.networking` → assert the child address is preserved across reconciles. **Fails without the guard, passes with it.** Full orphan suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)