### PR TITLE
fix(scenarios): provision rpc fleet via provision-node, not provision-snd

### DIFF
--- a/scenarios/load-test.yaml
+++ b/scenarios/load-test.yaml
@@ -77,8 +77,12 @@ spec:
                   fieldPath: metadata.namespace
 
     - name: provision-rpc-fleet
+      # 40m covers worst-case sequential readiness: running-timeout 18m +
+      # N×(WaitCaughtUp + WaitEVMServing) at first-block-timeout 5m each
+      # (N=2 → 18m + 4×5m = 38m). Keeps provision-node's typed exit ahead of
+      # the Chaos-Mesh deadline kill so real faults surface as typed errors.
       templateType: Task
-      deadline: 25m
+      deadline: 40m
       task:
         container:
           name: seitask
@@ -103,13 +107,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
 
-    # PodReady != caught up. SeiNetwork phase=Ready means the controller's
-    # reconciliation finished; seid may still be applying historical
-    # blocks behind a Ready RPC pod. Poll Tendermint /status until
-    # catching_up=false before pointing seiload at the fleet. Hits the
-    # aggregate RPC_TM_RPC URL (load-balanced across the fleet); jq's
-    # `.result // .` handles Sei CometBFT's envelope-or-bare shape
-    # tolerance (matches provision-snd's waitForFirstBlock parser).
+    # Redundant secondary gate: provision-node already waited every follower
+    # caught-up (height>1 && catching_up==false) before publishing endpoints —
+    # this re-confirms node-0 (RPC_TM_RPC is node-0's URL, not an aggregate) once
+    # more right before pointing seiload at the fleet. The sed extract tolerates
+    # Sei CometBFT's envelope-or-bare /status shape.
     - name: wait-rpc-caught-up
       templateType: Task
       deadline: 10m

--- a/scenarios/load-test.yaml
+++ b/scenarios/load-test.yaml
@@ -77,12 +77,15 @@ spec:
                   fieldPath: metadata.namespace
 
     - name: provision-rpc-fleet
-      # 40m covers worst-case sequential readiness: running-timeout 18m +
+      # 42m covers worst-case sequential readiness: running-timeout 18m +
       # N×(WaitCaughtUp + WaitEVMServing) at first-block-timeout 5m each
-      # (N=2 → 18m + 4×5m = 38m). Keeps provision-node's typed exit ahead of
-      # the Chaos-Mesh deadline kill so real faults surface as typed errors.
+      # (N=2 → 18m + 4×5m = 38m), plus 4m headroom. The Chaos-Mesh deadline
+      # clock starts at Task admission, so the headroom must also absorb pod
+      # scheduling + a cold $SEITASK_IMAGE pull (both outside the inner 38m) —
+      # else a slow-but-genuine readiness is killed opaquely before its typed
+      # exit lands, inverting the very invariant this budget protects.
       templateType: Task
-      deadline: 40m
+      deadline: 42m
       task:
         container:
           name: seitask

--- a/scenarios/load-test.yaml
+++ b/scenarios/load-test.yaml
@@ -84,13 +84,15 @@ spec:
           name: seitask
           image: $SEITASK_IMAGE
           args:
-            - provision-snd
+            - provision-node                     # rpc followers are standalone SeiNodes, not a SeiNetwork
             - --role=rpc
-            - --name=$SEI_CHAIN_ID-rpc
+            - --name=$SEI_CHAIN_ID-rpc           # BASE name; followers are <base>-0..N-1
+            - --replicas=2                       # seiload drives all N via RPC_EVM_RPC_LIST
+            - --network=$SEI_CHAIN_ID            # peer auto-wire to the genesis SeiNetwork (sei.io/seinetwork=<chain>)
             - --template=/scenarios/load-test/rpc.yaml.tmpl
             - --var=CHAIN_ID=$SEI_CHAIN_ID
             - --var=IMAGE=$SEID_IMAGE
-            - --ready-timeout=18m
+            - --running-timeout=18m              # was --ready-timeout; SeiNode has no Ready phase (default --first-block-timeout=5m)
           env:
             - name: SEI_WORKFLOW_NAME
               valueFrom:
@@ -138,7 +140,7 @@ spec:
     # Sed-substitute the source profile (mounted via volume from the
     # seiload-profiles CM in this namespace) and create the per-run
     # rendered ConfigMap with an ownerRef to the parent Workflow.
-    # $RPC_EVM_RPC_LIST is published by provision-snd as comma-
+    # $RPC_EVM_RPC_LIST is published by provision-node as comma-
     # separated bare URLs; the profile expects `[...]` with JSON-quoted
     # entries, so we quote+join here.
     - name: render-seiload-profile

--- a/scenarios/release-test.yaml
+++ b/scenarios/release-test.yaml
@@ -107,13 +107,15 @@ spec:
           name: seitask
           image: $SEITASK_IMAGE
           args:
-            - provision-snd
+            - provision-node                     # rpc follower is a standalone SeiNode, not a SeiNetwork
             - --role=rpc
-            - --name=$SEI_CHAIN_ID-rpc
+            - --name=$SEI_CHAIN_ID-rpc           # BASE name; follower is <base>-0
+            - --replicas=1                       # mocha hits a single RPC (RPC_TM_RPC/EVM/REST)
+            - --network=$SEI_CHAIN_ID            # peer auto-wire to the genesis SeiNetwork (sei.io/seinetwork=<chain>)
             - --template=/scenarios/release-test/rpc.yaml.tmpl
             - --var=CHAIN_ID=$SEI_CHAIN_ID
             - --var=IMAGE=$SEID_IMAGE
-            - --ready-timeout=18m
+            - --running-timeout=18m              # was --ready-timeout; SeiNode has no Ready phase (default --first-block-timeout=5m)
           env:
             - name: SEI_WORKFLOW_NAME
               valueFrom:
@@ -127,11 +129,11 @@ spec:
             - configMapRef:
                 name: workflow-vars-release-test-$SEI_WORKFLOW_RUN_ID
 
-    # TM RPC + REST go through the aggregate ClusterIP (stateless, safe
-    # to load-balance). EVM RPC pins to rpc pod-0 via provision-snd's
-    # RoleScoped(rpc, EVM_RPC) — stateful sequences (sei_newFilter +
-    # sei_getFilterLogs, eth_sendRawTransaction + tx.wait) need a single
-    # mempool + filter-store view.
+    # With one rpc follower (replicas=1), TM RPC + REST + EVM RPC all resolve to
+    # that node via provision-node's RoleScoped(rpc, *) off node-0's
+    # .status.endpoint. A single node also gives the stateful sequences
+    # (sei_newFilter + sei_getFilterLogs, eth_sendRawTransaction + tx.wait) one
+    # consistent mempool + filter-store view.
     - name: run-release-test
       templateType: Task
       deadline: 30m

--- a/scenarios/release-test.yaml
+++ b/scenarios/release-test.yaml
@@ -100,12 +100,15 @@ spec:
                 name: workflow-vars-release-test-$SEI_WORKFLOW_RUN_ID
 
     - name: provision-rpc-fleet
-      # 30m covers worst-case sequential readiness: running-timeout 18m +
+      # 32m covers worst-case sequential readiness: running-timeout 18m +
       # WaitCaughtUp + WaitEVMServing at first-block-timeout 5m each
-      # (N=1 → 18m + 2×5m = 28m). Keeps provision-node's typed exit ahead of
-      # the Chaos-Mesh deadline kill so real faults surface as typed errors.
+      # (N=1 → 18m + 2×5m = 28m), plus 4m headroom. The Chaos-Mesh deadline
+      # clock starts at Task admission, so the headroom must also absorb pod
+      # scheduling + a cold $SEITASK_IMAGE pull (both outside the inner 28m) —
+      # else a slow-but-genuine readiness is killed opaquely before its typed
+      # exit lands, inverting the very invariant this budget protects.
       templateType: Task
-      deadline: 30m
+      deadline: 32m
       task:
         container:
           name: seitask

--- a/scenarios/release-test.yaml
+++ b/scenarios/release-test.yaml
@@ -100,8 +100,12 @@ spec:
                 name: workflow-vars-release-test-$SEI_WORKFLOW_RUN_ID
 
     - name: provision-rpc-fleet
+      # 30m covers worst-case sequential readiness: running-timeout 18m +
+      # WaitCaughtUp + WaitEVMServing at first-block-timeout 5m each
+      # (N=1 → 18m + 2×5m = 28m). Keeps provision-node's typed exit ahead of
+      # the Chaos-Mesh deadline kill so real faults surface as typed errors.
       templateType: Task
-      deadline: 25m
+      deadline: 30m
       task:
         container:
           name: seitask


### PR DESCRIPTION
Coral-xreview blocker on the WS-C nightly migration (platform #1165): the externally-fetched `load-test`/`release-test` scenarios still provisioned the RPC fleet with `provision-snd --role=rpc` on a `kind: SeiNode` template — but `provision-snd` creates a **SeiNetwork** (strict-unmarshal), so the RPC step render-fails the first time the nightly cron fetches these scenarios → load + release dead on arrival.

## Change
Migrate the **RPC** provision step in both scenarios `provision-snd` → `provision-node` (standalone SeiNode followers), mirroring the in-repo chaos scenarios already migrated in #1165:
- `--replicas` (load-test=**2** — seiload drives all N via `RPC_EVM_RPC_LIST`; release-test=**1** — mocha hits a single `RPC_TM_RPC`/`EVM`/`REST`)
- `--network=$SEI_CHAIN_ID` — genesis peer auto-wire (`sei.io/seinetwork=<chain>`)
- `--running-timeout` (was `--ready-timeout`; SeiNode has no Ready phase)

The **validator** steps intentionally stay `provision-snd` (genesis SeiNetwork). Also refreshed two stale RPC-publishing comments.

## Note
`provision-node` exists in the pinned seitask image (`adca2d5`), so no image bump needed; platform #1191 bumps `SCENARIO_REF` to this commit. Validated YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)