### PR TITLE
feat(sdk): RunTask/WaitComplete over SeiNodeTask (WS-G)

### DIFF
--- a/sdk/sei/.xreview/sdk-task-surface.md
+++ b/sdk/sei/.xreview/sdk-task-surface.md
@@ -1,0 +1,46 @@
+# xreview ledger — SDK SeiNodeTask surface (WS-G)
+
+Class: component (public SDK surface over the SeiNodeTask CRD)
+Tier: T2
+
+Target: `sdk/sei/task.go`, `sdk/sei/provider.go`, `sdk/sei/provider/k8s/{render,handle,k8s}.go`, stubs + tests
+Artifact: branch `feat/sdk-task-surface` (diff /tmp/wsg-task-surface.diff)
+
+## Round 1
+
+State: RESOLVED
+OpenFindings: 0
+Convergence: independent (4 blinded reviewers)
+Blinded: yes
+Dissenter: sei-network-specialist (DISSENT → resolved)
+
+Slate: kubernetes-specialist (CRD-contract), idiomatic-reviewer (Go idiom), systems-engineer (poll/error contract), sei-network-specialist (dissenter, upgrade semantics).
+
+### Boundary table
+
+| Boundary | Provider | Consumer | Status | Evidence | Raised by |
+|---|---|---|---|---|---|
+| GovSoftwareUpgrade proposal-ID handoff | nodetask controller | harness (GovVote input) | **MISMATCH → FIXED** | `controller.go:360-369` populateOutputs only handles UpdateNodeImage; gov/await outputs never written (chain-as-medium by design). SDK advertised `ProposalID` as "the GovVote input" → always 0 → GovVote.proposalId Minimum=1 admission reject (`seinodetask_types.go:366`). | dissenter (lead), k8s, systems |
+| UpdateNodeImage RequirePhase on halted node | nodetask controller | harness (step 4) | **MISMATCH → FIXED** | Gate is `==` exact-match defaulting Running (`controller.go:195-199`); a node halted at upgrade height still reports Running (phase sticky). SDK doc+test told callers to relax to Pending → terminal timeout. | dissenter |
+| Payload field mapping (4 kinds) | CRD | renderTask | COMPATIBLE | All fields field-for-field congruent (render.go). | k8s |
+| SSA / status subresource | CRD | k8s apply | COMPATIBLE | Main-resource Apply; status subresource separate — no status stomp. | k8s |
+| WaitComplete poll loop | — | harness | **MISMATCH → FIXED** | Only NotFound tolerated; a transient Get error aborts a multi-minute wait. Tolerate retryable (ServerTimeout/TooManyRequests/InternalError). | systems |
+| Complete + nil outputs | controller | WaitComplete | MISMATCH → MITIGATED | `(nil,nil)` nil-deref hazard; largely mooted by removing the unpopulated gov output types. | systems, k8s |
+| Resubmit / idempotency | CRD + controller | RunTask | MISSING → DOCUMENTED | same-name re-apply is a no-op (no double-submit); delete+recreate resubmits the gov-tx. Doc'd on RunTask. CEL immutability + on-chain dedup are later coordinated CRD work. | systems |
+| GovVote per-validator key derivation | controller | harness | COMPATIBLE | `KeyName:""` derives per-target SeiNode key (`seinodetask_params.go:120,231`); no shared-key assumption. | dissenter |
+
+### Idiom addendum (idiomatic-reviewer — RATIFY)
+Clean. No correctness/divergence-with-consequence findings. Endorsed `WaitComplete (*TaskOutputs, error)` as the correct one-shot-terminal shape. Two pure-style notes accepted as-is. Process note: add a provider-side one-output-per-Kind test.
+
+### Resolutions (this PR, no controller change)
+1. **ProposalID lie:** removed `GovSoftwareUpgradeOutputs`/`GovVoteOutputs`/`AwaitNodesAtHeightOutputs` from the SDK (all structurally unpopulated); `TaskOutputs` now carries only `UpdateNodeImage` (the sole kind populateOutputs writes). Package + payload docs rewritten to the chain-as-medium reality.
+2. **RequirePhase backwards:** UpdateNodeImage doc fixed — a halted node still reports Running, so the default is correct; removed the relax-to-Pending guidance; repurposed the test to verify mechanical RequirePhase override (not the upgrade-failure pattern).
+3. **Transient-error tolerance:** WaitComplete keeps polling on retryable Get errors.
+4. **Cheap hardening:** validateTaskSpec now validates GovVote.Option enum + rejects 0<Timeout<1s (silent-unbounded trap).
+5. **Docs:** RunTask resubmit/idempotency contract; Namespace/Node co-location; AwaitNodesAtHeight H-vs-H-1 + ctx-bound; InitialDeposit≥min_deposit + voting-period<upgradeHeight traps.
+6. taskFailureReason: append phase to the no-reason fallback; prefer the Ready condition.
+
+### Deferred (un-defer conditions noted; not blocking)
+- CEL payload-immutability guard + on-chain upgrade-proposal dedup — coordinated CRD work; un-defer before driving a non-disposable chain.
+- Sidecar typed TaskResult → re-add gov output fields when it lands.
+- RestartSeid kind — when a release suite needs a config-only restart.

--- a/sdk/sei/provider.go
+++ b/sdk/sei/provider.go
@@ -20,6 +20,8 @@ type Provider interface {
 	GetNetwork(ctx context.Context, name, namespace string) (NetworkHandle, error)
 	CreateNode(ctx context.Context, spec NodeSpec) (NodeHandle, error)
 	GetNode(ctx context.Context, name, namespace string) (NodeHandle, error)
+	RunTask(ctx context.Context, spec TaskSpec) (TaskHandle, error)
+	GetTask(ctx context.Context, name, namespace string) (TaskHandle, error)
 }
 
 // NetworkHandle is the provider-side state the core *Network wraps. It exposes
@@ -44,6 +46,18 @@ type NodeHandle interface {
 	WaitReady(ctx context.Context) error
 	Delete(ctx context.Context) error
 	Object() any // mode-specific raw resource (k8s: *v1alpha1.SeiNode)
+}
+
+// TaskHandle is the provider-side state the core *Task wraps. A SeiNodeTask is
+// one-shot: WaitComplete blocks to a terminal phase and returns the typed
+// outputs, rather than exposing long-lived endpoint getters like the
+// network/node handles.
+type TaskHandle interface {
+	Name() string
+	Namespace() string
+	WaitComplete(ctx context.Context) (*TaskOutputs, error)
+	Delete(ctx context.Context) error
+	Object() any // mode-specific raw resource (k8s: *v1alpha1.SeiNodeTask)
 }
 
 // Factory builds a provider. Deferred so registration (init time) does no I/O —

--- a/sdk/sei/provider/docker/docker.go
+++ b/sdk/sei/provider/docker/docker.go
@@ -42,3 +42,11 @@ func (*Provider) CreateNode(context.Context, sei.NodeSpec) (sei.NodeHandle, erro
 func (*Provider) GetNode(context.Context, string, string) (sei.NodeHandle, error) {
 	return nil, ErrNotImplemented
 }
+
+func (*Provider) RunTask(context.Context, sei.TaskSpec) (sei.TaskHandle, error) {
+	return nil, ErrNotImplemented
+}
+
+func (*Provider) GetTask(context.Context, string, string) (sei.TaskHandle, error) {
+	return nil, ErrNotImplemented
+}

--- a/sdk/sei/provider/k8s/handle.go
+++ b/sdk/sei/provider/k8s/handle.go
@@ -193,7 +193,11 @@ func (h *taskHandle) WaitComplete(ctx context.Context) (*sei.TaskOutputs, error)
 	err := wait.PollUntilContextCancel(ctx, pollInterval, true, func(ctx context.Context) (bool, error) {
 		task := &seiv1alpha1.SeiNodeTask{}
 		if err := h.p.c.Get(ctx, types.NamespacedName{Namespace: h.namespace, Name: h.name}, task); err != nil {
-			if apierrors.IsNotFound(err) {
+			// A task wait spans minutes (the chain halts at the upgrade height), so
+			// a single transient read error must not collapse the whole wait — keep
+			// polling on retryable errors (and NotFound, for post-create cache lag).
+			// The caller's ctx remains the hard budget. Only a terminal error aborts.
+			if retryableGet(err) {
 				return false, nil
 			}
 			return false, fmt.Errorf("%s: reading status: %w", resource, err)
@@ -226,43 +230,56 @@ func (h *taskHandle) Delete(ctx context.Context) error {
 // Object returns the cached *v1alpha1.SeiNodeTask — the k8s raw-CR escape hatch.
 func (h *taskHandle) Object() any { return h.task }
 
+// retryableGet reports whether a Get error should be tolerated by continuing to
+// poll rather than aborting the wait: NotFound (post-create cache lag, or a task
+// briefly absent from the informer) and the transient server-side classes a
+// minutes-long wait will occasionally hit. A genuinely terminal error (Forbidden,
+// schema) is not retryable and aborts.
+func retryableGet(err error) bool {
+	return apierrors.IsNotFound(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsInternalError(err)
+}
+
 // taskFailureReason extracts a human reason from a failed task: the execution's
-// recorded error, else the message of any Ready=False condition, else a generic
-// note so the error is never empty.
+// recorded error, else a False condition message (preferring the terminal Ready
+// condition over others for a stable message), else the phase itself so the
+// error always carries some triage signal. The execution error is nil on a
+// failure before target resolution (e.g. a RequirePhase timeout), where the
+// condition message is the only source.
 func taskFailureReason(task *seiv1alpha1.SeiNodeTask) string {
 	if task.Status.Task != nil && task.Status.Task.Err != "" {
 		return task.Status.Task.Err
 	}
+	var firstFalse string
 	for _, c := range task.Status.Conditions {
-		if c.Status == metav1.ConditionFalse && c.Message != "" {
+		if c.Status != metav1.ConditionFalse || c.Message == "" {
+			continue
+		}
+		if c.Type == seiv1alpha1.ConditionSeiNodeTaskReady {
 			return c.Message
 		}
+		if firstFalse == "" {
+			firstFalse = c.Message
+		}
 	}
-	return "no failure reason recorded"
+	if firstFalse != "" {
+		return firstFalse
+	}
+	return fmt.Sprintf("no failure reason recorded (phase=%s)", task.Status.Phase)
 }
 
 // translateTaskOutputs maps the CRD outputs to the SDK-native shape. Returns nil
-// when the task recorded no outputs (e.g. a kind that produces none).
+// when the task recorded no outputs. Only UpdateNodeImage is surfaced — the only
+// kind the controller's populateOutputs writes; gov/await kinds coordinate via
+// chain queries (chain-as-medium), so the SDK exposes no always-empty fields.
 func translateTaskOutputs(out *seiv1alpha1.SeiNodeTaskOutputs) *sei.TaskOutputs {
-	if out == nil {
+	if out == nil || out.UpdateNodeImage == nil {
 		return nil
 	}
-	o := &sei.TaskOutputs{}
-	if u := out.GovSoftwareUpgrade; u != nil {
-		o.GovSoftwareUpgrade = &sei.GovSoftwareUpgradeOutputs{
-			ProposalID: u.ProposalID,
-			TxHash:     u.TxHash,
-			Height:     u.Height,
-		}
+	return &sei.TaskOutputs{
+		UpdateNodeImage: &sei.UpdateNodeImageOutputs{AppliedImage: out.UpdateNodeImage.AppliedImage},
 	}
-	if v := out.GovVote; v != nil {
-		o.GovVote = &sei.GovVoteOutputs{TxHash: v.TxHash, Height: v.Height}
-	}
-	if a := out.AwaitNodesAtHeight; a != nil {
-		o.AwaitNodesAtHeight = &sei.AwaitNodesAtHeightOutputs{CurrentHeight: a.CurrentHeight}
-	}
-	if i := out.UpdateNodeImage; i != nil {
-		o.UpdateNodeImage = &sei.UpdateNodeImageOutputs{AppliedImage: i.AppliedImage}
-	}
-	return o
 }

--- a/sdk/sei/provider/k8s/handle.go
+++ b/sdk/sei/provider/k8s/handle.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+
+	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
 )
 
 // pollInterval is the status re-read cadence for WaitReady. The overall budget is
@@ -168,3 +170,99 @@ func (h *nodeHandle) Delete(ctx context.Context) error {
 
 // Object returns the cached *v1alpha1.SeiNode — the k8s raw-CR escape hatch.
 func (h *nodeHandle) Object() any { return h.node }
+
+// taskHandle is the provider-side state behind a *sei.Task. It caches the
+// last-read SeiNodeTask; WaitComplete refreshes that cache as it polls and
+// returns the translated outputs from the terminal object.
+type taskHandle struct {
+	p         *Provider
+	namespace string
+	name      string
+	task      *seiv1alpha1.SeiNodeTask
+}
+
+func (h *taskHandle) Name() string      { return h.name }
+func (h *taskHandle) Namespace() string { return h.namespace }
+
+// WaitComplete blocks until the SeiNodeTask reaches Complete (returning its
+// translated outputs) or fails fast on Failed (returning the task's recorded
+// failure reason). The caller's ctx is the budget; a deadline surfaces as
+// context.DeadlineExceeded (sei.IsTimeout).
+func (h *taskHandle) WaitComplete(ctx context.Context) (*sei.TaskOutputs, error) {
+	resource := fmt.Sprintf("SeiNodeTask %s/%s", h.namespace, h.name)
+	err := wait.PollUntilContextCancel(ctx, pollInterval, true, func(ctx context.Context) (bool, error) {
+		task := &seiv1alpha1.SeiNodeTask{}
+		if err := h.p.c.Get(ctx, types.NamespacedName{Namespace: h.namespace, Name: h.name}, task); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("%s: reading status: %w", resource, err)
+		}
+		h.task = task
+		switch task.Status.Phase {
+		case seiv1alpha1.SeiNodeTaskPhaseComplete:
+			return true, nil
+		case seiv1alpha1.SeiNodeTaskPhaseFailed:
+			return false, fmt.Errorf("%s: failed: %s", resource, taskFailureReason(task))
+		default:
+			return false, nil
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return translateTaskOutputs(h.task.Status.Outputs), nil
+}
+
+// Delete removes the SeiNodeTask. Idempotent: a NotFound is success.
+func (h *taskHandle) Delete(ctx context.Context) error {
+	obj := &seiv1alpha1.SeiNodeTask{ObjectMeta: metav1.ObjectMeta{Name: h.name, Namespace: h.namespace}}
+	if err := h.p.c.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("SeiNodeTask %s/%s: delete: %w", h.namespace, h.name, err)
+	}
+	return nil
+}
+
+// Object returns the cached *v1alpha1.SeiNodeTask — the k8s raw-CR escape hatch.
+func (h *taskHandle) Object() any { return h.task }
+
+// taskFailureReason extracts a human reason from a failed task: the execution's
+// recorded error, else the message of any Ready=False condition, else a generic
+// note so the error is never empty.
+func taskFailureReason(task *seiv1alpha1.SeiNodeTask) string {
+	if task.Status.Task != nil && task.Status.Task.Err != "" {
+		return task.Status.Task.Err
+	}
+	for _, c := range task.Status.Conditions {
+		if c.Status == metav1.ConditionFalse && c.Message != "" {
+			return c.Message
+		}
+	}
+	return "no failure reason recorded"
+}
+
+// translateTaskOutputs maps the CRD outputs to the SDK-native shape. Returns nil
+// when the task recorded no outputs (e.g. a kind that produces none).
+func translateTaskOutputs(out *seiv1alpha1.SeiNodeTaskOutputs) *sei.TaskOutputs {
+	if out == nil {
+		return nil
+	}
+	o := &sei.TaskOutputs{}
+	if u := out.GovSoftwareUpgrade; u != nil {
+		o.GovSoftwareUpgrade = &sei.GovSoftwareUpgradeOutputs{
+			ProposalID: u.ProposalID,
+			TxHash:     u.TxHash,
+			Height:     u.Height,
+		}
+	}
+	if v := out.GovVote; v != nil {
+		o.GovVote = &sei.GovVoteOutputs{TxHash: v.TxHash, Height: v.Height}
+	}
+	if a := out.AwaitNodesAtHeight; a != nil {
+		o.AwaitNodesAtHeight = &sei.AwaitNodesAtHeightOutputs{CurrentHeight: a.CurrentHeight}
+	}
+	if i := out.UpdateNodeImage; i != nil {
+		o.UpdateNodeImage = &sei.UpdateNodeImageOutputs{AppliedImage: i.AppliedImage}
+	}
+	return o
+}

--- a/sdk/sei/provider/k8s/k8s.go
+++ b/sdk/sei/provider/k8s/k8s.go
@@ -101,6 +101,27 @@ func (p *Provider) GetNode(ctx context.Context, name, namespace string) (sei.Nod
 	return &nodeHandle{p: p, namespace: ns, name: name, node: node}, nil
 }
 
+// RunTask SSA-applies one SeiNodeTask against spec.Node and returns a handle
+// immediately. It does not wait — the caller calls Task.WaitComplete.
+func (p *Provider) RunTask(ctx context.Context, spec sei.TaskSpec) (sei.TaskHandle, error) {
+	ns := p.ns(spec.Namespace)
+	task := renderTask(spec, ns)
+	if err := p.apply(ctx, task, fmt.Sprintf("SeiNodeTask %s/%s", ns, task.Name)); err != nil {
+		return nil, err
+	}
+	return &taskHandle{p: p, namespace: ns, name: task.Name, task: task}, nil
+}
+
+// GetTask reads an existing SeiNodeTask into a handle.
+func (p *Provider) GetTask(ctx context.Context, name, namespace string) (sei.TaskHandle, error) {
+	ns := p.ns(namespace)
+	task := &seiv1alpha1.SeiNodeTask{}
+	if err := p.c.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, task); err != nil {
+		return nil, err
+	}
+	return &taskHandle{p: p, namespace: ns, name: name, task: task}, nil
+}
+
 // ns returns specNS or the provider default when specNS is empty.
 func (p *Provider) ns(specNS string) string {
 	if specNS != "" {

--- a/sdk/sei/provider/k8s/render.go
+++ b/sdk/sei/provider/k8s/render.go
@@ -108,3 +108,73 @@ func renderNode(spec sei.NodeSpec, namespace, networkNS string) *seiv1alpha1.Sei
 	}
 	return node
 }
+
+// renderTask builds a SeiNodeTask from a TaskSpec. Kind and the matching payload
+// are validated in core before this runs; here we translate the SDK-native
+// payload to the CRD sub-spec. An empty RequirePhase / zero RequirePhaseTimeout /
+// zero Timeout leaves the CRD defaults (Running / 5m / unbounded) in place.
+func renderTask(spec sei.TaskSpec, namespace string) *seiv1alpha1.SeiNodeTask {
+	target := seiv1alpha1.SeiNodeTaskTarget{
+		NodeRef: seiv1alpha1.SeiNodeTaskNodeRef{Name: spec.Node},
+	}
+	if spec.RequirePhase != "" {
+		target.RequirePhase = seiv1alpha1.SeiNodePhase(spec.RequirePhase)
+	}
+	if spec.RequirePhaseTimeout > 0 {
+		target.RequirePhaseTimeout = &metav1.Duration{Duration: spec.RequirePhaseTimeout}
+	}
+
+	task := &seiv1alpha1.SeiNodeTask{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: seiv1alpha1.GroupVersion.String(),
+			Kind:       "SeiNodeTask",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      spec.Name,
+			Namespace: namespace,
+		},
+		Spec: seiv1alpha1.SeiNodeTaskSpec{
+			Kind:           seiv1alpha1.SeiNodeTaskKind(spec.Kind),
+			Target:         target,
+			TimeoutSeconds: int32(spec.Timeout.Seconds()),
+		},
+	}
+
+	switch {
+	case spec.GovSoftwareUpgrade != nil:
+		p := spec.GovSoftwareUpgrade
+		task.Spec.GovSoftwareUpgrade = &seiv1alpha1.GovSoftwareUpgradePayload{
+			ChainID:        p.ChainID,
+			KeyName:        p.KeyName,
+			Title:          p.Title,
+			Description:    p.Description,
+			UpgradeName:    p.UpgradeName,
+			UpgradeHeight:  p.UpgradeHeight,
+			UpgradeInfo:    p.UpgradeInfo,
+			InitialDeposit: p.InitialDeposit,
+			Memo:           p.Memo,
+			Fees:           p.Fees,
+			Gas:            p.Gas,
+		}
+	case spec.GovVote != nil:
+		p := spec.GovVote
+		task.Spec.GovVote = &seiv1alpha1.GovVotePayload{
+			ChainID:    p.ChainID,
+			KeyName:    p.KeyName,
+			ProposalID: p.ProposalID,
+			Option:     p.Option,
+			Memo:       p.Memo,
+			Fees:       p.Fees,
+			Gas:        p.Gas,
+		}
+	case spec.AwaitNodesAtHeight != nil:
+		task.Spec.AwaitNodesAtHeight = &seiv1alpha1.AwaitNodesAtHeightPayload{
+			TargetHeight: spec.AwaitNodesAtHeight.TargetHeight,
+		}
+	case spec.UpdateNodeImage != nil:
+		task.Spec.UpdateNodeImage = &seiv1alpha1.UpdateNodeImagePayload{
+			Image: spec.UpdateNodeImage.Image,
+		}
+	}
+	return task
+}

--- a/sdk/sei/provider/k8s/render_task_test.go
+++ b/sdk/sei/provider/k8s/render_task_test.go
@@ -1,0 +1,85 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
+)
+
+func TestRenderTask_GovSoftwareUpgrade(t *testing.T) {
+	spec := sei.TaskSpec{
+		Name:      "upgrade",
+		Namespace: testNS,
+		Node:      "chaos-net-0",
+		Kind:      sei.TaskGovSoftwareUpgrade,
+		Timeout:   90 * time.Second,
+		GovSoftwareUpgrade: &sei.GovSoftwareUpgrade{
+			ChainID:        testNet,
+			Title:          "v2 upgrade",
+			Description:    "bump",
+			UpgradeName:    "v2",
+			UpgradeHeight:  200,
+			InitialDeposit: "10000000usei",
+			Fees:           "2000usei",
+			Gas:            200000,
+		},
+	}
+	task := renderTask(spec, testNS)
+
+	if task.Name != "upgrade" || task.Namespace != testNS {
+		t.Fatalf("metadata = %s/%s", task.Namespace, task.Name)
+	}
+	if string(task.Spec.Kind) != sei.TaskGovSoftwareUpgrade {
+		t.Errorf("kind = %q, want %q", task.Spec.Kind, sei.TaskGovSoftwareUpgrade)
+	}
+	if task.Spec.Target.NodeRef.Name != "chaos-net-0" {
+		t.Errorf("target.nodeRef.name = %q", task.Spec.Target.NodeRef.Name)
+	}
+	// Timeout maps to whole seconds.
+	if task.Spec.TimeoutSeconds != 90 {
+		t.Errorf("timeoutSeconds = %d, want 90", task.Spec.TimeoutSeconds)
+	}
+	// Zero RequirePhase / RequirePhaseTimeout leave the CRD defaults in place.
+	if task.Spec.Target.RequirePhase != "" {
+		t.Errorf("requirePhase = %q, want empty (CRD default)", task.Spec.Target.RequirePhase)
+	}
+	if task.Spec.Target.RequirePhaseTimeout != nil {
+		t.Errorf("requirePhaseTimeout = %v, want nil (CRD default)", task.Spec.Target.RequirePhaseTimeout)
+	}
+	p := task.Spec.GovSoftwareUpgrade
+	if p == nil {
+		t.Fatal("govSoftwareUpgrade payload nil")
+	}
+	if p.UpgradeName != "v2" || p.UpgradeHeight != 200 || p.Gas != 200000 || p.InitialDeposit != "10000000usei" {
+		t.Errorf("payload mistranslated = %+v", p)
+	}
+	// Exactly the matching payload is set.
+	if task.Spec.GovVote != nil || task.Spec.AwaitNodesAtHeight != nil || task.Spec.UpdateNodeImage != nil {
+		t.Error("non-matching payload set")
+	}
+}
+
+func TestRenderTask_UpdateNodeImageRelaxesRequirePhase(t *testing.T) {
+	// A major upgrade swaps the binary on a chain halted at the upgrade height —
+	// the target is not Running, so the caller relaxes RequirePhase.
+	spec := sei.TaskSpec{
+		Name:                "swap",
+		Node:                "chaos-net-0",
+		Kind:                sei.TaskUpdateNodeImage,
+		RequirePhase:        "Pending",
+		RequirePhaseTimeout: 2 * time.Minute,
+		UpdateNodeImage:     &sei.UpdateNodeImage{Image: "img:v2"},
+	}
+	task := renderTask(spec, testNS)
+
+	if got := string(task.Spec.Target.RequirePhase); got != "Pending" {
+		t.Errorf("requirePhase = %q, want Pending", got)
+	}
+	if task.Spec.Target.RequirePhaseTimeout == nil || task.Spec.Target.RequirePhaseTimeout.Duration != 2*time.Minute {
+		t.Errorf("requirePhaseTimeout = %v, want 2m", task.Spec.Target.RequirePhaseTimeout)
+	}
+	if task.Spec.UpdateNodeImage == nil || task.Spec.UpdateNodeImage.Image != "img:v2" {
+		t.Errorf("updateNodeImage payload = %+v", task.Spec.UpdateNodeImage)
+	}
+}

--- a/sdk/sei/provider/k8s/render_task_test.go
+++ b/sdk/sei/provider/k8s/render_task_test.go
@@ -4,14 +4,21 @@ import (
 	"testing"
 	"time"
 
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+
 	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
+)
+
+const (
+	testTaskNode = "chaos-net-0" // target SeiNode name used across the task render tests
+	testNewImage = "img:v2"      // upgrade image used across the task render tests
 )
 
 func TestRenderTask_GovSoftwareUpgrade(t *testing.T) {
 	spec := sei.TaskSpec{
 		Name:      "upgrade",
 		Namespace: testNS,
-		Node:      "chaos-net-0",
+		Node:      testTaskNode,
 		Kind:      sei.TaskGovSoftwareUpgrade,
 		Timeout:   90 * time.Second,
 		GovSoftwareUpgrade: &sei.GovSoftwareUpgrade{
@@ -33,7 +40,7 @@ func TestRenderTask_GovSoftwareUpgrade(t *testing.T) {
 	if string(task.Spec.Kind) != sei.TaskGovSoftwareUpgrade {
 		t.Errorf("kind = %q, want %q", task.Spec.Kind, sei.TaskGovSoftwareUpgrade)
 	}
-	if task.Spec.Target.NodeRef.Name != "chaos-net-0" {
+	if task.Spec.Target.NodeRef.Name != testTaskNode {
 		t.Errorf("target.nodeRef.name = %q", task.Spec.Target.NodeRef.Name)
 	}
 	// Timeout maps to whole seconds.
@@ -60,26 +67,47 @@ func TestRenderTask_GovSoftwareUpgrade(t *testing.T) {
 	}
 }
 
-func TestRenderTask_UpdateNodeImageRelaxesRequirePhase(t *testing.T) {
-	// A major upgrade swaps the binary on a chain halted at the upgrade height —
-	// the target is not Running, so the caller relaxes RequirePhase.
+func TestRenderTask_RequirePhaseOverride(t *testing.T) {
+	// A non-default RequirePhase / RequirePhaseTimeout threads through verbatim.
+	// (The gate is exact-equality, so a caller sets this only to match a genuinely
+	// non-Running target — never to "relax" a halted upgrade node, which stays
+	// Running; that case keeps the default. This test covers the mechanics only.)
 	spec := sei.TaskSpec{
 		Name:                "swap",
-		Node:                "chaos-net-0",
+		Node:                testTaskNode,
 		Kind:                sei.TaskUpdateNodeImage,
-		RequirePhase:        "Pending",
+		RequirePhase:        "Initializing",
 		RequirePhaseTimeout: 2 * time.Minute,
-		UpdateNodeImage:     &sei.UpdateNodeImage{Image: "img:v2"},
+		UpdateNodeImage:     &sei.UpdateNodeImage{Image: testNewImage},
 	}
 	task := renderTask(spec, testNS)
 
-	if got := string(task.Spec.Target.RequirePhase); got != "Pending" {
-		t.Errorf("requirePhase = %q, want Pending", got)
+	if got := string(task.Spec.Target.RequirePhase); got != "Initializing" {
+		t.Errorf("requirePhase = %q, want Initializing", got)
 	}
 	if task.Spec.Target.RequirePhaseTimeout == nil || task.Spec.Target.RequirePhaseTimeout.Duration != 2*time.Minute {
 		t.Errorf("requirePhaseTimeout = %v, want 2m", task.Spec.Target.RequirePhaseTimeout)
 	}
-	if task.Spec.UpdateNodeImage == nil || task.Spec.UpdateNodeImage.Image != "img:v2" {
+	if task.Spec.UpdateNodeImage == nil || task.Spec.UpdateNodeImage.Image != testNewImage {
 		t.Errorf("updateNodeImage payload = %+v", task.Spec.UpdateNodeImage)
+	}
+}
+
+func TestTranslateTaskOutputs(t *testing.T) {
+	// Only UpdateNodeImage is surfaced — the one kind the controller populates.
+	if got := translateTaskOutputs(nil); got != nil {
+		t.Errorf("nil outputs => %+v, want nil", got)
+	}
+	// An outputs object with no UpdateNodeImage (e.g. a gov task's empty outputs)
+	// translates to nil — the SDK never surfaces an always-empty field.
+	if got := translateTaskOutputs(&seiv1alpha1.SeiNodeTaskOutputs{}); got != nil {
+		t.Errorf("empty outputs => %+v, want nil", got)
+	}
+	out := &seiv1alpha1.SeiNodeTaskOutputs{
+		UpdateNodeImage: &seiv1alpha1.UpdateNodeImageOutputs{AppliedImage: testNewImage},
+	}
+	got := translateTaskOutputs(out)
+	if got == nil || got.UpdateNodeImage == nil || got.UpdateNodeImage.AppliedImage != testNewImage {
+		t.Errorf("translate => %+v, want AppliedImage=img:v2", got)
 	}
 }

--- a/sdk/sei/provider/local/local.go
+++ b/sdk/sei/provider/local/local.go
@@ -43,3 +43,11 @@ func (*Provider) CreateNode(context.Context, sei.NodeSpec) (sei.NodeHandle, erro
 func (*Provider) GetNode(context.Context, string, string) (sei.NodeHandle, error) {
 	return nil, ErrNotImplemented
 }
+
+func (*Provider) RunTask(context.Context, sei.TaskSpec) (sei.TaskHandle, error) {
+	return nil, ErrNotImplemented
+}
+
+func (*Provider) GetTask(context.Context, string, string) (sei.TaskHandle, error) {
+	return nil, ErrNotImplemented
+}

--- a/sdk/sei/registry_test.go
+++ b/sdk/sei/registry_test.go
@@ -28,6 +28,10 @@ func (stubProvider) CreateNode(context.Context, NodeSpec) (NodeHandle, error) { 
 func (stubProvider) GetNode(context.Context, string, string) (NodeHandle, error) {
 	return nil, nil
 }
+func (stubProvider) RunTask(context.Context, TaskSpec) (TaskHandle, error) { return nil, nil }
+func (stubProvider) GetTask(context.Context, string, string) (TaskHandle, error) {
+	return nil, nil
+}
 
 // resetRegistry clears the package registry so each test starts clean. Tests in
 // this file run sequentially (no t.Parallel) because they mutate global state.

--- a/sdk/sei/task.go
+++ b/sdk/sei/task.go
@@ -1,0 +1,237 @@
+package sei
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// Task support. A SeiNodeTask is a one-shot, typed operation against a single
+// SeiNode — submit a gov upgrade proposal, vote, wait for a height, swap the
+// node image. The harness drives a major-upgrade or release scenario by running
+// these in statement order, threading one task's outputs into the next (the
+// proposal ID a GovSoftwareUpgrade mints feeds the GovVote). This replaces the
+// Chaos-Mesh Workflow DAG + env-file handoffs the seitask-runner used.
+//
+// SeiNodeTask is SeiNode-specific, so it belongs in the SDK. The surface mirrors
+// CreateNetwork/CreateNode: a typed spec with SDK-native payloads (core stays
+// apimachinery-free), translated to the CRD in provider/k8s.
+
+// Task kinds the SDK exposes. A curated subset of the SeiNodeTask CRD kinds —
+// the ones the upgrade/release harness suites drive. The remaining CRD kinds
+// (GovParamChange, AwaitCondition, RestartSeid, MarkReady) are added here when a
+// suite needs them; the value strings match the CRD enum exactly.
+const (
+	TaskGovSoftwareUpgrade = "GovSoftwareUpgrade"
+	TaskGovVote            = "GovVote"
+	TaskAwaitNodesAtHeight = "AwaitNodesAtHeight"
+	TaskUpdateNodeImage    = "UpdateNodeImage"
+)
+
+// Vote options for GovVote.Option (gov v1beta1 VoteOption parse rules).
+const (
+	VoteYes        = "yes"
+	VoteNo         = "no"
+	VoteAbstain    = "abstain"
+	VoteNoWithVeto = "no_with_veto"
+)
+
+// TaskSpec is the typed input to RunTask — one SeiNodeTask against one target
+// SeiNode in the same namespace. Exactly one payload pointer must be set and it
+// must match Kind; RunTask validates this before applying.
+type TaskSpec struct {
+	Name      string        // metadata.name
+	Namespace string        // "" => client default (kubeconfig context / SA namespace)
+	Node      string        // target SeiNode name, same namespace -> spec.target.nodeRef.name
+	Kind      string        // -> spec.kind; one of the Task* consts
+	Timeout   time.Duration // -> spec.timeoutSeconds (truncated to whole seconds); 0 leaves the CRD unbounded default
+
+	// RequirePhase is the SeiNode phase the target must be in before the task
+	// dispatches; "" leaves the CRD default (Running). An UpdateNodeImage on a
+	// chain halted at an upgrade height must relax this — the target is not
+	// Running. -> spec.target.requirePhase.
+	RequirePhase string
+	// RequirePhaseTimeout bounds the requirePhase wait; 0 leaves the CRD default
+	// (5m). -> spec.target.requirePhaseTimeout.
+	RequirePhaseTimeout time.Duration
+
+	// Exactly one payload, matching Kind.
+	GovSoftwareUpgrade *GovSoftwareUpgrade
+	GovVote            *GovVote
+	AwaitNodesAtHeight *AwaitNodesAtHeight
+	UpdateNodeImage    *UpdateNodeImage
+}
+
+// GovSoftwareUpgrade is the payload for TaskGovSoftwareUpgrade — submit an
+// on-chain software-upgrade proposal from the target validator. The minted
+// proposal ID is returned in TaskOutputs.GovSoftwareUpgrade.ProposalID for the
+// follow-on GovVote tasks. Fees/deposit are usei-only (Sei gov rejects other
+// denoms; the sidecar pre-validates).
+type GovSoftwareUpgrade struct {
+	ChainID        string // chain ID the proposal targets
+	KeyName        string // signing keyring entry; "" lets the controller derive from the target
+	Title          string
+	Description    string
+	UpgradeName    string // must match an upgrade handler registered in the target binary
+	UpgradeHeight  int64  // block height the upgrade is scheduled at; >= 1
+	UpgradeInfo    string // optional Plan.Info (e.g. binary checksums)
+	InitialDeposit string // coin notation, usei-only (e.g. "10000000usei")
+	Memo           string // optional; do NOT pre-tag (the sidecar appends taskID=<id>)
+	Fees           string // coin notation, usei-only (e.g. "2000usei")
+	Gas            uint64 // tx gas limit; >= 1
+}
+
+// GovVote is the payload for TaskGovVote — cast one validator's vote on a
+// proposal. Run one per validator to clear the voting threshold.
+type GovVote struct {
+	ChainID    string // chain ID the vote targets
+	KeyName    string // signing keyring entry; "" lets the controller derive from the target
+	ProposalID uint64 // the proposal to vote on; >= 1
+	Option     string // one of the Vote* consts
+	Memo       string // optional; do NOT pre-tag
+	Fees       string // coin notation, usei-only
+	Gas        uint64 // tx gas limit; >= 1
+}
+
+// AwaitNodesAtHeight is the payload for TaskAwaitNodesAtHeight — block until the
+// target SeiNode's local height crosses TargetHeight. Used to wait out the
+// upgrade height (where the chain halts) before swapping binaries.
+type AwaitNodesAtHeight struct {
+	TargetHeight int64 // height the target must reach; >= 1
+}
+
+// UpdateNodeImage is the payload for TaskUpdateNodeImage — patch spec.image on
+// the target SeiNode and complete when status.currentImage observes the new
+// image. No readiness check: a major upgrade expects transient CrashLoop while
+// the new binary applies the upgrade. Relax TaskSpec.RequirePhase accordingly,
+// since the halted target is not Running.
+type UpdateNodeImage struct {
+	Image string // desired seid image (with tag/digest)
+}
+
+// TaskOutputs carries a completed task's typed results. Exactly one field is
+// populated, matching the task's Kind; populated only on a completed task.
+type TaskOutputs struct {
+	GovSoftwareUpgrade *GovSoftwareUpgradeOutputs
+	GovVote            *GovVoteOutputs
+	AwaitNodesAtHeight *AwaitNodesAtHeightOutputs
+	UpdateNodeImage    *UpdateNodeImageOutputs
+}
+
+// GovSoftwareUpgradeOutputs are the results of a GovSoftwareUpgrade task.
+type GovSoftwareUpgradeOutputs struct {
+	ProposalID uint64 // on-chain proposal ID parsed from the inclusion; the GovVote input
+	TxHash     string // upper-case hex tx hash
+	Height     int64  // inclusion height
+}
+
+// GovVoteOutputs are the results of a GovVote task.
+type GovVoteOutputs struct {
+	TxHash string
+	Height int64
+}
+
+// AwaitNodesAtHeightOutputs are the results of an AwaitNodesAtHeight task.
+type AwaitNodesAtHeightOutputs struct {
+	CurrentHeight int64 // height observed on the target when the condition cleared
+}
+
+// UpdateNodeImageOutputs are the results of an UpdateNodeImage task.
+type UpdateNodeImageOutputs struct {
+	AppliedImage string // image now observed on target.status.currentImage
+}
+
+// RunTask creates a SeiNodeTask and returns a handle immediately — it does NOT
+// wait for completion. Call Task.WaitComplete to block on the result.
+func (c *Client) RunTask(ctx context.Context, spec TaskSpec) (*Task, error) {
+	if err := validateTaskSpec(spec); err != nil {
+		return nil, err
+	}
+	h, err := c.provider.RunTask(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	return &Task{handle: h}, nil
+}
+
+// GetTask reads an existing SeiNodeTask into a handle.
+func (c *Client) GetTask(ctx context.Context, name, namespace string) (*Task, error) {
+	h, err := c.provider.GetTask(ctx, name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return &Task{handle: h}, nil
+}
+
+// Task is a Go-native handle to a SeiNodeTask.
+type Task struct{ handle TaskHandle }
+
+// Name is the SeiNodeTask resource name.
+func (t *Task) Name() string { return t.handle.Name() }
+
+// Namespace is where the SeiNodeTask lives.
+func (t *Task) Namespace() string { return t.handle.Namespace() }
+
+// WaitComplete blocks until the task reaches Complete and returns its typed
+// outputs, or returns an error if the task reaches Failed (carrying the task's
+// failure reason) or the caller's ctx fires (IsTimeout on a deadline). The
+// returned outputs carry exactly the sub-field matching the task's Kind.
+func (t *Task) WaitComplete(ctx context.Context) (*TaskOutputs, error) {
+	return t.handle.WaitComplete(ctx)
+}
+
+// Delete removes the SeiNodeTask. Caller-invoked; idempotent (a not-found is
+// success). SeiNodeTasks are not auto-pruned, so a harness deletes them in
+// cleanup the same way it deletes networks and nodes.
+func (t *Task) Delete(ctx context.Context) error { return t.handle.Delete(ctx) }
+
+// Object returns the mode-specific raw resource (k8s: *v1alpha1.SeiNodeTask).
+func (t *Task) Object() any { return t.handle.Object() }
+
+func validateTaskSpec(s TaskSpec) error {
+	if strings.TrimSpace(s.Name) == "" {
+		return usageErr("TaskSpec.Name is required")
+	}
+	if strings.TrimSpace(s.Node) == "" {
+		return usageErr("TaskSpec.Node is required (the target SeiNode)")
+	}
+	// Exactly one payload, and it must match Kind. Count set payloads so a
+	// mismatched/missing/extra payload fails here, not at apply.
+	set := 0
+	if s.GovSoftwareUpgrade != nil {
+		set++
+	}
+	if s.GovVote != nil {
+		set++
+	}
+	if s.AwaitNodesAtHeight != nil {
+		set++
+	}
+	if s.UpdateNodeImage != nil {
+		set++
+	}
+	if set != 1 {
+		return usageErr("TaskSpec requires exactly one payload set, got %d", set)
+	}
+	switch s.Kind {
+	case TaskGovSoftwareUpgrade:
+		if s.GovSoftwareUpgrade == nil {
+			return usageErr("TaskSpec.Kind %q requires GovSoftwareUpgrade payload", s.Kind)
+		}
+	case TaskGovVote:
+		if s.GovVote == nil {
+			return usageErr("TaskSpec.Kind %q requires GovVote payload", s.Kind)
+		}
+	case TaskAwaitNodesAtHeight:
+		if s.AwaitNodesAtHeight == nil {
+			return usageErr("TaskSpec.Kind %q requires AwaitNodesAtHeight payload", s.Kind)
+		}
+	case TaskUpdateNodeImage:
+		if s.UpdateNodeImage == nil {
+			return usageErr("TaskSpec.Kind %q requires UpdateNodeImage payload", s.Kind)
+		}
+	default:
+		return usageErr("TaskSpec.Kind %q is not supported by the SDK", s.Kind)
+	}
+	return nil
+}

--- a/sdk/sei/task.go
+++ b/sdk/sei/task.go
@@ -9,9 +9,16 @@ import (
 // Task support. A SeiNodeTask is a one-shot, typed operation against a single
 // SeiNode — submit a gov upgrade proposal, vote, wait for a height, swap the
 // node image. The harness drives a major-upgrade or release scenario by running
-// these in statement order, threading one task's outputs into the next (the
-// proposal ID a GovSoftwareUpgrade mints feeds the GovVote). This replaces the
-// Chaos-Mesh Workflow DAG + env-file handoffs the seitask-runner used.
+// these in statement order. This replaces the Chaos-Mesh Workflow DAG + env-file
+// handoffs the seitask-runner used.
+//
+// Cross-task coordination is chain-as-medium, NOT task-to-task output currying:
+// the controller surfaces typed Outputs only for UpdateNodeImage today (the gov
+// and await kinds leave them unset — surfacing the sidecar's TaskResult needs
+// typed per-task result payloads that are deferred). So a harness that needs a
+// minted proposal ID for a follow-on GovVote queries the chain for it (e.g. the
+// first proposal on a fresh chain is #1), rather than reading it off the upgrade
+// task. TaskOutputs therefore carries only the kinds the controller populates.
 //
 // SeiNodeTask is SeiNode-specific, so it belongs in the SDK. The surface mirrors
 // CreateNetwork/CreateNode: a typed spec with SDK-native payloads (core stays
@@ -47,9 +54,10 @@ type TaskSpec struct {
 	Timeout   time.Duration // -> spec.timeoutSeconds (truncated to whole seconds); 0 leaves the CRD unbounded default
 
 	// RequirePhase is the SeiNode phase the target must be in before the task
-	// dispatches; "" leaves the CRD default (Running). An UpdateNodeImage on a
-	// chain halted at an upgrade height must relax this — the target is not
-	// Running. -> spec.target.requirePhase.
+	// dispatches; "" leaves the CRD default (Running). The controller gates on
+	// EXACT equality (phase == RequirePhase), not a floor — so set this only when
+	// the target genuinely sits in a non-Running phase, never to "widen" the gate.
+	// -> spec.target.requirePhase.
 	RequirePhase string
 	// RequirePhaseTimeout bounds the requirePhase wait; 0 leaves the CRD default
 	// (5m). -> spec.target.requirePhaseTimeout.
@@ -64,18 +72,26 @@ type TaskSpec struct {
 
 // GovSoftwareUpgrade is the payload for TaskGovSoftwareUpgrade — submit an
 // on-chain software-upgrade proposal from the target validator. The minted
-// proposal ID is returned in TaskOutputs.GovSoftwareUpgrade.ProposalID for the
-// follow-on GovVote tasks. Fees/deposit are usei-only (Sei gov rejects other
-// denoms; the sidecar pre-validates).
+// proposal ID is NOT returned as a task output (chain-as-medium — see the
+// package doc); a harness reads it from the chain for the follow-on GovVote.
+//
+// Two on-chain timing invariants the SDK cannot enforce but a caller must honor:
+// InitialDeposit must clear the chain's min_deposit or the proposal sits in the
+// deposit period and never enters voting; and the proposal must PASS (voting
+// period elapsed, ≥2/3 yes, quorum) strictly before UpgradeHeight, or the plan
+// is scheduled for a height already passed and silently no-ops. On a short-
+// voting-period test chain both are easy to satisfy; size UpgradeHeight
+// accordingly. Fees/deposit are usei-only (Sei gov rejects other denoms; the
+// sidecar pre-validates).
 type GovSoftwareUpgrade struct {
 	ChainID        string // chain ID the proposal targets
 	KeyName        string // signing keyring entry; "" lets the controller derive from the target
 	Title          string
 	Description    string
 	UpgradeName    string // must match an upgrade handler registered in the target binary
-	UpgradeHeight  int64  // block height the upgrade is scheduled at; >= 1
+	UpgradeHeight  int64  // block height the upgrade is scheduled at; >= 1; must be after the proposal passes
 	UpgradeInfo    string // optional Plan.Info (e.g. binary checksums)
-	InitialDeposit string // coin notation, usei-only (e.g. "10000000usei")
+	InitialDeposit string // coin notation, usei-only (e.g. "10000000usei"); must clear min_deposit
 	Memo           string // optional; do NOT pre-tag (the sidecar appends taskID=<id>)
 	Fees           string // coin notation, usei-only (e.g. "2000usei")
 	Gas            uint64 // tx gas limit; >= 1
@@ -94,8 +110,13 @@ type GovVote struct {
 }
 
 // AwaitNodesAtHeight is the payload for TaskAwaitNodesAtHeight — block until the
-// target SeiNode's local height crosses TargetHeight. Used to wait out the
-// upgrade height (where the chain halts) before swapping binaries.
+// target SeiNode's local height reaches TargetHeight. Used to wait out the
+// upgrade height before swapping binaries.
+//
+// Boundary care at an upgrade halt: a chain that halts AT UpgradeHeight commits
+// up to UpgradeHeight-1 and stops producing UpgradeHeight, so await
+// UpgradeHeight-1 (awaiting UpgradeHeight may never clear and WaitComplete is
+// bounded only by the caller's ctx — it will hang to the deadline).
 type AwaitNodesAtHeight struct {
 	TargetHeight int64 // height the target must reach; >= 1
 }
@@ -103,37 +124,26 @@ type AwaitNodesAtHeight struct {
 // UpdateNodeImage is the payload for TaskUpdateNodeImage — patch spec.image on
 // the target SeiNode and complete when status.currentImage observes the new
 // image. No readiness check: a major upgrade expects transient CrashLoop while
-// the new binary applies the upgrade. Relax TaskSpec.RequirePhase accordingly,
-// since the halted target is not Running.
+// the new binary applies the upgrade.
+//
+// Leave TaskSpec.RequirePhase at its default: a SeiNode that has reached Running
+// stays Running across a transient halt (the controller does not demote phase on
+// a non-Running blip), so a node halted at an upgrade height still reports
+// Running — the default gate matches. Do NOT set RequirePhase to a non-Running
+// value here; the gate is exact-equality and would never match, failing the task
+// at RequirePhaseTimeout.
 type UpdateNodeImage struct {
 	Image string // desired seid image (with tag/digest)
 }
 
-// TaskOutputs carries a completed task's typed results. Exactly one field is
-// populated, matching the task's Kind; populated only on a completed task.
+// TaskOutputs carries a completed task's typed results. Only the kinds the
+// controller actually populates are surfaced — today just UpdateNodeImage; the
+// gov and await kinds coordinate via chain queries (see the package doc), so
+// their output fields are intentionally absent rather than present-but-always-
+// empty. Outputs are populated only on a completed task; a nil sub-field means
+// the task produced no typed output.
 type TaskOutputs struct {
-	GovSoftwareUpgrade *GovSoftwareUpgradeOutputs
-	GovVote            *GovVoteOutputs
-	AwaitNodesAtHeight *AwaitNodesAtHeightOutputs
-	UpdateNodeImage    *UpdateNodeImageOutputs
-}
-
-// GovSoftwareUpgradeOutputs are the results of a GovSoftwareUpgrade task.
-type GovSoftwareUpgradeOutputs struct {
-	ProposalID uint64 // on-chain proposal ID parsed from the inclusion; the GovVote input
-	TxHash     string // upper-case hex tx hash
-	Height     int64  // inclusion height
-}
-
-// GovVoteOutputs are the results of a GovVote task.
-type GovVoteOutputs struct {
-	TxHash string
-	Height int64
-}
-
-// AwaitNodesAtHeightOutputs are the results of an AwaitNodesAtHeight task.
-type AwaitNodesAtHeightOutputs struct {
-	CurrentHeight int64 // height observed on the target when the condition cleared
+	UpdateNodeImage *UpdateNodeImageOutputs
 }
 
 // UpdateNodeImageOutputs are the results of an UpdateNodeImage task.
@@ -143,6 +153,18 @@ type UpdateNodeImageOutputs struct {
 
 // RunTask creates a SeiNodeTask and returns a handle immediately — it does NOT
 // wait for completion. Call Task.WaitComplete to block on the result.
+//
+// Tasks are apply-once by name. The controller mints the execution on the first
+// reconcile and never re-reads spec, so re-running RunTask with the same Name is
+// a no-op (no double tx) — but a payload change on a same-name re-apply is
+// silently ignored (the original execution stands), and a Delete followed by a
+// RunTask with the same Name mints a NEW execution that resubmits the tx. For a
+// gov proposal that already landed on-chain, that means a duplicate proposal:
+// delete+recreate only against a disposable chain.
+//
+// The task and its target SeiNode (Node) resolve in the same namespace; set
+// Namespace to the target node's namespace (cross-namespace targeting is out of
+// scope).
 func (c *Client) RunTask(ctx context.Context, spec TaskSpec) (*Task, error) {
 	if err := validateTaskSpec(spec); err != nil {
 		return nil, err
@@ -195,6 +217,12 @@ func validateTaskSpec(s TaskSpec) error {
 	if strings.TrimSpace(s.Node) == "" {
 		return usageErr("TaskSpec.Node is required (the target SeiNode)")
 	}
+	// A sub-second non-zero Timeout truncates to 0 seconds, which the CRD reads as
+	// unbounded — the opposite of the caller's intent. Reject it rather than
+	// silently dropping the bound.
+	if s.Timeout != 0 && s.Timeout < time.Second {
+		return usageErr("TaskSpec.Timeout %s is below the 1s CRD resolution (0 means unbounded)", s.Timeout)
+	}
 	// Exactly one payload, and it must match Kind. Count set payloads so a
 	// mismatched/missing/extra payload fails here, not at apply.
 	set := 0
@@ -222,6 +250,9 @@ func validateTaskSpec(s TaskSpec) error {
 		if s.GovVote == nil {
 			return usageErr("TaskSpec.Kind %q requires GovVote payload", s.Kind)
 		}
+		if !validVoteOption(s.GovVote.Option) {
+			return usageErr("GovVote.Option %q is invalid (want one of yes/no/abstain/no_with_veto)", s.GovVote.Option)
+		}
 	case TaskAwaitNodesAtHeight:
 		if s.AwaitNodesAtHeight == nil {
 			return usageErr("TaskSpec.Kind %q requires AwaitNodesAtHeight payload", s.Kind)
@@ -234,4 +265,15 @@ func validateTaskSpec(s TaskSpec) error {
 		return usageErr("TaskSpec.Kind %q is not supported by the SDK", s.Kind)
 	}
 	return nil
+}
+
+// validVoteOption reports whether opt is an option the CRD's vote enum accepts
+// (the two no_with_veto spellings the gov v1beta1 parser allows are both valid).
+func validVoteOption(opt string) bool {
+	switch opt {
+	case VoteYes, VoteNo, VoteAbstain, VoteNoWithVeto, "no-with-veto":
+		return true
+	default:
+		return false
+	}
 }

--- a/sdk/sei/task_test.go
+++ b/sdk/sei/task_test.go
@@ -1,0 +1,72 @@
+package sei
+
+import "testing"
+
+func TestValidateTaskSpec(t *testing.T) {
+	good := TaskSpec{
+		Name:               "upgrade",
+		Node:               "net-0",
+		Kind:               TaskGovSoftwareUpgrade,
+		GovSoftwareUpgrade: &GovSoftwareUpgrade{},
+	}
+	cases := []struct {
+		name    string
+		mut     func(*TaskSpec)
+		wantErr bool
+	}{
+		{"valid", func(*TaskSpec) {}, false},
+		{"missing name", func(s *TaskSpec) { s.Name = "" }, true},
+		{"missing node", func(s *TaskSpec) { s.Node = "" }, true},
+		{"unknown kind", func(s *TaskSpec) { s.Kind = "Frobnicate" }, true},
+		{"no payload", func(s *TaskSpec) { s.GovSoftwareUpgrade = nil }, true},
+		{
+			"two payloads",
+			func(s *TaskSpec) { s.GovVote = &GovVote{} },
+			true,
+		},
+		{
+			"payload mismatches kind",
+			func(s *TaskSpec) {
+				s.GovSoftwareUpgrade = nil
+				s.GovVote = &GovVote{}
+			},
+			true,
+		},
+		{
+			"vote valid",
+			func(s *TaskSpec) {
+				s.Kind = TaskGovVote
+				s.GovSoftwareUpgrade = nil
+				s.GovVote = &GovVote{ProposalID: 1, Option: VoteYes}
+			},
+			false,
+		},
+		{
+			"await valid",
+			func(s *TaskSpec) {
+				s.Kind = TaskAwaitNodesAtHeight
+				s.GovSoftwareUpgrade = nil
+				s.AwaitNodesAtHeight = &AwaitNodesAtHeight{TargetHeight: 100}
+			},
+			false,
+		},
+		{
+			"update-image valid",
+			func(s *TaskSpec) {
+				s.Kind = TaskUpdateNodeImage
+				s.GovSoftwareUpgrade = nil
+				s.UpdateNodeImage = &UpdateNodeImage{Image: "img:v2"}
+			},
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := good
+			tc.mut(&s)
+			if err := validateTaskSpec(s); (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/sdk/sei/task_test.go
+++ b/sdk/sei/task_test.go
@@ -1,6 +1,9 @@
 package sei
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestValidateTaskSpec(t *testing.T) {
 	good := TaskSpec{
@@ -14,9 +17,9 @@ func TestValidateTaskSpec(t *testing.T) {
 		mut     func(*TaskSpec)
 		wantErr bool
 	}{
-		{"valid", func(*TaskSpec) {}, false},
-		{"missing name", func(s *TaskSpec) { s.Name = "" }, true},
-		{"missing node", func(s *TaskSpec) { s.Node = "" }, true},
+		{"ok", func(*TaskSpec) {}, false},
+		{"no name", func(s *TaskSpec) { s.Name = "" }, true},
+		{"no node", func(s *TaskSpec) { s.Node = "" }, true},
 		{"unknown kind", func(s *TaskSpec) { s.Kind = "Frobnicate" }, true},
 		{"no payload", func(s *TaskSpec) { s.GovSoftwareUpgrade = nil }, true},
 		{
@@ -40,6 +43,20 @@ func TestValidateTaskSpec(t *testing.T) {
 				s.GovVote = &GovVote{ProposalID: 1, Option: VoteYes}
 			},
 			false,
+		},
+		{
+			"vote bad option",
+			func(s *TaskSpec) {
+				s.Kind = TaskGovVote
+				s.GovSoftwareUpgrade = nil
+				s.GovVote = &GovVote{ProposalID: 1, Option: "maybe"}
+			},
+			true,
+		},
+		{
+			"sub-second timeout",
+			func(s *TaskSpec) { s.Timeout = 500 * time.Millisecond },
+			true,
 		},
 		{
 			"await valid",


### PR DESCRIPTION
## What

Adds the SeiNode-specific **task surface** the integration harness needs to drive `TestChainUpgrade` / `TestRelease` in statement order, replacing the Chaos-Mesh Workflow DAG + env-file output handoffs the seitask-runner used.

- `Client.RunTask(ctx, TaskSpec)` SSA-applies one SeiNodeTask against a target SeiNode → `*Task`
- `Task.WaitComplete(ctx)` polls status to a terminal phase → typed `*TaskOutputs` (or the recorded failure reason)
- Core stays apimachinery-free (SDK-native payloads); `provider/k8s` translates to the CRD — mirrors `CreateNetwork`/`CreateNode`
- Scoped (YAGNI) to the four kinds the upgrade/release suites drive: `GovSoftwareUpgrade`, `GovVote`, `AwaitNodesAtHeight`, `UpdateNodeImage`. local/docker stubs return `ErrNotImplemented`.

## Review

Full Coral slate (kubernetes-specialist / idiomatic-reviewer / systems-engineer + sei-network-specialist as **dissenter**), blinded. The dissenter **blocked** the first cut and caught two correctness defects, both fixed here without controller changes:

1. **ProposalID handoff was a lie** — the controller's `populateOutputs` writes outputs only for `UpdateNodeImage`; gov/await kinds coordinate **chain-as-medium**. Removed the always-empty gov/await output types; `TaskOutputs` now surfaces only the kind the controller populates.
2. **`UpdateNodeImage` RequirePhase guidance was backwards** — the gate is exact-equality and a node halted at an upgrade height stays `Running`, so the default is correct. Removed the relax-to-`Pending` advice + its test.

Plus: `WaitComplete` tolerates transient Get errors over its minutes-long wait; `validateTaskSpec` rejects bad `GovVote.Option` and sub-second `Timeout`; `taskFailureReason` hardened; resubmit/idempotency + deposit/voting-period traps documented.

Ledger: `sdk/sei/.xreview/sdk-task-surface.md`

## Test

`go build/vet ./sdk/...`, `go test ./sdk/sei/...`, `golangci-lint run ./sdk/...` — all green, 0 lint issues. New table-driven coverage for `validateTaskSpec`, `renderTask`, and `translateTaskOutputs`. Live end-to-end exercise lands with `TestChainUpgrade` (Step 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)