### PR TITLE
feat(test): port one-shot kill faults (pod-failure, container-kill)

### DIFF
--- a/sdk/sei/readiness.go
+++ b/sdk/sei/readiness.go
@@ -89,18 +89,27 @@ func latestHeight(ctx context.Context, hc *http.Client, tmRPC string) (int64, bo
 // stalled node, which still reports catching_up == false at a frozen height.
 // hc may be nil. The caller's ctx bounds the wait (IsTimeout on a deadline).
 func WaitHeightAdvances(ctx context.Context, hc *http.Client, tmRPC string, delta int64) error {
-	target := int64(-1) // set to start+delta on the first successful read
-	return pollUntil(ctx, fmt.Sprintf("%s height +%d", tmRPC, delta), func(ctx context.Context) bool {
-		h, ok := latestHeight(ctx, hc, tmRPC)
-		if !ok {
-			return false
+	tick := time.NewTicker(probeInterval)
+	defer tick.Stop()
+	var start, last int64 = -1, -1 // baseline + most-recent height, for the timeout error
+	for {
+		if h, ok := latestHeight(ctx, hc, tmRPC); ok {
+			if start < 0 {
+				start = h
+			}
+			last = h
+			if h >= start+delta {
+				return nil
+			}
 		}
-		if target < 0 {
-			target = h + delta
-			return false
+		select {
+		case <-ctx.Done():
+			// Report start→last so a timeout distinguishes a stalled chain from a
+			// too-short window (start<0 means the endpoint never answered).
+			return fmt.Errorf("%s height did not advance +%d (start=%d last=%d): %w", tmRPC, delta, start, last, ctx.Err())
+		case <-tick.C:
 		}
-		return h >= target
-	})
+	}
 }
 
 // evmResponse models a JSON-RPC envelope with a string result.

--- a/test/integration/chaos_test.go
+++ b/test/integration/chaos_test.go
@@ -125,23 +125,26 @@ func applyFault(ctx context.Context, t *testing.T, dc dynamic.Interface, ns stri
 	})
 }
 
-// gateInjected blocks until the fault reports status.conditions[AllInjected]=True
-// — the anti-false-green guard. Creating a fault CR is async (chaos-mesh must
-// program tc/tproxy/cgroups); asserting before it lands tests an undisturbed
-// chain.
-func gateInjected(ctx context.Context, t *testing.T, dc dynamic.Interface, ns string, f fault) {
+// gateInjected blocks until AllInjected, then asserts the fault hit the right
+// number of targets. AllInjected is set after chaos-mesh writes the per-target
+// records to the (durable) CR status, so a single read here doesn't race the
+// injection. oneShot kills must hit EXACTLY one validator (mode:one): ≥1 alone
+// wouldn't catch a future selector edit that killed 2/4 and halted the chain.
+func gateInjected(ctx context.Context, t *testing.T, dc dynamic.Interface, ns string, f fault, oneShot bool) {
 	t.Helper()
 	waitFaultCondition(ctx, t, dc, ns, f, "AllInjected")
-	// AllInjected is vacuously true for an empty target set, so a selector that
-	// matched 0 pods would pass against an undisturbed chain. Assert chaos-mesh
-	// actually injected at least one target.
 	u, err := dc.Resource(chaosGVR(f.resource)).Namespace(ns).Get(ctx, f.obj.GetName(), metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("read injected count for %s/%s: %v", f.resource, f.obj.GetName(), err)
+		t.Fatalf("read injected targets for %s/%s: %v", f.resource, f.obj.GetName(), err)
 	}
-	if n := faultInjectedTargets(u); n < 1 {
+	n := faultInjectedTargets(u)
+	if n < 1 {
 		t.Fatalf("fault %s/%s injected 0 targets — selector matched nothing (false-green guard)", f.resource, f.obj.GetName())
 	}
+	if oneShot && n != 1 {
+		t.Fatalf("one-shot fault %s/%s injected %d targets, want exactly 1 — quorum risk", f.resource, f.obj.GetName(), n)
+	}
+	t.Logf("%s/%s injected %d target(s)", f.resource, f.obj.GetName(), n)
 }
 
 // faultInjectedTargets counts the targets chaos-mesh actually injected. The

--- a/test/integration/chaos_test.go
+++ b/test/integration/chaos_test.go
@@ -46,6 +46,12 @@ var diskIOLatencyTmpl string
 //go:embed faults/byzantine.yaml.tmpl
 var byzantineTmpl string
 
+//go:embed faults/pod_failure.yaml.tmpl
+var podFailureTmpl string
+
+//go:embed faults/container_kill.yaml.tmpl
+var containerKillTmpl string
+
 // chaosGVR is the GroupVersionResource for a Chaos-Mesh fault kind. Faults are
 // applied unstructured so the chaos-mesh API stays out of the module's deps.
 func chaosGVR(resource string) schema.GroupVersionResource {

--- a/test/integration/chaossuite_test.go
+++ b/test/integration/chaossuite_test.go
@@ -19,14 +19,18 @@ const (
 	rStressChaos  = "stresschaos"
 	rTimeChaos    = "timechaos"
 	rIOChaos      = "iochaos"
+	rPodChaos     = "podchaos"
 )
 
 // chaosScenario is one fault ported from the platform chaos suite: a name, the
-// fault CR's GVR resource, and its template.
+// fault CR's GVR resource, and its template. oneShot marks a kill fault
+// (pod-kill / container-kill) — no spec.duration and no AllRecovered, so it
+// skips the self-expiry tripwire and the recovery gate.
 type chaosScenario struct {
 	name     string
 	resource string
 	tmpl     string
+	oneShot  bool
 }
 
 // chaosScenarios is the ported fault set. Growing toward the platform suite's
@@ -41,6 +45,8 @@ var chaosScenarios = []chaosScenario{
 	{name: "memory-stress", resource: rStressChaos, tmpl: memoryStressTmpl},
 	{name: "disk-io-latency", resource: rIOChaos, tmpl: diskIOLatencyTmpl},
 	{name: "byzantine", resource: rNetworkChaos, tmpl: byzantineTmpl},
+	{name: "pod-failure", resource: rPodChaos, tmpl: podFailureTmpl, oneShot: true},
+	{name: "container-kill", resource: rPodChaos, tmpl: containerKillTmpl, oneShot: true},
 	// dns-chaos deferred: it's a rediscovery fault (live MConnections don't
 	// re-resolve), so the under-fault progress assert can't perturb it — needs a
 	// recovery-focused assert + peer-FQDN-matching patterns.
@@ -106,7 +112,9 @@ func TestChaosSuite(t *testing.T) {
 				Namespace: faultNS,
 				Duration:  duration,
 			})
-			if !f.hasDuration() {
+			// Duration-bearing faults must self-expire (else gateRecovered hangs
+			// to the deadline). One-shot kills carry no duration by design.
+			if !sc.oneShot && !f.hasDuration() {
 				t.Fatalf("fault %s has no spec.duration — gateRecovered would hang until the deadline", sc.name)
 			}
 			applyFault(ctx, t, dc, faultNS, f)
@@ -117,21 +125,27 @@ func TestChaosSuite(t *testing.T) {
 			follower := ch.rpcNodes[0]
 			// Live under fault: the chain must keep producing blocks while the
 			// fault is active (f=1 holds 2/3 quorum). Assert the follower's height
-			// advances within a window inside the fault duration, so the progress
-			// is observed while the fault is programmed — not after it expires.
-			// catching_up==false alone is insufficient: a stalled node reports it
-			// at a frozen height.
-			underFault, cancelUF := context.WithTimeout(ctx, faultDur*2/3)
+			// advances within a window — observed while the fault is in effect, not
+			// after it lifts. catching_up==false alone is insufficient: a stalled
+			// node reports it at a frozen height.
+			window := faultDur * 2 / 3
+			if sc.oneShot {
+				window = 90 * time.Second // no duration; bound the kill + restart observation
+			}
+			underFault, cancelUF := context.WithTimeout(ctx, window)
 			err = sei.WaitHeightAdvances(underFault, hc, follower.TendermintRPC(), 3)
 			cancelUF()
 			if err != nil {
 				t.Errorf("under-fault %s height did not advance: %v", follower.Name(), err)
 			}
 
-			// The fault self-expires after its duration; gate recovery (catches
-			// stuck finalizers) then confirm the chain reconverged.
-			gateRecovered(ctx, t, dc, faultNS, f)
-			t.Logf("%s: fault recovered", sc.name)
+			// Duration-bearing faults self-expire; gate recovery (catches stuck
+			// finalizers). One-shot kills have no AllRecovered — recovery is the
+			// killed pod rejoining, covered by the caught-up check.
+			if !sc.oneShot {
+				gateRecovered(ctx, t, dc, faultNS, f)
+				t.Logf("%s: fault recovered", sc.name)
+			}
 			if err := sei.WaitCaughtUp(ctx, hc, follower.TendermintRPC()); err != nil {
 				t.Errorf("post-fault %s not caught up: %v", follower.Name(), err)
 			}

--- a/test/integration/chaossuite_test.go
+++ b/test/integration/chaossuite_test.go
@@ -10,8 +10,17 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
 )
+
+// oneShotObserveWindow bounds the under-fault liveness check for kill faults,
+// which carry no spec.duration to derive a window from. Sized for +3 blocks on
+// the surviving validators, not for the killed pod's restart.
+const oneShotObserveWindow = 90 * time.Second
 
 // Chaos-Mesh fault GVR resource names (the dynamic client's plural form).
 const (
@@ -98,6 +107,7 @@ func TestChaosSuite(t *testing.T) {
 
 			c := openClient(ctx, t)
 			dc := dynClient(t)
+			cs := clientset(t)
 
 			ch, err := provision(ctx, t, c, s)
 			cleanupChain(t, ch)
@@ -118,7 +128,7 @@ func TestChaosSuite(t *testing.T) {
 				t.Fatalf("fault %s has no spec.duration — gateRecovered would hang until the deadline", sc.name)
 			}
 			applyFault(ctx, t, dc, faultNS, f)
-			gateInjected(ctx, t, dc, faultNS, f)
+			gateInjected(ctx, t, dc, faultNS, f, sc.oneShot)
 			t.Logf("%s: fault injected", sc.name)
 
 			hc := &http.Client{Timeout: 10 * time.Second}
@@ -130,7 +140,7 @@ func TestChaosSuite(t *testing.T) {
 			// node reports it at a frozen height.
 			window := faultDur * 2 / 3
 			if sc.oneShot {
-				window = 90 * time.Second // no duration; bound the kill + restart observation
+				window = oneShotObserveWindow
 			}
 			underFault, cancelUF := context.WithTimeout(ctx, window)
 			err = sei.WaitHeightAdvances(underFault, hc, follower.TendermintRPC(), 3)
@@ -140,15 +150,62 @@ func TestChaosSuite(t *testing.T) {
 			}
 
 			// Duration-bearing faults self-expire; gate recovery (catches stuck
-			// finalizers). One-shot kills have no AllRecovered — recovery is the
-			// killed pod rejoining, covered by the caught-up check.
+			// finalizers). One-shot kills have no AllRecovered.
 			if !sc.oneShot {
 				gateRecovered(ctx, t, dc, faultNS, f)
 				t.Logf("%s: fault recovered", sc.name)
 			}
+			// Recovery: every validator — including the faulted/killed one — must
+			// return to Ready, not just the unfaulted survivors. The follower
+			// caught-up check alone would green a chain whose killed validator
+			// CrashLoops forever (f=1 keeps the survivors live). Mirrors the
+			// platform chaos verify-cleanup.
+			recCtx, cancelRec := context.WithTimeout(ctx, 5*time.Minute)
+			waitValidatorsReady(recCtx, t, cs, faultNS, s.chainID, s.validators)
+			cancelRec()
 			if err := sei.WaitCaughtUp(ctx, hc, follower.TendermintRPC()); err != nil {
 				t.Errorf("post-fault %s not caught up: %v", follower.Name(), err)
 			}
 		})
 	}
+}
+
+// waitValidatorsReady blocks until at least want validator pods
+// (sei.io/nodedeployment=chainID) report Ready — the recovery proof that the
+// faulted/killed validator rejoined. A validator stuck CrashLooping after the
+// fault fails here even though the survivors keep the chain live.
+func waitValidatorsReady(ctx context.Context, t *testing.T, cs *kubernetes.Clientset, ns, chainID string, want int) {
+	t.Helper()
+	tick := time.NewTicker(5 * time.Second)
+	defer tick.Stop()
+	for {
+		ready := 0
+		pods, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: "sei.io/nodedeployment=" + chainID})
+		if err == nil {
+			for i := range pods.Items {
+				if podReady(&pods.Items[i]) {
+					ready++
+				}
+			}
+		}
+		if ready >= want {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Errorf("post-fault validators ready %d/%d before deadline: %v", ready, want, ctx.Err())
+			return
+		case <-tick.C:
+		}
+	}
+}
+
+// podReady reports whether the pod's Ready condition is True.
+func podReady(p *corev1.Pod) bool {
+	for _, c := range p.Status.Conditions {
+		if c.Type == corev1.PodReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }

--- a/test/integration/faults/container_kill.yaml.tmpl
+++ b/test/integration/faults/container_kill.yaml.tmpl
@@ -1,0 +1,19 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: container-kill-{{.RunID}}
+  namespace: {{.Namespace}}
+  labels:
+    sei.io/harness-run: "{{.RunID}}"
+spec:
+  # One-shot: kill the seid container in one validator pod; the kubelet restarts
+  # it in place while the chain holds on the other 3 (f=1). No duration / no
+  # AllRecovered — same one-shot handling as pod-failure.
+  action: container-kill
+  mode: one
+  containerNames: ["seid"]
+  gracePeriod: 0
+  selector:
+    namespaces: ["{{.Namespace}}"]
+    expressionSelectors:
+      - {key: sei.io/nodedeployment, operator: In, values: ["{{.ChainID}}"]}

--- a/test/integration/faults/pod_failure.yaml.tmpl
+++ b/test/integration/faults/pod_failure.yaml.tmpl
@@ -1,0 +1,19 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: pod-failure-{{.RunID}}
+  namespace: {{.Namespace}}
+  labels:
+    sei.io/harness-run: "{{.RunID}}"
+spec:
+  # One-shot: kill one validator pod outright; the StatefulSet recreates it
+  # while the chain keeps producing on the other 3 (f=1). No duration, so no
+  # AllRecovered — recovery is the killed pod rejoining, observed via the
+  # follower staying live.
+  action: pod-kill
+  mode: one
+  gracePeriod: 0
+  selector:
+    namespaces: ["{{.Namespace}}"]
+    expressionSelectors:
+      - {key: sei.io/nodedeployment, operator: In, values: ["{{.ChainID}}"]}


### PR DESCRIPTION
## WS-I — chaos one-shot kill faults

Two PodChaos kill faults that need distinct handling: **no `duration`, no `AllRecovered`**. A `chaosScenario.oneShot` flag routes them:
- skip the self-expiry tripwire (one-shot kills carry no duration by design),
- under-fault window is fixed (the kill + StatefulSet/kubelet restart) rather than duration-derived,
- skip `gateRecovered` (nothing to recover at the chaos-mesh level) — recovery = the killed pod rejoining, covered by the post `WaitCaughtUp`.

| fault | action | effect |
|---|---|---|
| pod-failure | pod-kill | kills one validator pod; StatefulSet recreates it |
| container-kill | container-kill | kills the seid container; kubelet restarts in place |

Chain stays live on the other 3 (f=1); the follower advances through the kill. Chaos suite → **11/14**.

**Remaining:** rpc-chaos (HTTPChaos×2, follower-targeted), dns-chaos (recovery assert), mempool (PromQL/telemetry).

### Verification
build/lint clean · `go test -c -tags integration` compiles · in-cluster smoke of both in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)