### PR TITLE
feat(test): TestChaosSuite — chaos faults via the harness (network-partition)

### DIFF
--- a/sdk/sei/readiness.go
+++ b/sdk/sei/readiness.go
@@ -65,6 +65,44 @@ func WaitCaughtUp(ctx context.Context, hc *http.Client, tmRPC string) error {
 	})
 }
 
+// latestHeight reads tmRPC's committed block height from /status. ok=false on an
+// unreachable endpoint or unparseable body (keep polling).
+func latestHeight(ctx context.Context, hc *http.Client, tmRPC string) (int64, bool) {
+	body, ok := getJSON(ctx, hc, http.MethodGet, tmRPC+"/status", "")
+	if !ok {
+		return 0, false
+	}
+	var s tendermintStatus
+	if json.Unmarshal(body, &s) != nil {
+		return 0, false
+	}
+	h, err := strconv.ParseInt(s.sync().LatestBlockHeight, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return h, true
+}
+
+// WaitHeightAdvances blocks until tmRPC's committed height has risen by at least
+// delta from the height observed on the first successful read — proof the chain
+// is producing blocks, not merely reachable. Unlike WaitCaughtUp this catches a
+// stalled node, which still reports catching_up == false at a frozen height.
+// hc may be nil. The caller's ctx bounds the wait (IsTimeout on a deadline).
+func WaitHeightAdvances(ctx context.Context, hc *http.Client, tmRPC string, delta int64) error {
+	target := int64(-1) // set to start+delta on the first successful read
+	return pollUntil(ctx, fmt.Sprintf("%s height +%d", tmRPC, delta), func(ctx context.Context) bool {
+		h, ok := latestHeight(ctx, hc, tmRPC)
+		if !ok {
+			return false
+		}
+		if target < 0 {
+			target = h + delta
+			return false
+		}
+		return h >= target
+	})
+}
+
 // evmResponse models a JSON-RPC envelope with a string result.
 type evmResponse struct {
 	Result string `json:"result"`

--- a/test/integration/chaos_test.go
+++ b/test/integration/chaos_test.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,6 +41,14 @@ type faultParams struct {
 type fault struct {
 	resource string // GVR resource, e.g. "networkchaos"
 	obj      *unstructured.Unstructured
+}
+
+// hasDuration reports whether the fault self-expires (carries spec.duration). A
+// duration-less fault would block gateRecovered until the scenario deadline, so
+// every ported fault must currently carry one.
+func (f fault) hasDuration() bool {
+	_, found, _ := unstructured.NestedString(f.obj.Object, "spec", "duration")
+	return found
 }
 
 // dynClient builds a dynamic client from the ambient config — the harness
@@ -93,6 +102,16 @@ func applyFault(ctx context.Context, t *testing.T, dc dynamic.Interface, ns stri
 func gateInjected(ctx context.Context, t *testing.T, dc dynamic.Interface, ns string, f fault) {
 	t.Helper()
 	waitFaultCondition(ctx, t, dc, ns, f, "AllInjected")
+	// AllInjected is vacuously true for an empty target set, so a selector that
+	// matched 0 pods would pass against an undisturbed chain. Assert chaos-mesh
+	// actually injected at least one target.
+	u, err := dc.Resource(chaosGVR(f.resource)).Namespace(ns).Get(ctx, f.obj.GetName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("read injected count for %s/%s: %v", f.resource, f.obj.GetName(), err)
+	}
+	if n, _, _ := unstructured.NestedInt64(u.Object, "status", "experiment", "injectedCount"); n < 1 {
+		t.Fatalf("fault %s/%s injected 0 targets — selector matched nothing (false-green guard)", f.resource, f.obj.GetName())
+	}
 }
 
 // gateRecovered blocks until AllRecovered=True, catching chaos-mesh finalizers
@@ -107,14 +126,19 @@ func waitFaultCondition(ctx context.Context, t *testing.T, dc dynamic.Interface,
 	ri := dc.Resource(chaosGVR(f.resource)).Namespace(ns)
 	tick := time.NewTicker(5 * time.Second)
 	defer tick.Stop()
+	var lastErr error // a real (non-NotFound) Get error, surfaced on timeout
 	for {
 		u, err := ri.Get(ctx, f.obj.GetName(), metav1.GetOptions{})
-		if err == nil && faultConditionTrue(u, condType) {
+		switch {
+		case err == nil && faultConditionTrue(u, condType):
 			return
+		case err != nil && !apierrors.IsNotFound(err): // NotFound is transient post-create cache lag
+			lastErr = err
 		}
 		select {
 		case <-ctx.Done():
-			t.Fatalf("fault %s/%s: %s not True before deadline: %v", f.resource, f.obj.GetName(), condType, ctx.Err())
+			t.Fatalf("fault %s/%s: %s not True before deadline: %v (last get: %v)",
+				f.resource, f.obj.GetName(), condType, ctx.Err(), lastErr)
 		case <-tick.C:
 		}
 	}

--- a/test/integration/chaos_test.go
+++ b/test/integration/chaos_test.go
@@ -109,9 +109,27 @@ func gateInjected(ctx context.Context, t *testing.T, dc dynamic.Interface, ns st
 	if err != nil {
 		t.Fatalf("read injected count for %s/%s: %v", f.resource, f.obj.GetName(), err)
 	}
-	if n, _, _ := unstructured.NestedInt64(u.Object, "status", "experiment", "injectedCount"); n < 1 {
+	if n := faultInjectedTargets(u); n < 1 {
 		t.Fatalf("fault %s/%s injected 0 targets — selector matched nothing (false-green guard)", f.resource, f.obj.GetName())
 	}
+}
+
+// faultInjectedTargets counts the targets chaos-mesh actually injected. The
+// count lives per-target in status.experiment.containerRecords[].injectedCount
+// (there is no top-level injectedCount), so a 0-match selector yields no records.
+func faultInjectedTargets(u *unstructured.Unstructured) int {
+	recs, _, _ := unstructured.NestedSlice(u.Object, "status", "experiment", "containerRecords")
+	n := 0
+	for _, r := range recs {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if ic, _, _ := unstructured.NestedInt64(m, "injectedCount"); ic > 0 {
+			n++
+		}
+	}
+	return n
 }
 
 // gateRecovered blocks until AllRecovered=True, catching chaos-mesh finalizers

--- a/test/integration/chaos_test.go
+++ b/test/integration/chaos_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"testing"
+	"text/template"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/yaml"
+)
+
+//go:embed faults/network_partition.yaml.tmpl
+var networkPartitionTmpl string
+
+// chaosGVR is the GroupVersionResource for a Chaos-Mesh fault kind. Faults are
+// applied unstructured so the chaos-mesh API stays out of the module's deps.
+func chaosGVR(resource string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: resource}
+}
+
+// faultParams are the per-run values templated into a fault CR.
+type faultParams struct {
+	ChainID   string
+	RunID     string
+	Namespace string
+	Duration  string
+}
+
+// fault is a rendered Chaos-Mesh fault CR plus the resource name its dynamic
+// client needs.
+type fault struct {
+	resource string // GVR resource, e.g. "networkchaos"
+	obj      *unstructured.Unstructured
+}
+
+// dynClient builds a dynamic client from the ambient config — the harness
+// applies fault CRs unstructured through it.
+func dynClient(t *testing.T) dynamic.Interface {
+	t.Helper()
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		t.Fatalf("load kubeconfig: %v", err)
+	}
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("build dynamic client: %v", err)
+	}
+	return dc
+}
+
+// renderFault templates a fault CR and decodes it to an unstructured object.
+func renderFault(t *testing.T, resource, tmpl string, p faultParams) fault {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := template.Must(template.New("fault").Parse(tmpl)).Execute(&buf, p); err != nil {
+		t.Fatalf("render fault: %v", err)
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("unmarshal fault: %v", err)
+	}
+	return fault{resource: resource, obj: &unstructured.Unstructured{Object: m}}
+}
+
+// applyFault creates the fault CR and registers best-effort deletion. Deletion
+// is also what stops a duration-less fault; duration-bearing faults self-expire.
+func applyFault(ctx context.Context, t *testing.T, dc dynamic.Interface, ns string, f fault) {
+	t.Helper()
+	ri := dc.Resource(chaosGVR(f.resource)).Namespace(ns)
+	if _, err := ri.Create(ctx, f.obj, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("apply %s/%s: %v", f.resource, f.obj.GetName(), err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		_ = ri.Delete(ctx, f.obj.GetName(), metav1.DeleteOptions{})
+	})
+}
+
+// gateInjected blocks until the fault reports status.conditions[AllInjected]=True
+// — the anti-false-green guard. Creating a fault CR is async (chaos-mesh must
+// program tc/tproxy/cgroups); asserting before it lands tests an undisturbed
+// chain.
+func gateInjected(ctx context.Context, t *testing.T, dc dynamic.Interface, ns string, f fault) {
+	t.Helper()
+	waitFaultCondition(ctx, t, dc, ns, f, "AllInjected")
+}
+
+// gateRecovered blocks until AllRecovered=True, catching chaos-mesh finalizers
+// stuck on leftover tc/tproxy rules before teardown.
+func gateRecovered(ctx context.Context, t *testing.T, dc dynamic.Interface, ns string, f fault) {
+	t.Helper()
+	waitFaultCondition(ctx, t, dc, ns, f, "AllRecovered")
+}
+
+func waitFaultCondition(ctx context.Context, t *testing.T, dc dynamic.Interface, ns string, f fault, condType string) {
+	t.Helper()
+	ri := dc.Resource(chaosGVR(f.resource)).Namespace(ns)
+	tick := time.NewTicker(5 * time.Second)
+	defer tick.Stop()
+	for {
+		u, err := ri.Get(ctx, f.obj.GetName(), metav1.GetOptions{})
+		if err == nil && faultConditionTrue(u, condType) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("fault %s/%s: %s not True before deadline: %v", f.resource, f.obj.GetName(), condType, ctx.Err())
+		case <-tick.C:
+		}
+	}
+}
+
+// faultConditionTrue reports whether the fault CR carries condType=True.
+func faultConditionTrue(u *unstructured.Unstructured, condType string) bool {
+	conds, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if !found || err != nil {
+		return false
+	}
+	for _, c := range conds {
+		m, ok := c.(map[string]any)
+		if ok && m["type"] == condType && m["status"] == "True" {
+			return true
+		}
+	}
+	return false
+}

--- a/test/integration/chaossuite_test.go
+++ b/test/integration/chaossuite_test.go
@@ -41,10 +41,20 @@ func TestChaosSuite(t *testing.T) {
 	seid := mustEnv(t, "SEID_IMAGE")
 	ns := envOr("SEI_NAMESPACE", "")
 	duration := envOr("CHAOS_DURATION", "3m")
+	faultDur, err := time.ParseDuration(duration)
+	if err != nil {
+		t.Fatalf("CHAOS_DURATION %q: %v", duration, err)
+	}
 
 	for _, sc := range chaosScenarios {
 		t.Run(sc.name, func(t *testing.T) {
 			id := base + "-" + sc.name
+			// The validator-0 selector value sei.io/node=<id>-0 is a k8s label
+			// value (capped at 63 chars); fail loud rather than on an opaque
+			// admission rejection at fault-apply time.
+			if v := id + "-0"; len(v) > 63 {
+				t.Fatalf("chain id %q yields label value %q > 63 chars", id, v)
+			}
 			s := spec{
 				chainID:       id,
 				runID:         id,
@@ -77,16 +87,26 @@ func TestChaosSuite(t *testing.T) {
 				Namespace: faultNS,
 				Duration:  duration,
 			})
+			if !f.hasDuration() {
+				t.Fatalf("fault %s has no spec.duration — gateRecovered would hang until the deadline", sc.name)
+			}
 			applyFault(ctx, t, dc, faultNS, f)
 			gateInjected(ctx, t, dc, faultNS, f)
 			t.Logf("%s: fault injected", sc.name)
 
 			hc := &http.Client{Timeout: 10 * time.Second}
 			follower := ch.rpcNodes[0]
-			// Live under fault: with f=1 the chain keeps 2/3 quorum, so the
-			// unfaulted follower must stay caught up while the fault is active.
-			if err := sei.WaitCaughtUp(ctx, hc, follower.TendermintRPC()); err != nil {
-				t.Errorf("under-fault %s not caught up: %v", follower.Name(), err)
+			// Live under fault: the chain must keep producing blocks while the
+			// fault is active (f=1 holds 2/3 quorum). Assert the follower's height
+			// advances within a window inside the fault duration, so the progress
+			// is observed while the fault is programmed — not after it expires.
+			// catching_up==false alone is insufficient: a stalled node reports it
+			// at a frozen height.
+			underFault, cancelUF := context.WithTimeout(ctx, faultDur*2/3)
+			err = sei.WaitHeightAdvances(underFault, hc, follower.TendermintRPC(), 3)
+			cancelUF()
+			if err != nil {
+				t.Errorf("under-fault %s height did not advance: %v", follower.Name(), err)
 			}
 
 			// The fault self-expires after its duration; gate recovery (catches

--- a/test/integration/chaossuite_test.go
+++ b/test/integration/chaossuite_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/http"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
+)
+
+// chaosScenario is one fault ported from the platform chaos suite: a name, the
+// fault CR's GVR resource, and its template.
+type chaosScenario struct {
+	name     string
+	resource string
+	tmpl     string
+}
+
+// chaosScenarios is the ported fault set. Growing toward the platform suite's
+// 14; each is added once it passes in-cluster.
+var chaosScenarios = []chaosScenario{
+	{name: "network-partition", resource: "networkchaos", tmpl: networkPartitionTmpl},
+}
+
+// TestChaosSuite runs each fault against its own fresh chain: provision → inject
+// the Chaos-Mesh fault → gate it injected → assert the chain stays live under it
+// (faults are bounded to f=1, so 2/3 quorum holds) → gate recovery → assert the
+// chain reconverged. Each fault is a subtest so one failure doesn't abort the
+// rest (matching the platform suite's continue-on-failure).
+//
+// Inputs (env): SEI_CHAIN_ID (base), SEID_IMAGE [required]; SEI_NAMESPACE,
+// CHAOS_DURATION [optional]. Run with -test.timeout 0 (see TestBenchmark).
+func TestChaosSuite(t *testing.T) {
+	requireCluster(t)
+	base := mustEnv(t, "SEI_CHAIN_ID")
+	seid := mustEnv(t, "SEID_IMAGE")
+	ns := envOr("SEI_NAMESPACE", "")
+	duration := envOr("CHAOS_DURATION", "3m")
+
+	for _, sc := range chaosScenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			id := base + "-" + sc.name
+			s := spec{
+				chainID:       id,
+				runID:         id,
+				namespace:     ns,
+				seidImage:     seid,
+				validators:    4,
+				rpcNodes:      1, // an unfaulted observer of liveness + recovery
+				timeout:       40 * time.Minute,
+				storageConfig: memiavlStorageConfig,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+			defer cancel()
+			ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+			defer stop()
+
+			c := openClient(ctx, t)
+			dc := dynClient(t)
+
+			ch, err := provision(ctx, t, c, s)
+			cleanupChain(t, ch)
+			if err != nil {
+				t.Fatalf("provision: %v", err)
+			}
+			faultNS := ch.network.Namespace()
+
+			f := renderFault(t, sc.resource, sc.tmpl, faultParams{
+				ChainID:   s.chainID,
+				RunID:     s.runID,
+				Namespace: faultNS,
+				Duration:  duration,
+			})
+			applyFault(ctx, t, dc, faultNS, f)
+			gateInjected(ctx, t, dc, faultNS, f)
+			t.Logf("%s: fault injected", sc.name)
+
+			hc := &http.Client{Timeout: 10 * time.Second}
+			follower := ch.rpcNodes[0]
+			// Live under fault: with f=1 the chain keeps 2/3 quorum, so the
+			// unfaulted follower must stay caught up while the fault is active.
+			if err := sei.WaitCaughtUp(ctx, hc, follower.TendermintRPC()); err != nil {
+				t.Errorf("under-fault %s not caught up: %v", follower.Name(), err)
+			}
+
+			// The fault self-expires after its duration; gate recovery (catches
+			// stuck finalizers) then confirm the chain reconverged.
+			gateRecovered(ctx, t, dc, faultNS, f)
+			t.Logf("%s: fault recovered", sc.name)
+			if err := sei.WaitCaughtUp(ctx, hc, follower.TendermintRPC()); err != nil {
+				t.Errorf("post-fault %s not caught up: %v", follower.Name(), err)
+			}
+		})
+	}
+}

--- a/test/integration/faults/network_partition.yaml.tmpl
+++ b/test/integration/faults/network_partition.yaml.tmpl
@@ -1,0 +1,26 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-partition-{{.RunID}}
+  namespace: {{.Namespace}}
+  labels:
+    sei.io/harness-run: "{{.RunID}}"
+spec:
+  # Isolate validator-0 from validators 1-3 (f=1, the chain keeps 2/3 quorum
+  # and must stay live). The RPC follower is unaffected and observes recovery.
+  action: partition
+  mode: all
+  selector:
+    namespaces: ["{{.Namespace}}"]
+    expressionSelectors:
+      - {key: sei.io/nodedeployment, operator: In, values: ["{{.ChainID}}"]}
+      - {key: sei.io/node, operator: In, values: ["{{.ChainID}}-0"]}
+  direction: both
+  target:
+    mode: all
+    selector:
+      namespaces: ["{{.Namespace}}"]
+      expressionSelectors:
+        - {key: sei.io/nodedeployment, operator: In, values: ["{{.ChainID}}"]}
+        - {key: sei.io/node, operator: NotIn, values: ["{{.ChainID}}-0"]}
+  duration: "{{.Duration}}"


### PR DESCRIPTION
## WS-I — the chaos suite, ported into the go-test harness

First chaos increment: ports the platform chaos suite's inject/verify/recover pattern into `TestChaosSuite`, starting with **network-partition**. Builds on the merged load suite (#430/#431).

### Pattern (mirrors the platform verify-injection/verify-cleanup)
- **apply** the Chaos-Mesh fault CR **unstructured** via the dynamic client — keeps the chaos-mesh API out of the module's deps (the k8s lens's de-risk recommendation); fault templates are `//go:embed`'d.
- **gateInjected**: poll `status.conditions[AllInjected]=True` before asserting — the anti-false-green guard (inject is async; a 0-match selector would let the assert run against an undisturbed chain).
- **assert live-under-fault**: the unfaulted RPC follower stays caught up (faults are f=1-bounded → 2/3 quorum holds).
- **gateRecovered**: poll `AllRecovered=True` (catches stuck tc/tproxy finalizers); then assert the chain reconverged.

network-partition isolates validator-0 from validators 1-3. Each fault is a **subtest with its own fresh chain** (continue-on-failure, matching the platform suite). Per-run `sei.io/harness-run` on the fault CR.

### Verification
`go build ./...` clean · golangci-lint 0 issues · `go test -c -tags integration` → TestBenchmark + TestChaosSuite · **in-cluster smoke on harbor in progress**.

### Next
More faults (the other 6 kinds) once each passes in-cluster; container-kill (one-shot, no AllRecovered) + rpc-chaos (2 CRs) + mempool (PromQL, deferred telemetry gate) get per-scenario handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)