### PR TITLE
feat(test): port dns-chaos with corrected peer-FQDN patterns

### DIFF
--- a/test/integration/chaos_test.go
+++ b/test/integration/chaos_test.go
@@ -46,6 +46,9 @@ var diskIOLatencyTmpl string
 //go:embed faults/byzantine.yaml.tmpl
 var byzantineTmpl string
 
+//go:embed faults/dns_chaos.yaml.tmpl
+var dnsChaosTmpl string
+
 //go:embed faults/pod_failure.yaml.tmpl
 var podFailureTmpl string
 

--- a/test/integration/chaossuite_test.go
+++ b/test/integration/chaossuite_test.go
@@ -29,6 +29,7 @@ const (
 	rTimeChaos    = "timechaos"
 	rIOChaos      = "iochaos"
 	rPodChaos     = "podchaos"
+	rDNSChaos     = "dnschaos"
 )
 
 // chaosScenario is one fault ported from the platform chaos suite: a name, the
@@ -56,9 +57,7 @@ var chaosScenarios = []chaosScenario{
 	{name: "byzantine", resource: rNetworkChaos, tmpl: byzantineTmpl},
 	{name: "pod-failure", resource: rPodChaos, tmpl: podFailureTmpl, oneShot: true},
 	{name: "container-kill", resource: rPodChaos, tmpl: containerKillTmpl, oneShot: true},
-	// dns-chaos deferred: it's a rediscovery fault (live MConnections don't
-	// re-resolve), so the under-fault progress assert can't perturb it — needs a
-	// recovery-focused assert + peer-FQDN-matching patterns.
+	{name: "dns-chaos", resource: rDNSChaos, tmpl: dnsChaosTmpl},
 }
 
 // TestChaosSuite runs each fault against its own fresh chain: provision → inject

--- a/test/integration/faults/dns_chaos.yaml.tmpl
+++ b/test/integration/faults/dns_chaos.yaml.tmpl
@@ -1,0 +1,23 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: DNSChaos
+metadata:
+  name: dns-chaos-{{.RunID}}
+  namespace: {{.Namespace}}
+  labels:
+    sei.io/harness-run: "{{.RunID}}"
+spec:
+  # DNS resolution errors on every validator for the chain's own names. The
+  # <chain>-* glob matches the per-pod peer FQDNs validators actually resolve
+  # (<chain>-N-0.<chain>-N.<ns>.svc.cluster.local), not just the bare service
+  # name. Established MConnections don't re-resolve, so this asserts the chain is
+  # RESILIENT to DNS failure (keeps producing) rather than that DNS halts it; the
+  # injected-targets gate proves the interceptor is actually installed.
+  action: error
+  mode: all
+  selector:
+    namespaces: ["{{.Namespace}}"]
+    expressionSelectors:
+      - {key: sei.io/nodedeployment, operator: In, values: ["{{.ChainID}}"]}
+  patterns:
+    - "{{.ChainID}}-*.{{.Namespace}}.svc.cluster.local"
+  duration: "{{.Duration}}"


### PR DESCRIPTION
## WS-I — dns-chaos (corrected)

Re-adds dns-chaos, **deferred in #433** because its patterns (`<chain>`/`<chain>-internal`/`<chain>-rpc`) matched no name seid resolves → vacuous. Corrected to `<chain>-*.<ns>.svc.cluster.local`, which matches the per-pod peer FQDNs validators actually resolve (`<chain>-N-0.<chain>-N.<ns>.svc…`).

With the `injectedTargets>0` gate confirming the DNS interceptor is actually installed on the validators, this is a legitimate **DNS-resilience** test: the chain keeps producing despite resolution failures on its own names (established MConnections don't re-resolve, so DNS error doesn't tear down live peering). The template comment is explicit that it asserts *resilience*, not active consensus perturbation — honest about what a green means.

Fits the standard flow (gateInjected + height-advance + recovery Ready-gate). Chaos suite → **12/14** (rpc-chaos + mempool/PromQL remain).

### Verification
build/lint clean · in-cluster smoke in progress (validates the corrected patterns inject + the chain stays resilient + recovers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)