### PR TITLE
fix(test): provision chains with working seid config (smoke-proven)

### DIFF
--- a/test/integration/benchmark_test.go
+++ b/test/integration/benchmark_test.go
@@ -46,6 +46,7 @@ func TestBenchmark(t *testing.T) {
 		seiloadProfile: envOr("SEILOAD_PROFILE", "nightly_evm_transfer"),
 		seiloadCommit:  envOr("SEILOAD_COMMIT_ID", ""),
 		durationMin:    envInt(t, "DURATION_MINUTES", 10),
+		storageConfig:  memiavlStorageConfig,
 		// EVM tuning the followers need to absorb the load (matches the load
 		// scenario's rpc overrides).
 		rpcConfig: map[string]string{

--- a/test/integration/benchmark_test.go
+++ b/test/integration/benchmark_test.go
@@ -46,6 +46,13 @@ func TestBenchmark(t *testing.T) {
 		seiloadProfile: envOr("SEILOAD_PROFILE", "nightly_evm_transfer"),
 		seiloadCommit:  envOr("SEILOAD_COMMIT_ID", ""),
 		durationMin:    envInt(t, "DURATION_MINUTES", 10),
+		// EVM tuning the followers need to absorb the load (matches the load
+		// scenario's rpc overrides).
+		rpcConfig: map[string]string{
+			"evm.worker_pool_size":  "32",
+			"evm.worker_queue_size": "4000",
+			"evm.max_tx_pool_txs":   "10000",
+		},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -40,15 +40,17 @@ import (
 // DeletionPolicy cascade are the cleanup path.
 const runLabelKey = "sei.io/harness-run"
 
-// baseStorageConfig is the storage write-mode every harness-provisioned seid
-// needs to start: the controller default (cosmos_only) is rejected by the
-// nightly image. Mirrors the scenario templates' configOverrides.
-var baseStorageConfig = map[string]string{
+// memiavlStorageConfig is the storage write-mode the load + release suites run
+// with — the controller default (cosmos_only) is rejected by the nightly image.
+// NOT universal: the major-upgrade suite deliberately omits it (the storage /
+// migration path is what that suite tests), so it's applied per-suite via
+// spec.storageConfig, never globally.
+var memiavlStorageConfig = map[string]string{
 	"storage.state_commit.write_mode": "memiavl_only",
 	"storage.state_store.write_mode":  "memiavl_only",
 }
 
-// mergeConfig overlays extra onto a copy of base (extra wins); nil-safe.
+// mergeConfig returns base overlaid with extra; extra wins on key collision.
 func mergeConfig(base, extra map[string]string) map[string]string {
 	out := make(map[string]string, len(base)+len(extra))
 	maps.Copy(out, base)
@@ -59,14 +61,15 @@ func mergeConfig(base, extra map[string]string) map[string]string {
 // spec is the typed input shared by the suites — the local-Go-state replacement
 // for the per-run workflow-vars contract.
 type spec struct {
-	chainID    string            // SeiNetwork name == genesis chain id; also peer-selector value + run discriminator
-	runID      string            // unique per run; the sei.io/harness-run label value
-	namespace  string            // shared nightly namespace; "" => the SDK client's resolved default
-	seidImage  string            // seid container image under test
-	validators int               // genesis validator count (>= 1)
-	rpcNodes   int               // standalone RPC followers; named <chain>-rpc-0..N-1
-	timeout    time.Duration     // overall scenario deadline (drives ctx, kept < CronJob activeDeadlineSeconds)
-	rpcConfig  map[string]string // extra per-RPC-node config overlaid on the storage baseline (e.g. EVM tuning)
+	chainID       string            // SeiNetwork name == genesis chain id; also peer-selector value + run discriminator
+	runID         string            // unique per run; the sei.io/harness-run label value
+	namespace     string            // shared nightly namespace; "" => the SDK client's resolved default
+	seidImage     string            // seid container image under test
+	validators    int               // genesis validator count (>= 1)
+	rpcNodes      int               // standalone RPC followers; named <chain>-rpc-0..N-1
+	timeout       time.Duration     // overall scenario deadline (drives ctx, kept < CronJob activeDeadlineSeconds)
+	storageConfig map[string]string // per-suite seid storage config (load/release set memiavl; upgrade leaves the default)
+	rpcConfig     map[string]string // extra per-RPC-node config overlaid on storageConfig (e.g. EVM tuning)
 
 	// seiload inputs (load suite)
 	seiloadImage   string // sei-load benchmark image
@@ -119,7 +122,7 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 		Image:      s.seidImage,
 		Validators: s.validators,
 		Labels:     runLabels,
-		Config:     mergeConfig(baseStorageConfig, nil),
+		Config:     maps.Clone(s.storageConfig),
 		// Ephemeral chain: cascade-delete the controller-created validators (+
 		// their PVCs) on teardown. The CRD default Retain would orphan them —
 		// they never carry sei.io/harness-run, so neither t.Cleanup nor the
@@ -144,7 +147,7 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 			Namespace: s.namespace,
 			Image:     s.seidImage,
 			Labels:    runLabels,
-			Config:    mergeConfig(baseStorageConfig, s.rpcConfig),
+			Config:    mergeConfig(s.storageConfig, s.rpcConfig),
 		})
 		if err != nil {
 			return ch, fmt.Errorf("create rpc node %q: %w", name, err)

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"strconv"
@@ -39,16 +40,33 @@ import (
 // DeletionPolicy cascade are the cleanup path.
 const runLabelKey = "sei.io/harness-run"
 
+// baseStorageConfig is the storage write-mode every harness-provisioned seid
+// needs to start: the controller default (cosmos_only) is rejected by the
+// nightly image. Mirrors the scenario templates' configOverrides.
+var baseStorageConfig = map[string]string{
+	"storage.state_commit.write_mode": "memiavl_only",
+	"storage.state_store.write_mode":  "memiavl_only",
+}
+
+// mergeConfig overlays extra onto a copy of base (extra wins); nil-safe.
+func mergeConfig(base, extra map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(extra))
+	maps.Copy(out, base)
+	maps.Copy(out, extra)
+	return out
+}
+
 // spec is the typed input shared by the suites — the local-Go-state replacement
 // for the per-run workflow-vars contract.
 type spec struct {
-	chainID    string        // SeiNetwork name == genesis chain id; also the peer-selector value and per-run discriminator
-	runID      string        // unique per run; the sei.io/harness-run label value
-	namespace  string        // shared nightly namespace; "" => the SDK client's resolved default
-	seidImage  string        // seid container image under test
-	validators int           // genesis validator count (>= 1)
-	rpcNodes   int           // standalone RPC followers; named <chain>-rpc-0..N-1
-	timeout    time.Duration // overall scenario deadline (drives ctx, kept < CronJob activeDeadlineSeconds)
+	chainID    string            // SeiNetwork name == genesis chain id; also peer-selector value + run discriminator
+	runID      string            // unique per run; the sei.io/harness-run label value
+	namespace  string            // shared nightly namespace; "" => the SDK client's resolved default
+	seidImage  string            // seid container image under test
+	validators int               // genesis validator count (>= 1)
+	rpcNodes   int               // standalone RPC followers; named <chain>-rpc-0..N-1
+	timeout    time.Duration     // overall scenario deadline (drives ctx, kept < CronJob activeDeadlineSeconds)
+	rpcConfig  map[string]string // extra per-RPC-node config overlaid on the storage baseline (e.g. EVM tuning)
 
 	// seiload inputs (load suite)
 	seiloadImage   string // sei-load benchmark image
@@ -101,6 +119,7 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 		Image:      s.seidImage,
 		Validators: s.validators,
 		Labels:     runLabels,
+		Config:     mergeConfig(baseStorageConfig, nil),
 		// Ephemeral chain: cascade-delete the controller-created validators (+
 		// their PVCs) on teardown. The CRD default Retain would orphan them —
 		// they never carry sei.io/harness-run, so neither t.Cleanup nor the
@@ -125,6 +144,7 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 			Namespace: s.namespace,
 			Image:     s.seidImage,
 			Labels:    runLabels,
+			Config:    mergeConfig(baseStorageConfig, s.rpcConfig),
 		})
 		if err != nil {
 			return ch, fmt.Errorf("create rpc node %q: %w", name, err)


### PR DESCRIPTION
## Follow-up to #430 — make TestBenchmark actually bring up a chain

In-cluster smoke of TestBenchmark on harbor (run via an in-cluster pod with a harness SA) caught two real gaps the SDK's *generic* provisioning left vs the old scenario templates:

1. **Validators CrashLooped** — `seid` exits with `invalid state-commit.sc-write-mode "cosmos_only"`. Every scenario template set `storage.state_commit/state_store.write_mode=memiavl_only`; the SDK's `CreateNetwork` omitted it. `provision` now applies that **storage baseline** to the network + every node.
2. **Load followers** need the EVM tuning the rpc template carried (`evm.worker_pool_size/worker_queue_size/max_tx_pool_txs`); `TestBenchmark` passes it via `spec.rpcConfig`, merged over the baseline.

### Proof (live, harbor)
```
network ... ready
rpc-0: running -> caught up -> EVM serving
rpc-1: running -> caught up -> EVM serving
--- PASS: TestBenchmark (353.16s)   # provision -> 2m seiload -> all followers caught-up post-load -> clean teardown
```
Resources fully reaped after (DeletionPolicy cascade + t.Cleanup).

### Run-model RBAC note (for the cutover deliverable)
The SDK provisions via **server-side apply**, so the harness ServiceAccount Role needs `patch`/`update` on `seinetworks`/`seinodes`, not just `create`. Folds into the harness-Role manifest.

### Verification
`go build ./...` clean · golangci-lint 0 issues · `go test -c -tags integration` compiles · **passes in-cluster end-to-end**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)