### PR TITLE
feat(test): WS-I sei integration suite — TestBenchmark provision spine [DRAFT]

### DIFF
--- a/sdk/sei/provider/k8s/k8s_test.go
+++ b/sdk/sei/provider/k8s/k8s_test.go
@@ -29,6 +29,10 @@ const (
 	rpc0Name  = "rpc-0"
 	rpc1Name  = "rpc-1"
 	resultKey = "result"
+
+	// caller-label fixtures for the GC-selector render tests
+	testRunLabel = "sei.io/harness-run"
+	testRunID    = "run-xyz"
 )
 
 // TestMain shrinks the poll cadences so phase/probe tests resolve in

--- a/sdk/sei/provider/k8s/render.go
+++ b/sdk/sei/provider/k8s/render.go
@@ -20,8 +20,9 @@ const fieldOwner client.FieldOwner = sei.FieldOwner
 // renderNetwork builds the SeiNetwork from a NetworkSpec. ChainID is not a spec
 // field: it defaults to Name (chain ID == network name) and maps to
 // spec.genesis.chainId. Genesis maps to spec.genesis.overrides; Config maps to
-// spec.configOverrides. The network object is NOT label-stamped — nodes match on
-// its name, not a label on it.
+// spec.configOverrides. Nodes peer by the network's name, not a label on it, so
+// the object carries no canonical labels — but spec.Labels (e.g. a caller GC
+// selector) are stamped when provided.
 func renderNetwork(spec sei.NetworkSpec, namespace string) *seiv1alpha1.SeiNetwork {
 	net := &seiv1alpha1.SeiNetwork{
 		TypeMeta: metav1.TypeMeta{
@@ -31,6 +32,7 @@ func renderNetwork(spec sei.NetworkSpec, namespace string) *seiv1alpha1.SeiNetwo
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      spec.Name,
 			Namespace: namespace,
+			Labels:    maps.Clone(spec.Labels), // nil-safe; caller GC/run-id selector
 		},
 		Spec: seiv1alpha1.SeiNetworkSpec{
 			Image:    spec.Image,
@@ -66,6 +68,16 @@ func renderNetwork(spec sei.NetworkSpec, namespace string) *seiv1alpha1.SeiNetwo
 // the peer selector searches networkNS, where the genesis validators live (equal
 // to namespace when co-located). ChainID defaults to spec.Network.
 func renderNode(spec sei.NodeSpec, namespace, networkNS string) *seiv1alpha1.SeiNode {
+	// Caller labels first, then the canonical labels on top — the canonical
+	// sei.io/role + sei.io/seinetwork are load-bearing (peer wiring, chaos
+	// selectors) and must win on any key collision.
+	labels := maps.Clone(spec.Labels)
+	if labels == nil {
+		labels = make(map[string]string, 2)
+	}
+	labels[sei.LabelRole] = sei.RoleNode
+	labels[sei.LabelSeiNetwork] = spec.Network
+
 	node := &seiv1alpha1.SeiNode{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: seiv1alpha1.GroupVersion.String(),
@@ -74,10 +86,7 @@ func renderNode(spec sei.NodeSpec, namespace, networkNS string) *seiv1alpha1.Sei
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      spec.Name,
 			Namespace: namespace,
-			Labels: map[string]string{
-				sei.LabelRole:       sei.RoleNode,
-				sei.LabelSeiNetwork: spec.Network,
-			},
+			Labels:    labels,
 		},
 		Spec: seiv1alpha1.SeiNodeSpec{
 			ChainID:  spec.Network,

--- a/sdk/sei/provider/k8s/render_test.go
+++ b/sdk/sei/provider/k8s/render_test.go
@@ -12,7 +12,7 @@ func TestRenderNetwork_ChainIDDefaultsToName(t *testing.T) {
 		Genesis:  map[string]string{"staking.params.unbonding_time": "60s"},
 		Config:   map[string]string{"app.pruning": "nothing"},
 		Accounts: []sei.GenesisAccount{{Address: "sei1abc", Balance: "100usei"}},
-		Labels:   map[string]string{"sei.io/harness-run": "run-xyz"},
+		Labels:   map[string]string{testRunLabel: testRunID},
 	}
 	net := renderNetwork(spec, testNS)
 
@@ -37,8 +37,8 @@ func TestRenderNetwork_ChainIDDefaultsToName(t *testing.T) {
 	}
 	// The network carries caller labels (e.g. a GC/run-id selector) but NOT the
 	// canonical sei.io/seinetwork (nodes peer by its name, not a label on it).
-	if got := net.Labels["sei.io/harness-run"]; got != "run-xyz" {
-		t.Errorf("caller label sei.io/harness-run = %q, want run-xyz", got)
+	if got := net.Labels[testRunLabel]; got != testRunID {
+		t.Errorf("caller label sei.io/harness-run = %q, want run-xyz (testRunID)", got)
 	}
 	if _, ok := net.Labels[sei.LabelSeiNetwork]; ok {
 		t.Errorf("network object must not carry sei.io/seinetwork label")
@@ -88,14 +88,14 @@ func TestRenderNode_CallerLabelsMergeUnderCanonical(t *testing.T) {
 	spec := sei.NodeSpec{
 		Name: rpc0Name, Network: testNet, Image: testImage,
 		Labels: map[string]string{
-			"sei.io/harness-run": "run-xyz",   // caller GC selector — must land
-			sei.LabelRole:        "validator", // collides with canonical — must NOT win
+			testRunLabel:  testRunID,   // caller GC selector — must land
+			sei.LabelRole: "validator", // collides with canonical — must NOT win
 		},
 	}
 	node := renderNode(spec, testNS, testNS)
 
-	if got := node.Labels["sei.io/harness-run"]; got != "run-xyz" {
-		t.Errorf("caller label sei.io/harness-run = %q, want run-xyz", got)
+	if got := node.Labels[testRunLabel]; got != testRunID {
+		t.Errorf("caller label sei.io/harness-run = %q, want run-xyz (testRunID)", got)
 	}
 	// Canonical labels are load-bearing (peer wiring, chaos selectors) and win
 	// on any key collision with caller labels.

--- a/sdk/sei/provider/k8s/render_test.go
+++ b/sdk/sei/provider/k8s/render_test.go
@@ -12,6 +12,7 @@ func TestRenderNetwork_ChainIDDefaultsToName(t *testing.T) {
 		Genesis:  map[string]string{"staking.params.unbonding_time": "60s"},
 		Config:   map[string]string{"app.pruning": "nothing"},
 		Accounts: []sei.GenesisAccount{{Address: "sei1abc", Balance: "100usei"}},
+		Labels:   map[string]string{"sei.io/harness-run": "run-xyz"},
 	}
 	net := renderNetwork(spec, testNS)
 
@@ -34,7 +35,11 @@ func TestRenderNetwork_ChainIDDefaultsToName(t *testing.T) {
 	if len(net.Spec.Genesis.Accounts) != 1 || net.Spec.Genesis.Accounts[0].Address != "sei1abc" {
 		t.Errorf("genesis accounts = %+v", net.Spec.Genesis.Accounts)
 	}
-	// The network object is NOT label-stamped (nodes match on its name).
+	// The network carries caller labels (e.g. a GC/run-id selector) but NOT the
+	// canonical sei.io/seinetwork (nodes peer by its name, not a label on it).
+	if got := net.Labels["sei.io/harness-run"]; got != "run-xyz" {
+		t.Errorf("caller label sei.io/harness-run = %q, want run-xyz", got)
+	}
 	if _, ok := net.Labels[sei.LabelSeiNetwork]; ok {
 		t.Errorf("network object must not carry sei.io/seinetwork label")
 	}
@@ -76,6 +81,29 @@ func TestRenderNode_LabelsAndPeerWiring(t *testing.T) {
 	}
 	if node.Spec.ChainID != testNet {
 		t.Errorf("chainId = %q, want %q (defaults to Network)", node.Spec.ChainID, testNet)
+	}
+}
+
+func TestRenderNode_CallerLabelsMergeUnderCanonical(t *testing.T) {
+	spec := sei.NodeSpec{
+		Name: rpc0Name, Network: testNet, Image: testImage,
+		Labels: map[string]string{
+			"sei.io/harness-run": "run-xyz",   // caller GC selector — must land
+			sei.LabelRole:        "validator", // collides with canonical — must NOT win
+		},
+	}
+	node := renderNode(spec, testNS, testNS)
+
+	if got := node.Labels["sei.io/harness-run"]; got != "run-xyz" {
+		t.Errorf("caller label sei.io/harness-run = %q, want run-xyz", got)
+	}
+	// Canonical labels are load-bearing (peer wiring, chaos selectors) and win
+	// on any key collision with caller labels.
+	if got := node.Labels[sei.LabelRole]; got != sei.RoleNode {
+		t.Errorf("canonical %s = %q, want %q (must override caller)", sei.LabelRole, got, sei.RoleNode)
+	}
+	if got := node.Labels[sei.LabelSeiNetwork]; got != testNet {
+		t.Errorf("canonical %s = %q, want %s", sei.LabelSeiNetwork, got, testNet)
 	}
 }
 

--- a/sdk/sei/spec.go
+++ b/sdk/sei/spec.go
@@ -13,6 +13,7 @@ type NetworkSpec struct {
 	Accounts []GenesisAccount  // non-validator genesis accounts to fund
 	Genesis  map[string]string // -> spec.genesis.overrides (TOML-path keys)
 	Config   map[string]string // -> spec.configOverrides (config.toml/app.toml)
+	Labels   map[string]string // extra labels on the SeiNetwork object (e.g. a caller GC/run-id selector); the network object carries no labels otherwise
 }
 
 // GenesisAccount is a non-validator genesis account to fund.
@@ -31,4 +32,5 @@ type NodeSpec struct {
 	NetworkNamespace string            // "" => same as Namespace (co-located, the common case); set it when the SeiNetwork lives in a different namespace
 	Image            string            // -> spec.image
 	Config           map[string]string // -> spec.overrides (TOML-path keys)
+	Labels           map[string]string // extra labels on the SeiNode object, merged UNDER the canonical sei.io/role + sei.io/seinetwork (which win on key conflict)
 }

--- a/test/integration/benchmark_test.go
+++ b/test/integration/benchmark_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestBenchmark is the load suite: provision a validator chain + RPC fleet,
+// drive seiload against the fleet for the configured duration, and upload the
+// report. Replaces the load-test Chaos-Mesh Workflow.
+//
+// Inputs (env, mirroring k8s_nightly.yml):
+//
+//	SEI_CHAIN_ID   per-run chain id (e.g. bench-<run-id>)   [required]
+//	SEID_IMAGE     seid image under test                    [required]
+//	SEI_RUN_ID     unique run id (sei.io/harness-run)       [default: SEI_CHAIN_ID]
+//	SEI_NAMESPACE  shared nightly namespace                 [default: SDK default]
+func TestBenchmark(t *testing.T) {
+	requireCluster(t)
+
+	chainID := mustEnv(t, "SEI_CHAIN_ID")
+	s := spec{
+		chainID:    chainID,
+		runID:      env("SEI_RUN_ID", chainID),
+		namespace:  env("SEI_NAMESPACE", ""),
+		seidImage:  mustEnv(t, "SEID_IMAGE"),
+		validators: 4,
+		rpcNodes:   2, // seiload fans across both via the EVM endpoint list
+		timeout:    90 * time.Minute,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	defer cancel()
+
+	c := openClient(ctx, t)
+
+	ch, err := provision(ctx, c, s)
+	cleanupChain(t, ch)
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	t.Logf("provisioned %s: %d validators + %d RPC followers; EVM endpoints=%v",
+		s.chainID, s.validators, len(ch.rpcNodes), ch.evmEndpoints())
+
+	// TODO(WS-I step 1, next increment): drive seiload as a DECOUPLED unit
+	// (decision D3) — apply seiload's own manifest parameterized with
+	// ch.evmEndpoints(), stamped sei.io/harness-run=s.runID; wait for
+	// completion; read its report from the agreed S3 path; assert TPS/receipts.
+	// seiload's Job spec is NOT constructed here.
+	t.Skip("seiload drive + report not yet wired (WS-I step 1 next increment)")
+}

--- a/test/integration/benchmark_test.go
+++ b/test/integration/benchmark_test.go
@@ -4,6 +4,8 @@ package integration
 
 import (
 	"context"
+	"os/signal"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -18,14 +20,20 @@ import (
 //	SEID_IMAGE     seid image under test                    [required]
 //	SEI_RUN_ID     unique run id (sei.io/harness-run)       [default: SEI_CHAIN_ID]
 //	SEI_NAMESPACE  shared nightly namespace                 [default: SDK default]
+//
+// Deadlines: the CronJob MUST run this with `-test.timeout 0` (or safely above
+// the scenario timeout). A -test.timeout breach panics and bypasses t.Cleanup,
+// so the scenario ctx below — not the test-runner alarm — must own the deadline,
+// nested inside the CronJob activeDeadlineSeconds (the SIGKILL backstop the
+// label-GC sweep covers).
 func TestBenchmark(t *testing.T) {
 	requireCluster(t)
 
 	chainID := mustEnv(t, "SEI_CHAIN_ID")
 	s := spec{
 		chainID:    chainID,
-		runID:      env("SEI_RUN_ID", chainID),
-		namespace:  env("SEI_NAMESPACE", ""),
+		runID:      envOr("SEI_RUN_ID", chainID),
+		namespace:  envOr("SEI_NAMESPACE", ""),
 		seidImage:  mustEnv(t, "SEID_IMAGE"),
 		validators: 4,
 		rpcNodes:   2, // seiload fans across both via the EVM endpoint list
@@ -34,10 +42,16 @@ func TestBenchmark(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
 	defer cancel()
+	// SIGTERM (the activeDeadlineSeconds grace period, or a manual pod delete)
+	// cancels ctx so the SDK calls unwind and t.Cleanup teardown runs before the
+	// kubelet SIGKILLs the pod. SIGKILL itself still bypasses cleanup — that is
+	// what the label-GC sweep backstops.
+	ctx, stopSignals := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+	defer stopSignals()
 
 	c := openClient(ctx, t)
 
-	ch, err := provision(ctx, c, s)
+	ch, err := provision(ctx, t, c, s)
 	cleanupChain(t, ch)
 	if err != nil {
 		t.Fatalf("provision: %v", err)
@@ -51,5 +65,6 @@ func TestBenchmark(t *testing.T) {
 	// ch.evmEndpoints(), stamped sei.io/harness-run=s.runID; wait for
 	// completion; read its report from the agreed S3 path; assert TPS/receipts.
 	// seiload's Job spec is NOT constructed here.
-	t.Skip("seiload drive + report not yet wired (WS-I step 1 next increment)")
+	t.Skipf("provisioned %s (%d validators + %d followers); seiload drive + report not yet wired — tearing down",
+		s.chainID, s.validators, len(ch.rpcNodes))
 }

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -35,11 +35,13 @@ import (
 	_ "github.com/sei-protocol/sei-k8s-controller/sdk/sei/provider/k8s"
 )
 
-// runLabelKey is stamped on every resource a suite creates (network, nodes,
-// and — in chaos scenarios — fault CRs and the seiload Job) so the nightly
-// label-GC can reap an abnormally-exited run. Under the shared-namespace model
-// (decision D2) this label sweep is the SOLE abnormal-exit reaper; t.Cleanup
-// teardown is only the normal-exit fast path, and does not run on SIGKILL.
+// runLabelKey identifies a run's resources for the nightly label-GC sweep — the
+// SOLE abnormal-exit reaper under the shared-namespace model (D2), since
+// t.Cleanup does NOT run on SIGKILL or a -test.timeout breach. provision stamps
+// it (via the SDK NetworkSpec/NodeSpec Labels) on the network + every node; the
+// seiload Job and fault CRs a suite applies directly must stamp it too (load /
+// chaos increments). The sweep must be proven against an orphaned run before the
+// Workflow ownerRef cascade is removed (WS-I step 2).
 const runLabelKey = "sei.io/harness-run"
 
 // spec is the typed input shared by the suites — the local-Go-state replacement
@@ -85,14 +87,20 @@ func rpcNodeName(chainID string, ordinal int) string {
 // to Running + caught-up + EVM-serving before returning. The returned chain is
 // non-nil even on error so the caller can still tear down whatever was created
 // (pair every provision with a t.Cleanup(teardown)).
-func provision(ctx context.Context, c *sei.Client, s spec) (*chain, error) {
+func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain, error) {
+	t.Helper()
 	ch := &chain{}
+
+	// Stamped on the network + every node so the label-GC sweep can reap this
+	// run's resources on an abnormal exit t.Cleanup can't cover.
+	runLabels := map[string]string{runLabelKey: s.runID}
 
 	net, err := c.CreateNetwork(ctx, sei.NetworkSpec{
 		Name:       s.chainID,
 		Namespace:  s.namespace,
 		Image:      s.seidImage,
 		Validators: s.validators,
+		Labels:     runLabels,
 	})
 	if err != nil {
 		return ch, fmt.Errorf("create network %q: %w", s.chainID, err)
@@ -101,30 +109,37 @@ func provision(ctx context.Context, c *sei.Client, s spec) (*chain, error) {
 	if err := net.WaitReady(ctx); err != nil {
 		return ch, fmt.Errorf("network %q ready: %w", s.chainID, err)
 	}
+	t.Logf("network %s: ready", s.chainID)
 
 	hc := &http.Client{Timeout: 10 * time.Second}
-	for i := 0; i < s.rpcNodes; i++ {
+	for i := range s.rpcNodes {
 		name := rpcNodeName(s.chainID, i)
 		node, err := c.CreateNode(ctx, sei.NodeSpec{
 			Name:      name,
 			Network:   s.chainID,
 			Namespace: s.namespace,
 			Image:     s.seidImage,
+			Labels:    runLabels,
 		})
 		if err != nil {
 			return ch, fmt.Errorf("create rpc node %q: %w", name, err)
 		}
 		ch.rpcNodes = append(ch.rpcNodes, node)
 
+		// Per-gate progress so a stall is localizable in real time from the pod
+		// log (which node, which gate) rather than a single terminal error.
 		if err := node.WaitReady(ctx); err != nil {
 			return ch, fmt.Errorf("rpc node %q running: %w", name, err)
 		}
+		t.Logf("rpc node %s: running", name)
 		if err := sei.WaitCaughtUp(ctx, hc, node.TendermintRPC()); err != nil {
 			return ch, fmt.Errorf("rpc node %q caught up: %w", name, err)
 		}
+		t.Logf("rpc node %s: caught up", name)
 		if err := sei.WaitEVMServing(ctx, hc, node.EVMRPC()); err != nil {
 			return ch, fmt.Errorf("rpc node %q EVM serving: %w", name, err)
 		}
+		t.Logf("rpc node %s: EVM serving", name)
 	}
 	return ch, nil
 }
@@ -186,8 +201,8 @@ func openClient(ctx context.Context, t *testing.T) *sei.Client {
 	return c
 }
 
-// env returns the env var or a fallback (for local runs).
-func env(key, fallback string) string {
+// envOr returns the env var or a fallback (for local runs).
+func envOr(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
 	}

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -1,0 +1,205 @@
+//go:build integration
+
+// Package integration holds the Sei nightly integration-test suites as plain
+// `go test` targets — TestBenchmark, TestChaosSuite, TestChainUpgrade,
+// TestRelease — selected with `-run`. It replaces the Chaos-Mesh Workflow DAG +
+// seitask Task pods + workflow-vars ConfigMap (WS-I LLD): state that the
+// ConfigMap passed across pods now lives in local Go values (chain), and
+// orchestration is statement order in one process.
+//
+// Isolation (decisions D2/D4/D5): everything here lives in *_test.go files, so
+// Go itself guarantees it never links into a production binary (controller /
+// seid / seitask). The //go:build integration tag additionally excludes it from
+// the default `go test ./...`; the nightly compiles it once with
+// `go test -c -tags integration` and ships the standalone binary in its own
+// image, run by one in-cluster CronJob per target (`-test.run TestX`).
+//
+// The suite depends ONLY on sdk/sei (+ the k8s provider blank import) — never
+// internal/seitask or internal/taskruntime — so the seitask runner can be
+// removed wholesale once the four targets cover the nightly.
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
+
+	// Register the k8s provisioning provider for the SDK (database/sql-style
+	// blank import; sei.Open(ctx, "k8s") needs it present).
+	_ "github.com/sei-protocol/sei-k8s-controller/sdk/sei/provider/k8s"
+)
+
+// runLabelKey is stamped on every resource a suite creates (network, nodes,
+// and — in chaos scenarios — fault CRs and the seiload Job) so the nightly
+// label-GC can reap an abnormally-exited run. Under the shared-namespace model
+// (decision D2) this label sweep is the SOLE abnormal-exit reaper; t.Cleanup
+// teardown is only the normal-exit fast path, and does not run on SIGKILL.
+const runLabelKey = "sei.io/harness-run"
+
+// spec is the typed input shared by the suites — the local-Go-state replacement
+// for the per-run workflow-vars contract.
+type spec struct {
+	chainID    string        // SeiNetwork name == genesis chain id; also the peer-selector value and per-run discriminator
+	runID      string        // unique per run; the sei.io/harness-run label value
+	namespace  string        // shared nightly namespace (D2); "" => SDK client default (SA namespace)
+	seidImage  string        // seid container image under test
+	validators int           // genesis validator count (>= 1)
+	rpcNodes   int           // standalone RPC followers; named <chain>-rpc-0..N-1
+	timeout    time.Duration // overall scenario deadline (drives ctx, kept < CronJob activeDeadlineSeconds)
+}
+
+// chain is the live provisioned topology a suite runs load against and asserts
+// on. Held entirely in local Go state — what the workflow-vars ConfigMap used
+// to pass between pods.
+type chain struct {
+	network  *sei.Network
+	rpcNodes []*sei.Node
+}
+
+// evmEndpoints returns the per-follower EVM JSON-RPC URLs that seiload's profile
+// fans its workload across.
+func (ch *chain) evmEndpoints() []string {
+	urls := make([]string, 0, len(ch.rpcNodes))
+	for _, n := range ch.rpcNodes {
+		urls = append(urls, n.EVMRPC())
+	}
+	return urls
+}
+
+// rpcNodeName is the load-bearing selector contract: chaos fault CRs target
+// followers by sei.io/node=<chain>-rpc-<ordinal>. The SDK NodeSpec has no
+// Replicas field (the caller loops CreateNode), so the suite reproduces the
+// <base>-<ordinal> naming the old `provision-node --replicas` produced.
+func rpcNodeName(chainID string, ordinal int) string {
+	return fmt.Sprintf("%s-rpc-%d", chainID, ordinal)
+}
+
+// provision stands up the genesis SeiNetwork + N standalone RPC SeiNodes via the
+// SDK in-process (decision D3 — not a seictl subprocess), waiting each follower
+// to Running + caught-up + EVM-serving before returning. The returned chain is
+// non-nil even on error so the caller can still tear down whatever was created
+// (pair every provision with a t.Cleanup(teardown)).
+func provision(ctx context.Context, c *sei.Client, s spec) (*chain, error) {
+	ch := &chain{}
+
+	net, err := c.CreateNetwork(ctx, sei.NetworkSpec{
+		Name:       s.chainID,
+		Namespace:  s.namespace,
+		Image:      s.seidImage,
+		Validators: s.validators,
+	})
+	if err != nil {
+		return ch, fmt.Errorf("create network %q: %w", s.chainID, err)
+	}
+	ch.network = net
+	if err := net.WaitReady(ctx); err != nil {
+		return ch, fmt.Errorf("network %q ready: %w", s.chainID, err)
+	}
+
+	hc := &http.Client{Timeout: 10 * time.Second}
+	for i := 0; i < s.rpcNodes; i++ {
+		name := rpcNodeName(s.chainID, i)
+		node, err := c.CreateNode(ctx, sei.NodeSpec{
+			Name:      name,
+			Network:   s.chainID,
+			Namespace: s.namespace,
+			Image:     s.seidImage,
+		})
+		if err != nil {
+			return ch, fmt.Errorf("create rpc node %q: %w", name, err)
+		}
+		ch.rpcNodes = append(ch.rpcNodes, node)
+
+		if err := node.WaitReady(ctx); err != nil {
+			return ch, fmt.Errorf("rpc node %q running: %w", name, err)
+		}
+		if err := sei.WaitCaughtUp(ctx, hc, node.TendermintRPC()); err != nil {
+			return ch, fmt.Errorf("rpc node %q caught up: %w", name, err)
+		}
+		if err := sei.WaitEVMServing(ctx, hc, node.EVMRPC()); err != nil {
+			return ch, fmt.Errorf("rpc node %q EVM serving: %w", name, err)
+		}
+	}
+	return ch, nil
+}
+
+// teardown deletes the provisioned resources — the normal-exit fast path, wired
+// via t.Cleanup. Best-effort and idempotent (the SDK treats not-found as
+// success): every delete is attempted and errors joined, so one failure never
+// strands the rest. The harness-run label sweep is the backstop when this never
+// runs (SIGKILL).
+func (ch *chain) teardown(ctx context.Context) error {
+	var errs []error
+	for _, n := range ch.rpcNodes {
+		if n == nil {
+			continue
+		}
+		if err := n.Delete(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("delete node %q: %w", n.Name(), err))
+		}
+	}
+	if ch.network != nil {
+		if err := ch.network.Delete(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("delete network %q: %w", ch.network.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// cleanupChain registers best-effort teardown on a fresh context, so it still
+// runs when the scenario ctx is already expired.
+func cleanupChain(t *testing.T, ch *chain) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+		if err := ch.teardown(ctx); err != nil {
+			t.Errorf("teardown: %v", err)
+		}
+	})
+}
+
+// requireCluster skips a suite unless it is pointed at a real cluster. The SDK
+// selects its k8s provider on SEI_NODE_CLUSTER presence; without it there is
+// nothing to provision against.
+func requireCluster(t *testing.T) {
+	t.Helper()
+	if os.Getenv("SEI_NODE_CLUSTER") == "" {
+		t.Skip("integration suite: set SEI_NODE_CLUSTER to run against a cluster")
+	}
+}
+
+// openClient opens the SDK in k8s mode (config resolved from the ambient
+// kubeconfig / in-cluster SA chain).
+func openClient(ctx context.Context, t *testing.T) *sei.Client {
+	t.Helper()
+	c, err := sei.Open(ctx, "k8s")
+	if err != nil {
+		t.Fatalf("open sei SDK (k8s): %v", err)
+	}
+	return c
+}
+
+// env returns the env var or a fallback (for local runs).
+func env(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// mustEnv fails the suite if a required input is missing.
+func mustEnv(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		t.Fatalf("integration suite: required env %s is unset", key)
+	}
+	return v
+}


### PR DESCRIPTION
## WS-I Step 1 (foundation) — Go-native nightly harness as `go test` targets

First increment of the Go-native test harness that replaces the Chaos-Mesh Workflow DAG + seitask Task pods + workflow-vars ConfigMap. **Draft** — lands the architecture + provisioning spine; the seiload drive + S3 report is the next increment (marked TODO + `t.Skip`).

### What's here
- `test/integration/harness_test.go` — shared machinery: `spec`/`chain` (local Go state, replacing workflow-vars), `provision` (SDK in-process: CreateNetwork 4 validators + N RPC SeiNodes, each waited Running→caught-up→EVM-serving), `teardown` via `t.Cleanup`, `sei.io/harness-run` label const, env gate.
- `test/integration/benchmark_test.go` — `TestBenchmark` (load suite).

### Architecture decisions (WS-I LLD)
- **D3** Go orchestrator, SDK in-process; seiload + chaos are decoupled units the suite *applies*, not constructs.
- **D4** plain `go test` targets in `_test.go` (not a CLI binary) — Go's `_test.go` rule guarantees **zero test code in any production binary**; `//go:build integration` hides it from default CI. Verified: `go build ./...` clean, no integration code in `cmd/` deps.
- **D5** in-cluster CronJob vehicle; one `go test -c` image, one CronJob per target (`-test.run TestX`). Targets: TestBenchmark / TestChaosSuite / TestChainUpgrade / TestRelease.
- **Stages wholesale seitask-runner removal:** imports only `sdk/sei` (+ k8s provider).

### Verification
`gofmt` clean · `go build ./...` clean · `go vet -tags integration ./test/integration` clean · `go test -c -tags integration` → binary exposes `TestBenchmark` · skips cleanly without `SEI_NODE_CLUSTER`.

### Next increment
seiload as a decoupled unit (apply its own manifest w/ `evmEndpoints()`, stamped `harness-run`) → wait → read S3 report → assert TPS. Then mark ready + Coral/Bugbot/CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)