### PR TITLE
feat(sdk): guard provider Register keys against Open's mode literals (#422)

### DIFF
--- a/sdk/sei/provider.go
+++ b/sdk/sei/provider.go
@@ -97,3 +97,7 @@ func registeredNames() []string {
 	sort.Strings(names)
 	return names
 }
+
+// RegisteredProviders returns the names providers have registered under, sorted —
+// the public mirror of sql.Drivers().
+func RegisteredProviders() []string { return registeredNames() }

--- a/sdk/sei/provider/registry_drift_test.go
+++ b/sdk/sei/provider/registry_drift_test.go
@@ -1,0 +1,28 @@
+package provider_test
+
+// External test package + own binary: the only registry writers here are the
+// three provider blank imports, so package sei's resetRegistry can't race it.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
+
+	_ "github.com/sei-protocol/sei-k8s-controller/sdk/sei/provider/docker"
+	_ "github.com/sei-protocol/sei-k8s-controller/sdk/sei/provider/k8s"
+	_ "github.com/sei-protocol/sei-k8s-controller/sdk/sei/provider/local"
+)
+
+// TestProviderKeysMatchOpenModes pins each provider's Register key to the mode
+// literal Open resolves to ("k8s"/"local"/"docker"). Open's doc notes this match
+// is by duplicated literal with nothing mechanical enforcing it; this is that
+// enforcement — a drifted key fails the build instead of failing Open at runtime.
+func TestProviderKeysMatchOpenModes(t *testing.T) {
+	registered := sei.RegisteredProviders()
+	for _, mode := range []string{"k8s", "local", "docker"} {
+		if !slices.Contains(registered, mode) {
+			t.Errorf("mode %q resolvable by Open but no provider Registered under it; registered: %v", mode, registered)
+		}
+	}
+}


### PR DESCRIPTION
## What

The SDK's `Open` resolves `SEI_NODE_CLUSTER`/`SEI_LOCAL`/`SEI_DOCKER` to the mode literals `"k8s"`/`"local"`/`"docker"` (`sei.go:48-52`) and looks up a factory registered under that name. The providers `Register` under their *own* duplicated literals. `sei.go:45-47` says it outright: *"the literals are duplicated there; nothing mechanical enforces the match."* A drifted key would leave `SEI_NODE_CLUSTER` resolving to a mode with no factory — failing `Open` at runtime with "forgotten blank import?".

This adds that enforcement:
- `sei.RegisteredProviders() []string` — the public mirror of `sql.Drivers()`, wrapping the existing `registeredNames()`.
- An isolated guard test (`provider/registry_drift_test.go`) that blank-imports all three providers and pins their Register keys to the modes `Open` resolves. A drifted key now **fails the build** (verified: flipping the k8s key to `"kubernetes"` fails the test; restored, it passes).

The test is its own external `package provider_test` on purpose — package `sei`'s `registry_test.go` calls `resetRegistry`, which would clear the registrations out from under a co-located guard.

## Scope note (#422)

Closes only the **provider-key drift guard** item of #422. The code showed the other two items rest on inaccurate premises — see the re-scoping comment on #422:
- **Probe dedup** — SDK probe (light serve-probe, `height != ""`, unexported) and provisionnode's `waitForFirstBlock` (`height > 0`, `taskruntime.Infra` taxonomy) are *different contracts*. Keep separate.
- **Label-constant dedup** — canonical home is `api/v1alpha1`, not the SDK. Gated on #175, same posture as seictl#212.

## Test
`go test ./sdk/...` green; `go vet`/`gofmt` clean. Idiom-reviewed; gating comment-discipline finding and the keys-vs-modes naming point both addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)