### PR TITLE
fix(sdk,test): cascade-delete ephemeral chain validators (Bugbot high-sev follow-up to #428)

### DIFF
--- a/sdk/sei/provider/k8s/render.go
+++ b/sdk/sei/provider/k8s/render.go
@@ -37,6 +37,9 @@ func renderNetwork(spec sei.NetworkSpec, namespace string) *seiv1alpha1.SeiNetwo
 		Spec: seiv1alpha1.SeiNetworkSpec{
 			Image:    spec.Image,
 			Replicas: int32(spec.Validators),
+			// "" leaves the CRD default (Retain); a caller sets Delete so an
+			// ephemeral chain's validators cascade-delete instead of orphaning.
+			DeletionPolicy: seiv1alpha1.DeletionPolicy(spec.DeletionPolicy),
 			Genesis: seiv1alpha1.GenesisCeremonyConfig{
 				ChainID: spec.Name, // chain ID defaults to the network name
 			},

--- a/sdk/sei/provider/k8s/render_test.go
+++ b/sdk/sei/provider/k8s/render_test.go
@@ -9,10 +9,11 @@ import (
 func TestRenderNetwork_ChainIDDefaultsToName(t *testing.T) {
 	spec := sei.NetworkSpec{
 		Name: testNet, Image: testImage, Validators: 4,
-		Genesis:  map[string]string{"staking.params.unbonding_time": "60s"},
-		Config:   map[string]string{"app.pruning": "nothing"},
-		Accounts: []sei.GenesisAccount{{Address: "sei1abc", Balance: "100usei"}},
-		Labels:   map[string]string{testRunLabel: testRunID},
+		Genesis:        map[string]string{"staking.params.unbonding_time": "60s"},
+		Config:         map[string]string{"app.pruning": "nothing"},
+		Accounts:       []sei.GenesisAccount{{Address: "sei1abc", Balance: "100usei"}},
+		Labels:         map[string]string{testRunLabel: testRunID},
+		DeletionPolicy: sei.DeletionDelete,
 	}
 	net := renderNetwork(spec, testNS)
 
@@ -34,6 +35,11 @@ func TestRenderNetwork_ChainIDDefaultsToName(t *testing.T) {
 	}
 	if len(net.Spec.Genesis.Accounts) != 1 || net.Spec.Genesis.Accounts[0].Address != "sei1abc" {
 		t.Errorf("genesis accounts = %+v", net.Spec.Genesis.Accounts)
+	}
+	// DeletionPolicy threads through so an ephemeral chain cascades to its
+	// validators on teardown instead of orphaning them (the CRD default Retain).
+	if got := string(net.Spec.DeletionPolicy); got != sei.DeletionDelete {
+		t.Errorf("deletionPolicy = %q, want %q", got, sei.DeletionDelete)
 	}
 	// The network carries caller labels (e.g. a GC/run-id selector) but NOT the
 	// canonical sei.io/seinetwork (nodes peer by its name, not a label on it).

--- a/sdk/sei/spec.go
+++ b/sdk/sei/spec.go
@@ -25,11 +25,8 @@ type NetworkSpec struct {
 	Config   map[string]string // -> spec.configOverrides (config.toml/app.toml)
 	Labels   map[string]string // extra labels on the SeiNetwork object (e.g. a caller GC/run-id selector); the network object carries no labels otherwise
 
-	// DeletionPolicy controls whether the SeiNetwork's child validators are
-	// deleted with it. "" leaves the CRD default (Retain — orphans children,
-	// stripping their ownerRef so they keep running); set DeletionDelete for an
-	// ephemeral chain so Delete cascades to the validators (+ their PVCs) instead
-	// of leaking them. -> spec.deletionPolicy.
+	// DeletionPolicy controls child-validator deletion; "" leaves the CRD Retain
+	// default. Set DeletionDelete for ephemeral chains. -> spec.deletionPolicy.
 	DeletionPolicy string
 }
 

--- a/sdk/sei/spec.go
+++ b/sdk/sei/spec.go
@@ -1,5 +1,15 @@
 package sei
 
+// DeletionPolicy values for NetworkSpec.DeletionPolicy. They mirror the
+// SeiNetwork CRD enum (kept as plain strings so this core stays stdlib-only).
+const (
+	// DeletionDelete cascades a SeiNetwork delete to its child validators
+	// (and their PVCs) — the right choice for an ephemeral chain.
+	DeletionDelete = "Delete"
+	// DeletionRetain orphans children on delete (the CRD default).
+	DeletionRetain = "Retain"
+)
+
 // NetworkSpec is the typed input to CreateNetwork. ChainID is not a field: it
 // defaults to Name (the genesis chain ID == the network name). Genesis and
 // Config are the two override escape hatches so the typed surface need not chase
@@ -14,6 +24,13 @@ type NetworkSpec struct {
 	Genesis  map[string]string // -> spec.genesis.overrides (TOML-path keys)
 	Config   map[string]string // -> spec.configOverrides (config.toml/app.toml)
 	Labels   map[string]string // extra labels on the SeiNetwork object (e.g. a caller GC/run-id selector); the network object carries no labels otherwise
+
+	// DeletionPolicy controls whether the SeiNetwork's child validators are
+	// deleted with it. "" leaves the CRD default (Retain — orphans children,
+	// stripping their ownerRef so they keep running); set DeletionDelete for an
+	// ephemeral chain so Delete cascades to the validators (+ their PVCs) instead
+	// of leaking them. -> spec.deletionPolicy.
+	DeletionPolicy string
 }
 
 // GenesisAccount is a non-validator genesis account to fund.

--- a/test/integration/benchmark_test.go
+++ b/test/integration/benchmark_test.go
@@ -10,9 +10,8 @@ import (
 	"time"
 )
 
-// TestBenchmark is the load suite: provision a validator chain + RPC fleet,
-// drive seiload against the fleet for the configured duration, and upload the
-// report. Replaces the load-test Chaos-Mesh Workflow.
+// TestBenchmark provisions a validator chain + RPC fleet for the load suite.
+// seiload drive + report upload are not yet wired (see TODO below).
 //
 // Inputs (env, mirroring k8s_nightly.yml):
 //
@@ -60,11 +59,10 @@ func TestBenchmark(t *testing.T) {
 	t.Logf("provisioned %s: %d validators + %d RPC followers; EVM endpoints=%v",
 		s.chainID, s.validators, len(ch.rpcNodes), ch.evmEndpoints())
 
-	// TODO(WS-I step 1, next increment): drive seiload as a DECOUPLED unit
-	// (decision D3) — apply seiload's own manifest parameterized with
-	// ch.evmEndpoints(), stamped sei.io/harness-run=s.runID; wait for
-	// completion; read its report from the agreed S3 path; assert TPS/receipts.
-	// seiload's Job spec is NOT constructed here.
+	// TODO: drive seiload as a decoupled unit — apply its own manifest
+	// parameterized with ch.evmEndpoints(), stamped sei.io/harness-run; wait,
+	// read the report from S3, assert TPS/receipts. seiload's Job spec is not
+	// constructed here.
 	t.Skipf("provisioned %s (%d validators + %d followers); seiload drive + report not yet wired — tearing down",
 		s.chainID, s.validators, len(ch.rpcNodes))
 }

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -1,22 +1,17 @@
 //go:build integration
 
-// Package integration holds the Sei nightly integration-test suites as plain
-// `go test` targets — TestBenchmark, TestChaosSuite, TestChainUpgrade,
-// TestRelease — selected with `-run`. It replaces the Chaos-Mesh Workflow DAG +
-// seitask Task pods + workflow-vars ConfigMap (WS-I LLD): state that the
-// ConfigMap passed across pods now lives in local Go values (chain), and
-// orchestration is statement order in one process.
+// Package integration holds the Sei nightly integration suites as plain `go test`
+// targets (TestBenchmark, TestChaosSuite, TestChainUpgrade, TestRelease), selected
+// with -run. Orchestration is statement order in one process; cross-step state is
+// local Go values, not external config.
 //
-// Isolation (decisions D2/D4/D5): everything here lives in *_test.go files, so
-// Go itself guarantees it never links into a production binary (controller /
-// seid / seitask). The //go:build integration tag additionally excludes it from
-// the default `go test ./...`; the nightly compiles it once with
-// `go test -c -tags integration` and ships the standalone binary in its own
-// image, run by one in-cluster CronJob per target (`-test.run TestX`).
+// Everything lives in *_test.go behind //go:build integration, so it never links
+// into a production binary and is excluded from the default `go test ./...`. The
+// nightly compiles it once (go test -c -tags integration) and runs each target as
+// an in-cluster CronJob (-test.run TestX).
 //
-// The suite depends ONLY on sdk/sei (+ the k8s provider blank import) — never
-// internal/seitask or internal/taskruntime — so the seitask runner can be
-// removed wholesale once the four targets cover the nightly.
+// Depends only on sdk/sei (+ the k8s provider blank import); never internal/seitask
+// or internal/taskruntime.
 package integration
 
 import (
@@ -35,13 +30,10 @@ import (
 	_ "github.com/sei-protocol/sei-k8s-controller/sdk/sei/provider/k8s"
 )
 
-// runLabelKey identifies a run's resources for the nightly label-GC sweep — the
-// SOLE abnormal-exit reaper under the shared-namespace model (D2), since
-// t.Cleanup does NOT run on SIGKILL or a -test.timeout breach. provision stamps
-// it (via the SDK NetworkSpec/NodeSpec Labels) on the network + every node; the
-// seiload Job and fault CRs a suite applies directly must stamp it too (load /
-// chaos increments). The sweep must be proven against an orphaned run before the
-// Workflow ownerRef cascade is removed (WS-I step 2).
+// runLabelKey marks a run's resources for the nightly label-GC sweep — the only
+// reaper on abnormal exit (shared namespace), since t.Cleanup is skipped on
+// SIGKILL or a -test.timeout breach. provision stamps it on the network + every
+// node; a suite's directly-applied seiload Job and fault CRs must stamp it too.
 const runLabelKey = "sei.io/harness-run"
 
 // spec is the typed input shared by the suites — the local-Go-state replacement
@@ -57,8 +49,7 @@ type spec struct {
 }
 
 // chain is the live provisioned topology a suite runs load against and asserts
-// on. Held entirely in local Go state — what the workflow-vars ConfigMap used
-// to pass between pods.
+// on, held in local Go state.
 type chain struct {
 	network  *sei.Network
 	rpcNodes []*sei.Node
@@ -83,7 +74,7 @@ func rpcNodeName(chainID string, ordinal int) string {
 }
 
 // provision stands up the genesis SeiNetwork + N standalone RPC SeiNodes via the
-// SDK in-process (decision D3 — not a seictl subprocess), waiting each follower
+// SDK in-process (not a seictl subprocess), waiting each follower
 // to Running + caught-up + EVM-serving before returning. The returned chain is
 // non-nil even on error so the caller can still tear down whatever was created
 // (pair every provision with a t.Cleanup(teardown)).
@@ -104,7 +95,7 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 		// Ephemeral chain: cascade-delete the controller-created validators (+
 		// their PVCs) on teardown. The CRD default Retain would orphan them —
 		// they never carry sei.io/harness-run, so neither t.Cleanup nor the
-		// label-GC sweep would reap them (Bugbot high-sev).
+		// label-GC sweep would reap them.
 		DeletionPolicy: sei.DeletionDelete,
 	})
 	if err != nil {

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -101,6 +101,11 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 		Image:      s.seidImage,
 		Validators: s.validators,
 		Labels:     runLabels,
+		// Ephemeral chain: cascade-delete the controller-created validators (+
+		// their PVCs) on teardown. The CRD default Retain would orphan them —
+		// they never carry sei.io/harness-run, so neither t.Cleanup nor the
+		// label-GC sweep would reap them (Bugbot high-sev).
+		DeletionPolicy: sei.DeletionDelete,
 	})
 	if err != nil {
 		return ch, fmt.Errorf("create network %q: %w", s.chainID, err)


### PR DESCRIPTION
## Follow-up to #428 — Bugbot high-severity finding

Bugbot flagged on #428 (verified valid): the integration harness's `teardown` **orphans validator SeiNodes**.

### Root cause (confirmed in-tree)
- `provision` creates the genesis `SeiNetwork`; `teardown` deletes it + the RPC `SeiNode`s.
- The CRD defaults `DeletionPolicy=Retain` (`+kubebuilder:default=Retain`, `seinetwork_types.go:98`), and under Retain the controller **strips the validator children's ownerRef** (`removeOwnerRef`, `internal/controller/seinetwork/nodes.go:301`) so they survive network deletion.
- The validators are **controller-created** → they never carry `sei.io/harness-run` → neither `t.Cleanup` nor the label-GC sweep reaps them. **Leaks 4 validators + PVCs every run** in the shared `nightly` namespace.

### Fix
- Add `DeletionPolicy` to the SDK `NetworkSpec` (plain `string` + `DeletionDelete`/`DeletionRetain` constants — core stays stdlib-only; threaded into `renderNetwork`). Same additive one-way-door pattern as `Labels` (#428).
- The harness sets `DeletionDelete` — an ephemeral chain cascade-deletes its validators (+ PVCs) on teardown. Correct for a throwaway test chain (distinct from production fleet nodes, which stay Retain).
- Locked by a `render_test` assertion that `DeletionPolicy` threads through.

### Verification
`go build ./...` clean · `go test ./sdk/...` pass (incl. new assertion) · `go test -c -tags integration` compiles · golangci-lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)