### PR TITLE
feat(seitask): WS-C — rpc scenario templates → SeiNode + provision-node RBAC

### DIFF
--- a/internal/seitask/provisionnode/provision_test.go
+++ b/internal/seitask/provisionnode/provision_test.go
@@ -644,3 +644,32 @@ func healthyRPCServer(t *testing.T) *httptest.Server {
 	t.Cleanup(srv.Close)
 	return srv
 }
+
+// TestBundledTemplates_RenderClean ensures every bundled SeiNode (rpc follower)
+// scenario template renders + strict-unmarshals against a representative --var
+// set. Guards against template-vs-schema drift after a CRD field rename. The
+// SeiNetwork genesis/validator templates are validated in provisionsnd.
+func TestBundledTemplates_RenderClean(t *testing.T) {
+	repoRoot, err := filepath.Abs("../../../")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, scenario := range []string{"load-test", "release-test"} {
+		t.Run(scenario+"/rpc.yaml.tmpl", func(t *testing.T) {
+			p := Params{
+				TemplatePath: filepath.Join(repoRoot, "scenarios", scenario, "rpc.yaml.tmpl"),
+				Vars:         map[string]string{varKeyChainID: testChainID, varKeyImage: testImage},
+			}
+			node, err := renderNode(p, 0)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			if node.Spec.ChainID != testChainID {
+				t.Fatalf("chainId = %q, want %q", node.Spec.ChainID, testChainID)
+			}
+			if node.Spec.FullNode == nil {
+				t.Fatalf("rpc template must render a fullNode SeiNode; spec = %+v", node.Spec)
+			}
+		})
+	}
+}

--- a/internal/seitask/provisionsnd/provision_test.go
+++ b/internal/seitask/provisionsnd/provision_test.go
@@ -151,9 +151,10 @@ func TestRenderTemplate_ConfigOverridesSubstitution(t *testing.T) {
 	}
 }
 
-// TestBundledTemplates_RenderClean ensures every bundled scenario template
-// renders + strict-unmarshals against a representative --var set. Guards
-// against template-vs-schema drift after a CRD field rename.
+// TestBundledTemplates_RenderClean ensures every bundled SeiNetwork scenario
+// template (genesis/validator) renders + strict-unmarshals against a
+// representative --var set. Guards against template-vs-schema drift after a
+// CRD field rename. The SeiNode rpc.yaml.tmpl is validated in provisionnode.
 func TestBundledTemplates_RenderClean(t *testing.T) {
 	repoRoot, err := filepath.Abs("../../../")
 	if err != nil {
@@ -166,10 +167,6 @@ func TestBundledTemplates_RenderClean(t *testing.T) {
 		{
 			path: filepath.Join(repoRoot, "scenarios", "release-test", "validator.yaml.tmpl"),
 			vars: map[string]string{varKeyChainID: "rel-test", varKeyImage: "img:1", varKeyAdminAddress: testAdminAddress},
-		},
-		{
-			path: filepath.Join(repoRoot, "scenarios", "release-test", "rpc.yaml.tmpl"),
-			vars: map[string]string{varKeyChainID: "rel-test", varKeyImage: "img:1"},
 		},
 	}
 	for _, tc := range cases {

--- a/runner/rbac.yaml
+++ b/runner/rbac.yaml
@@ -32,11 +32,21 @@ rules:
 - apiGroups: ["sei.io"]
   resources: ["seinodetasks/status"]
   verbs: ["get"]
-# SeiNode: read-only, for --per-node-selector fan-out mode. Omit if your
-# Workflows only use single-node invocations.
+# SeiNode: create + read. create is required by provision-node, whose first
+# act is c.Create(SeiNode) to fan out N standalone follower CRs; without it
+# every provision-node step 403s. get/list/watch back the --per-node-selector
+# fan-out mode and the post-create wait-for-Running loop (.status.phase /
+# .status.endpoint are read off the main object, gated by seinodes get).
 - apiGroups: ["sei.io"]
   resources: ["seinodes"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["create", "get", "list", "watch"]
+# seinodes/status get is a forward-compat over-grant, NOT currently exercised:
+# provision-node reads .status off the main object (seinodes get), not the
+# subresource. Kept to match the /status pattern above and a future
+# c.Status() read.
+- apiGroups: ["sei.io"]
+  resources: ["seinodes/status"]
+  verbs: ["get"]
 # SeiNetwork: create + read for provision-snd. Polls .status.phase
 # until Ready and reads .status.endpoints to publish role-scoped TM/REST/
 # EVM URLs into workflow-vars. patch covers the major-upgrade bump-snd-image

--- a/scenarios/load-test/rpc.yaml.tmpl
+++ b/scenarios/load-test/rpc.yaml.tmpl
@@ -1,17 +1,17 @@
-# PLACEHOLDER — pending the follower reshape (seinetwork-lld § Followers / M2-M3).
-# Followers (rpc/full/archive) are no longer modeled as a SeiNetwork: a
-# SeiNetwork bootstraps a genesis validator pool only. An rpc fleet joining an
-# existing chain becomes standalone SeiNode CRs + hand-rolled GitOps networking,
-# orchestrated by the seictl/harbor-dev skills. Until that flow lands, this file
-# renders as a minimal scoped SeiNetwork so the bench harness keeps building.
+# Standalone follower SeiNode. provision-node renders this once per replica,
+# stamping metadata.name=<base>-<ordinal> (e.g. <chain>-rpc-0), namespace,
+# ownerRef->Workflow, the sei.io/role=node + sei.io/seinetwork=<network> object
+# labels, and a synthesized peers[].label.selector{sei.io/seinetwork:<network>}.
+# This template describes the node only -- never its name, peering, or topology.
 apiVersion: sei.io/v1alpha1
-kind: SeiNetwork
+kind: SeiNode
 metadata:
-  name: PLACEHOLDER
+  name: PLACEHOLDER          # overwritten to <base>-<ordinal> by provision-node
 spec:
+  chainId: "{{ .CHAIN_ID }}"
   image: "{{ .IMAGE }}"
-  replicas: 2
-  configOverrides:
+  fullNode: {}               # the rpc role = EVM-serving full node
+  overrides:
     storage.state_commit.write_mode: memiavl_only
     storage.state_store.write_mode: memiavl_only
     evm.worker_pool_size: "32"
@@ -21,5 +21,3 @@ spec:
     mempool.size: "{{ . }}"
     mempool.pending_size: "{{ . }}"
     {{- end }}
-  genesis:
-    chainId: "{{ .CHAIN_ID }}"

--- a/scenarios/release-test/rpc.yaml.tmpl
+++ b/scenarios/release-test/rpc.yaml.tmpl
@@ -1,22 +1,20 @@
-# PLACEHOLDER — pending the follower reshape (seinetwork-lld § Followers / M2-M3).
-# Followers (rpc/full/archive) are no longer modeled as a SeiNetwork: a
-# SeiNetwork bootstraps a genesis validator pool only. An rpc fleet joining an
-# existing chain becomes standalone SeiNode CRs + hand-rolled GitOps networking,
-# orchestrated by the seictl/harbor-dev skills. Until that flow lands, this file
-# renders as a minimal scoped SeiNetwork so the bench harness keeps building.
+# Standalone follower SeiNode. provision-node renders this once per replica,
+# stamping metadata.name=<base>-<ordinal> (e.g. <chain>-rpc-0), namespace,
+# ownerRef->Workflow, the sei.io/role=node + sei.io/seinetwork=<network> object
+# labels, and a synthesized peers[].label.selector{sei.io/seinetwork:<network>}.
+# This template describes the node only -- never its name, peering, or topology.
 apiVersion: sei.io/v1alpha1
-kind: SeiNetwork
+kind: SeiNode
 metadata:
-  name: PLACEHOLDER
+  name: PLACEHOLDER          # overwritten to <base>-<ordinal> by provision-node
 spec:
+  chainId: "{{ .CHAIN_ID }}"
   image: "{{ .IMAGE }}"
-  replicas: 2
-  configOverrides:
+  fullNode: {}               # the rpc role = EVM-serving full node
+  overrides:
     tx_index.indexer: kv
     storage.state_commit.write_mode: memiavl_only
     storage.state_store.write_mode: memiavl_only
     mempool.ttl_duration: 60s
     network.rpc.lag_threshold: "2"
     evm.enabled_legacy_sei_apis: sei_getLogs,sei_getBlockByNumber,sei_getBlockByHash,sei_getSeiAddress,sei_getEVMAddress,sei_getCosmosTx,sei_getEvmTx,sei_newFilter,sei_getFilterLogs
-  genesis:
-    chainId: "{{ .CHAIN_ID }}"


### PR DESCRIPTION
## What
Controller-side half of WS-C (the platform nightly migration):
- `runner/rbac.yaml`: grant the `seitask-runner` Role `seinodes` **create** (`provision-node`'s first act is `c.Create(SeiNode)` — without it every rpc-fleet step 403s) + `seinodes/status` get (forward-compat, matches the existing `/status` pattern).
- `scenarios/{load-test,release-test}/rpc.yaml.tmpl`: rewrite from a dead second `kind: SeiNetwork` (`replicas: 2`) to a single `kind: SeiNode` `fullNode` follower. name/ns/ownerRef/labels/peers are stamped by `provision-node` at runtime.

## Why
Pairs with the platform WS-C PR (chaos workflows → `provision-node`) and consumes the already-merged `provision-node` (#419) + `SeiNode.status.endpoint` (#418). The old `rpc.yaml.tmpl` rendered a second genesis pool, not followers.

## ⚠️ Hard merge gate — Q4 live-CRD dry-run
The new `kind: SeiNode` template has **never been applied against the deployed CRD**. `make build`/lint/`manifests` are clean and strict-unmarshal passes, but that only covers the repo-bundled CRD. Before merge, run server-side validation against the target cluster:
```
seictl node apply bench-nightly-r1-rpc-0 --preset rpc --chain-id bench-nightly-r1 \
  --image <img> --network bench-nightly-r1 -n <ns> --dry-run
```
A clean dry-run (no `Invalid`/unknown-field/missing-required) closes it. Specifically verify the deployed CRD doesn't enforce a `peers`/CEL constraint on `fullNode` that the repo CRD doesn't (followers get `peers` stamped post-render).

## Sequence
This PR (+ its seitask image build) lands **before** the platform PR, which bumps to the resulting image. RBAC should merge first/standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)