### PR TITLE
feat(test): TestChainUpgrade — major upgrade via the SDK task surface (WS-I)

### DIFF
--- a/sdk/sei/provider/k8s/render.go
+++ b/sdk/sei/provider/k8s/render.go
@@ -132,6 +132,7 @@ func renderTask(spec sei.TaskSpec, namespace string) *seiv1alpha1.SeiNodeTask {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      spec.Name,
 			Namespace: namespace,
+			Labels:    maps.Clone(spec.Labels), // nil-safe; caller GC/run-id selector
 		},
 		Spec: seiv1alpha1.SeiNodeTaskSpec{
 			Kind:           seiv1alpha1.SeiNodeTaskKind(spec.Kind),

--- a/sdk/sei/provider/k8s/render_task_test.go
+++ b/sdk/sei/provider/k8s/render_task_test.go
@@ -21,6 +21,7 @@ func TestRenderTask_GovSoftwareUpgrade(t *testing.T) {
 		Node:      testTaskNode,
 		Kind:      sei.TaskGovSoftwareUpgrade,
 		Timeout:   90 * time.Second,
+		Labels:    map[string]string{testRunLabel: testRunID},
 		GovSoftwareUpgrade: &sei.GovSoftwareUpgrade{
 			ChainID:        testNet,
 			Title:          "v2 upgrade",
@@ -36,6 +37,10 @@ func TestRenderTask_GovSoftwareUpgrade(t *testing.T) {
 
 	if task.Name != "upgrade" || task.Namespace != testNS {
 		t.Fatalf("metadata = %s/%s", task.Namespace, task.Name)
+	}
+	// Caller labels (the run-id GC selector) are stamped on the task object.
+	if got := task.Labels[testRunLabel]; got != testRunID {
+		t.Errorf("task label %s = %q, want %q", testRunLabel, got, testRunID)
 	}
 	if string(task.Spec.Kind) != sei.TaskGovSoftwareUpgrade {
 		t.Errorf("kind = %q, want %q", task.Spec.Kind, sei.TaskGovSoftwareUpgrade)

--- a/sdk/sei/readiness.go
+++ b/sdk/sei/readiness.go
@@ -65,6 +65,14 @@ func WaitCaughtUp(ctx context.Context, hc *http.Client, tmRPC string) error {
 	})
 }
 
+// LatestHeight reads tmRPC's committed block height from /status. ok=false on an
+// unreachable endpoint or unparseable body (the caller keeps polling). It accepts
+// both the enveloped and unwrapped /status shapes the Sei fork emits, so callers
+// need not re-model that quirk — the readiness/wait family's one height reader.
+func LatestHeight(ctx context.Context, hc *http.Client, tmRPC string) (int64, bool) {
+	return latestHeight(ctx, hc, tmRPC)
+}
+
 // latestHeight reads tmRPC's committed block height from /status. ok=false on an
 // unreachable endpoint or unparseable body (keep polling).
 func latestHeight(ctx context.Context, hc *http.Client, tmRPC string) (int64, bool) {

--- a/sdk/sei/task.go
+++ b/sdk/sei/task.go
@@ -53,6 +53,11 @@ type TaskSpec struct {
 	Kind      string        // -> spec.kind; one of the Task* consts
 	Timeout   time.Duration // -> spec.timeoutSeconds (truncated to whole seconds); 0 leaves the CRD unbounded default
 
+	// Labels are extra labels on the SeiNodeTask object — e.g. a caller's
+	// run-id/GC selector so a sweep can reap a run's tasks (which are not children
+	// of any provisioned resource and so are not cascade-deleted).
+	Labels map[string]string
+
 	// RequirePhase is the SeiNode phase the target must be in before the task
 	// dispatches; "" leaves the CRD default (Running). The controller gates on
 	// EXACT equality (phase == RequirePhase), not a floor — so set this only when

--- a/test/integration/.xreview/upgrade-suite.md
+++ b/test/integration/.xreview/upgrade-suite.md
@@ -1,0 +1,41 @@
+# xreview ledger — TestChainUpgrade (WS-I Step 5)
+
+Class: component (integration suite consuming the SDK + harness)
+Tier: T2
+
+Target: `test/integration/upgrade_test.go`
+Artifact: branch `feat/test-chain-upgrade`
+
+## Round 1
+
+State: RESOLVED
+OpenFindings: 0
+Convergence: independent (4 blinded reviewers)
+Blinded: yes
+Dissenter: sei-network-specialist (DISSENT → resolved)
+
+Slate: sei-network-specialist (dissenter, upgrade mechanics), systems-engineer (concurrency/poll/error), kubernetes-specialist (re-apply/targeting), idiomatic-reviewer.
+
+### Boundary table
+
+| Boundary | Status | Evidence | Raised by | Resolution |
+|---|---|---|---|---|
+| Halt detection (step 5) | **MISMATCH → FIXED** | Scenario uses a fixed wait, NOT a poll — validators halt together and stop serving RPC exactly when the predicate is true (major-upgrade.yaml:380-392); aggregate VIP drops NotReady backends at halt → black hole. My pollHeightAtLeast(aggregate, upgradeHeight-1) hangs/flakes. | dissenter | Poll aggregate only to a PRE-halt height (upgradeHeight-haltMargin, endpoint still alive), then a bounded settle for the halt; bump after. |
+| Proposal-resolve JSON shape | **MISMATCH → FIXED** | Scenario jq matches content.plan.name OR messages[].content.plan.name (legacy+v1, :177-200); my struct only decodes content → hangs on gov v1. | dissenter | govProposal decodes both arms; matcher checks both. |
+| Recovery gate soundness | **MISMATCH → FIXED** | waitValidatorsReady = PodReady ≠ rejoined-consensus-on-new-binary (brief-Ready-then-CrashLoop slips through). | k8s, dissenter | Replaced with RunTask(AwaitNodesAtHeight{upgradeHeight+postDelta}) per validator (port-faithful to scenario step 9, semantic, targets by NodeRef — no pod-label dependence) + a definitive /cosmos/upgrade applied-plan assertion. |
+| False-pass on fast blocks | **MISSING → FIXED** | No assertion the upgrade actually executed; fast blocks → chain passes upgradeHeight while voting → no plan → no halt → WaitHeightAdvances greens a never-upgraded chain. | dissenter | Added waitUpgradeApplied (/cosmos/upgrade/v1beta1/applied_plan/{name} height>0) — proves the handler ran. |
+| Enveloped-only /status decode | **MISMATCH → FIXED** | pollHeight re-models /status wrapped-only; the Sei fork sometimes answers unwrapped (SDK latestHeight handles both) → spins forever on such a node. | idiom | Promote SDK latestHeight → exported sei.LatestHeight (dual-shape); suite consumes it. |
+| Diagnosability of timeouts | **MISMATCH → FIXED** | Poll helpers swallow last-seen height/status into bare deadline errors — below the WaitHeightAdvances bar; suite is unattended-nightly. | systems | pollREST threads a last-seen string into the deadline error; height polls use LatestHeight's value. |
+| Task GC label | **MISSING → FIXED** | Task CRs carry no sei.io/harness-run label → leak on abnormal exit. | k8s | Added SDK TaskSpec.Labels (mirrors NetworkSpec.Labels); suite stamps runLabelKey. |
+| Vote error fan-in | flag → FIXED | Only first-in-slice error surfaced. | systems, idiom | errors.Join across all validators. |
+| NetworkSpec drift (provision vs bump) | flag → FIXED | Two hand-duplicated literals; a future field added to one strips it on the other via ForceOwnership. | systems, k8s | Single networkSpec builder; bump mutates only Image. |
+| Image bump full-spec SSA re-apply | COMPATIBLE | k8s read the controller: it never writes the parent spec (finalizer + status only); genesis re-stamp idempotent (ceremony latched, nodes.go:91); no replica churn; no SSA conflict. Verified equivalent to `patch spec.image`. | k8s (refutes dissenter concern) | Kept; builder shared. |
+| Concurrency / leaks / SIGTERM | COMPATIBLE | Race-free vote fan-out, body closed, ctx nesting + NotifyContext match sibling suites. | systems | — |
+| Validator naming / namespace co-location | COMPATIBLE | <chain>-<ordinal> 0-based matches controller labels.go; task/target/pods co-located. | k8s | — |
+
+### Idiom addendum (RATIFY)
+Reads native (env+spec idiom, helpers, comment register, build-tag). Divergence-with-consequence = the /status + poll duplication of the SDK (resolved by exporting LatestHeight; gov-REST polling stays harness-local as gov-query orchestration, not readiness — matches the scope rule).
+
+### Deferred (not blocking)
+- Parent 60m can fire mid-child-step → misattributed error (systems): generous envelope; un-defer on first spurious occurrence.
+- min_deposit / deposit-period hang (dissenter): params match the proven scenario (20000000usei clears min_deposit); the last-seen diagnostic surfaces a stuck deposit-period proposal if it ever regresses.

--- a/test/integration/upgrade_test.go
+++ b/test/integration/upgrade_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os/signal"
@@ -19,7 +20,7 @@ import (
 
 // Gov tx parameters for the upgrade flow, ported from the major-upgrade scenario
 // (scenarios/major-upgrade.yaml). usei-only; the deposit must clear the chain's
-// min_deposit so the proposal enters voting immediately.
+// min_deposit so the proposal enters voting immediately (not the deposit period).
 const (
 	upgradeDeposit = "20000000usei"
 	govFees        = "10000usei"
@@ -27,26 +28,56 @@ const (
 	voteGas        = 200000
 )
 
-// upgradeHeightDelta is how many blocks ahead of the current height the upgrade
-// is scheduled — wide enough that the proposal clears the (shortened) voting
-// period and passes before the chain reaches it. Env-overridable for faster or
-// slower chains.
-const defaultUpgradeHeightDelta = 200
+const (
+	// defaultUpgradeHeightDelta schedules the upgrade this many blocks ahead of
+	// the current height — wide enough that the proposal clears the shortened
+	// voting period and passes before the chain reaches it. At Sei's ~600ms-1s
+	// blocks, 200 blocks comfortably outlasts the 60s voting period + tally;
+	// env-overridable for faster/slower chains. The whole flow's safety rests on
+	// this margin, so it must stay generous (see TestChainUpgrade).
+	defaultUpgradeHeightDelta = 200
+	// minUpgradeHeightDelta guards against a misconfigured delta too small for the
+	// pre-halt poll margin below.
+	minUpgradeHeightDelta = 30
+	// haltPollMargin is how many blocks BEFORE the upgrade height the suite stops
+	// polling: it polls the (load-balanced) aggregate RPC only while the chain is
+	// still serving, then settles. At the halt itself every validator stops
+	// serving RPC simultaneously, so the halt height is unpollable (the scenario
+	// uses a fixed wait for the same reason) — polling to a pre-halt height keeps
+	// the endpoint alive while still confirming the chain is about to halt.
+	haltPollMargin = 10
+	// haltSettle bounds the wait, after the chain reaches the pre-halt height, for
+	// the remaining blocks to commit and every validator to halt at the upgrade
+	// height. Over-waiting is free (the chain sits halted until the image bump);
+	// the only failure is waiting too short, so this is sized with slack.
+	haltSettle = 90 * time.Second
+	// postUpgradeProgress is how many blocks past the upgrade height each
+	// validator must reach to prove it resumed on the new binary.
+	postUpgradeProgress = 10
+)
 
-// votingPeriodOverride shortens the genesis gov voting period so the proposal
-// passes within the upgradeHeightDelta window rather than the multi-day default.
+// votingPeriodGenesis shortens the genesis gov voting period so the proposal
+// passes within the upgrade-height window rather than the multi-day default.
 var votingPeriodGenesis = map[string]string{
 	"gov.voting_params.voting_period": "60s",
 }
 
+// restUnreachable is the last-seen note when a gov REST poll gets no 200.
+const restUnreachable = "REST unreachable / non-200"
+
 // TestChainUpgrade drives a Sei major software upgrade end-to-end through the SDK
 // task surface, replacing the Chaos-Mesh Workflow DAG: provision a 4-validator
 // chain on the pre-upgrade image -> submit a GovSoftwareUpgrade proposal ->
-// resolve its ID from the chain (chain-as-medium) -> vote yes from every
-// validator -> wait for it to pass -> let the chain halt at the upgrade height ->
-// bump the SeiNetwork image to the post-upgrade build -> assert the chain
-// resumes past the upgrade height. The upgrade height is chosen so the proposal
-// passes before the chain reaches it.
+// resolve its ID from the chain's gov REST (chain-as-medium, since the controller
+// does not surface it as a task output) -> vote yes from every validator -> wait
+// for it to pass -> let the chain halt at the upgrade height -> bump the
+// SeiNetwork image to the post-upgrade build -> assert the upgrade handler ran
+// and every validator resumed past the upgrade height.
+//
+// The upgrade height is scheduled far enough ahead (defaultUpgradeHeightDelta)
+// that the proposal passes before the chain reaches it; the upgrade-applied check
+// (waitUpgradeApplied) is the safety net that fails loud if a too-fast chain
+// passed the height while still voting (no plan scheduled, no real upgrade).
 //
 // Inputs (env): SEI_CHAIN_ID (base), SEID_IMAGE (pre-upgrade) [required],
 // SEID_UPGRADE_IMAGE (post-upgrade) [required], SEI_UPGRADE_NAME (the upgrade
@@ -60,6 +91,9 @@ func TestChainUpgrade(t *testing.T) {
 	upgradeName := mustEnv(t, "SEI_UPGRADE_NAME")
 	ns := envOr("SEI_NAMESPACE", "")
 	delta := int64(envInt(t, "UPGRADE_HEIGHT_DELTA", defaultUpgradeHeightDelta))
+	if delta < minUpgradeHeightDelta {
+		t.Fatalf("UPGRADE_HEIGHT_DELTA %d below minimum %d", delta, minUpgradeHeightDelta)
+	}
 
 	const validators = 4
 	s := spec{
@@ -69,38 +103,44 @@ func TestChainUpgrade(t *testing.T) {
 		seidImage:  preImage,
 		validators: validators,
 		// No RPC followers: the aggregate network endpoints serve the gov REST
-		// queries + height polls, and the validators are the vote targets.
+		// queries + pre-halt height polls, and the validators are the vote targets
+		// and the per-node post-upgrade liveness targets.
 		rpcNodes: 0,
-		timeout:  60 * time.Minute,
 		// No storageConfig override: the upgrade/migration path is what this suite
 		// exercises, so it runs the controller's default storage mode.
 	}
+	runLabels := map[string]string{runLabelKey: s.runID}
 
-	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
 	defer cancel()
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
 	c := openClient(ctx, t)
-	cs := clientset(t)
 
 	// Provision on the pre-upgrade image with a shortened voting period so the
 	// proposal can pass inside the upgrade-height window.
-	ch, err := provisionUpgrade(ctx, t, c, s)
+	ch := &chain{}
 	cleanupChain(t, ch)
+	net, err := c.CreateNetwork(ctx, networkSpec(s, preImage, runLabels))
 	if err != nil {
-		t.Fatalf("provision: %v", err)
+		t.Fatalf("create network %q: %v", chainID, err)
 	}
-	netNS := ch.network.Namespace()
-	tmRPC := ch.network.TendermintRPC()
+	ch.network = net
+	if err := net.WaitReady(ctx); err != nil {
+		t.Fatalf("network %q ready: %v", chainID, err)
+	}
+	t.Logf("network %s: ready (%d validators, pre-upgrade image)", chainID, validators)
+
+	tmRPC := ch.network.TendermintRPC() // aggregate endpoint; name/namespace-derived, stable across the image bump
 	rest := ch.network.REST()
 	hc := &http.Client{Timeout: 15 * time.Second}
 
 	// Schedule the upgrade comfortably ahead of the current height so the 60s
 	// voting period elapses and the proposal passes before the chain halts.
-	cur, err := pollHeight(ctx, hc, tmRPC)
-	if err != nil {
-		t.Fatalf("read current height: %v", err)
+	cur, ok := sei.LatestHeight(ctx, hc, tmRPC)
+	if !ok {
+		t.Fatalf("read current height from %s", tmRPC)
 	}
 	upgradeHeight := cur + delta
 	t.Logf("current height %d; scheduling upgrade %q at height %d", cur, upgradeName, upgradeHeight)
@@ -113,6 +153,7 @@ func TestChainUpgrade(t *testing.T) {
 		Node:      proposer,
 		Kind:      sei.TaskGovSoftwareUpgrade,
 		Timeout:   8 * time.Minute,
+		Labels:    runLabels,
 		GovSoftwareUpgrade: &sei.GovSoftwareUpgrade{
 			ChainID:        chainID,
 			Title:          "integration upgrade " + upgradeName,
@@ -135,7 +176,7 @@ func TestChainUpgrade(t *testing.T) {
 	t.Logf("resolved proposal id %d", proposalID)
 
 	// 3) Vote yes from every validator in parallel.
-	voteAllValidators(ctx, t, c, chainID, ns, validators, proposalID)
+	voteAllValidators(ctx, t, c, chainID, ns, validators, proposalID, runLabels)
 	t.Logf("all %d validators voted yes on proposal %d", validators, proposalID)
 
 	// 4) Wait for the proposal to pass.
@@ -144,89 +185,76 @@ func TestChainUpgrade(t *testing.T) {
 	}
 	t.Logf("proposal %d passed", proposalID)
 
-	// 5) Let the chain reach the upgrade height and halt (it commits up to
-	// upgradeHeight-1 and stops producing the upgrade block).
-	haltCtx, cancelHalt := context.WithTimeout(ctx, 15*time.Minute)
-	err = pollHeightAtLeast(haltCtx, hc, tmRPC, upgradeHeight-1)
-	cancelHalt()
+	// 5) Wait for the chain to approach the upgrade height, then settle for the
+	// halt. The halt height itself is unpollable (all validators stop serving RPC
+	// at once), so poll the aggregate only to a pre-halt height (still serving),
+	// then settle a bounded time for the final blocks + halt. The image bump must
+	// land only after the halt: the post binary panics if it processes any block
+	// below the upgrade height.
+	preHalt := upgradeHeight - haltPollMargin
+	approachCtx, cancelApproach := context.WithTimeout(ctx, 15*time.Minute)
+	err = pollHeightAtLeast(approachCtx, hc, tmRPC, preHalt)
+	cancelApproach()
 	if err != nil {
-		t.Fatalf("chain did not reach the upgrade halt height %d: %v", upgradeHeight-1, err)
+		t.Fatalf("chain did not approach the upgrade height (target %d): %v", preHalt, err)
 	}
-	t.Logf("chain reached the upgrade height %d and halted", upgradeHeight)
+	t.Logf("chain reached pre-halt height %d; settling %s for the halt at %d", preHalt, haltSettle, upgradeHeight)
+	select {
+	case <-time.After(haltSettle):
+	case <-ctx.Done():
+		t.Fatalf("interrupted while settling for the halt: %v", ctx.Err())
+	}
 
 	// 6) Bump the image by re-applying the SeiNetwork with the post-upgrade build.
-	// A single SeiNetwork patch (not per-node UpdateNodeImage) lets the controller
-	// cascade the new binary to every validator without fighting its own image
-	// re-assertion — the canonical major-upgrade mechanism.
-	bumpNetworkImage(ctx, t, c, s, postImage)
+	// A SeiNetwork re-apply (not per-node UpdateNodeImage) lets the controller
+	// cascade the new binary to every validator; the controller never writes the
+	// parent spec itself, so the SDK's server-side apply does not conflict and the
+	// unchanged fields re-apply idempotently (the genesis ceremony is latched).
+	if _, err := c.CreateNetwork(ctx, networkSpec(s, postImage, runLabels)); err != nil {
+		t.Fatalf("bump network image to %q: %v", postImage, err)
+	}
 	t.Logf("SeiNetwork %s image bumped to %s", chainID, postImage)
 
-	// 7) Recovery: every validator returns to Ready on the new binary, and the
-	// chain produces blocks past the upgrade height.
-	recCtx, cancelRec := context.WithTimeout(ctx, 15*time.Minute)
-	waitValidatorsReady(recCtx, t, cs, netNS, chainID, validators)
-	cancelRec()
-
-	progCtx, cancelProg := context.WithTimeout(ctx, 10*time.Minute)
-	err = sei.WaitHeightAdvances(progCtx, hc, tmRPC, 5)
-	cancelProg()
-	if err != nil {
-		t.Fatalf("chain did not produce blocks past the upgrade: %v", err)
+	// 7) Assert the upgrade actually executed: the x/upgrade module records the
+	// applied plan only when the handler ran at the scheduled height. This fails
+	// loud if a too-fast chain sailed past the upgrade height while still voting
+	// (no plan scheduled), which a liveness-only check would green.
+	if err := waitUpgradeApplied(ctx, hc, rest, upgradeName); err != nil {
+		t.Fatalf("upgrade %q was not applied on-chain: %v", upgradeName, err)
 	}
-	t.Logf("chain advanced past the upgrade — TestChainUpgrade OK")
+	t.Logf("upgrade %q applied on-chain", upgradeName)
+
+	// 8) Recovery: every validator resumed on the new binary and advanced past the
+	// upgrade height. AwaitNodesAtHeight polls each validator's own sidecar
+	// (co-located, not the aggregate RPC), so it is immune to the halt black-hole
+	// and proves each validator individually — not merely "a pod is Ready".
+	target := upgradeHeight + postUpgradeProgress
+	awaitAllValidatorsAtHeight(ctx, t, c, chainID, ns, validators, target, runLabels)
+	t.Logf("all %d validators advanced past the upgrade to height %d — TestChainUpgrade OK", validators, target)
 }
 
-// provisionUpgrade provisions the genesis chain with the shortened voting period.
-// It mirrors provision() but stamps the gov genesis override (CreateNetwork's
-// Genesis map, not Config) and creates no RPC followers.
-func provisionUpgrade(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain, error) {
-	t.Helper()
-	ch := &chain{}
-	net, err := c.CreateNetwork(ctx, sei.NetworkSpec{
-		Name:           s.chainID,
-		Namespace:      s.namespace,
-		Image:          s.seidImage,
-		Validators:     s.validators,
-		Labels:         map[string]string{runLabelKey: s.runID},
-		Genesis:        votingPeriodGenesis,
-		DeletionPolicy: sei.DeletionDelete,
-	})
-	if err != nil {
-		return ch, fmt.Errorf("create network %q: %w", s.chainID, err)
-	}
-	ch.network = net
-	if err := net.WaitReady(ctx); err != nil {
-		return ch, fmt.Errorf("network %q ready: %w", s.chainID, err)
-	}
-	t.Logf("network %s: ready (%d validators, pre-upgrade image)", s.chainID, s.validators)
-	return ch, nil
-}
-
-// bumpNetworkImage re-applies the SeiNetwork with the post-upgrade image. The SDK
-// applies server-side, so re-applying the same spec with a new image patches
-// spec.image and the controller rolls every validator onto the new binary; the
-// unchanged fields (validators, genesis, deletion policy) re-apply idempotently.
-func bumpNetworkImage(ctx context.Context, t *testing.T, c *sei.Client, s spec, image string) {
-	t.Helper()
-	_, err := c.CreateNetwork(ctx, sei.NetworkSpec{
+// networkSpec builds the SeiNetwork spec for the upgrade chain. provision and the
+// image bump share it so a re-apply changes ONLY the image — a field added here
+// can never be silently stripped by the bump's server-side apply.
+func networkSpec(s spec, image string, labels map[string]string) sei.NetworkSpec {
+	return sei.NetworkSpec{
 		Name:           s.chainID,
 		Namespace:      s.namespace,
 		Image:          image,
 		Validators:     s.validators,
-		Labels:         map[string]string{runLabelKey: s.runID},
+		Labels:         labels,
 		Genesis:        votingPeriodGenesis,
 		DeletionPolicy: sei.DeletionDelete,
-	})
-	if err != nil {
-		t.Fatalf("bump network image to %q: %v", image, err)
 	}
 }
 
 // voteAllValidators runs a GovVote task against each validator in parallel and
-// fails the suite if any vote does not complete. A vote clears 2/3 once enough
-// validators have voted; the suite votes all of them.
+// fails the suite (surfacing every failure via errors.Join) if any vote does not
+// complete. A proposal passes once 2/3 have voted; the suite votes all of them so
+// a single unhealthy validator is caught rather than masked.
 func voteAllValidators(
-	ctx context.Context, t *testing.T, c *sei.Client, chainID, ns string, validators int, proposalID uint64,
+	ctx context.Context, t *testing.T, c *sei.Client, chainID, ns string,
+	validators int, proposalID uint64, labels map[string]string,
 ) {
 	t.Helper()
 	var wg sync.WaitGroup
@@ -242,6 +270,7 @@ func voteAllValidators(
 				Node:      node,
 				Kind:      sei.TaskGovVote,
 				Timeout:   8 * time.Minute,
+				Labels:    labels,
 				GovVote: &sei.GovVote{
 					ChainID:    chainID,
 					ProposalID: proposalID,
@@ -254,21 +283,58 @@ func voteAllValidators(
 				errs[i] = fmt.Errorf("%s: run vote: %w", node, err)
 				return
 			}
-			t.Cleanup(func() {
-				delCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
-				defer cancel()
-				_ = task.Delete(delCtx)
-			})
+			registerTaskCleanup(t, task)
 			if _, err := task.WaitComplete(ctx); err != nil {
 				errs[i] = fmt.Errorf("%s: vote: %w", node, err)
 			}
 		}(i)
 	}
 	wg.Wait()
-	for _, err := range errs {
-		if err != nil {
-			t.Fatalf("vote: %v", err)
-		}
+	if err := errors.Join(errs...); err != nil {
+		t.Fatalf("votes: %v", err)
+	}
+}
+
+// awaitAllValidatorsAtHeight runs an AwaitNodesAtHeight task against each
+// validator in parallel — the semantic recovery gate: each validator's sidecar
+// confirms its own local height crossed target on the new binary.
+func awaitAllValidatorsAtHeight(
+	ctx context.Context, t *testing.T, c *sei.Client, chainID, ns string,
+	validators int, target int64, labels map[string]string,
+) {
+	t.Helper()
+	var wg sync.WaitGroup
+	errs := make([]error, validators)
+	for i := range validators {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			node := validatorName(chainID, i)
+			task, err := c.RunTask(ctx, sei.TaskSpec{
+				Name:      taskName(chainID, fmt.Sprintf("await-%d", i)),
+				Namespace: ns,
+				Node:      node,
+				Kind:      sei.TaskAwaitNodesAtHeight,
+				Timeout:   12 * time.Minute,
+				Labels:    labels,
+				// A validator halted at the upgrade height is still phase=Running
+				// (the controller does not demote phase on a transient halt), so the
+				// default RequirePhase=Running is correct here.
+				AwaitNodesAtHeight: &sei.AwaitNodesAtHeight{TargetHeight: target},
+			})
+			if err != nil {
+				errs[i] = fmt.Errorf("%s: run await: %w", node, err)
+				return
+			}
+			registerTaskCleanup(t, task)
+			if _, err := task.WaitComplete(ctx); err != nil {
+				errs[i] = fmt.Errorf("%s: await height %d: %w", node, target, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if err := errors.Join(errs...); err != nil {
+		t.Fatalf("post-upgrade progress: %v", err)
 	}
 }
 
@@ -280,18 +346,24 @@ func runTaskComplete(ctx context.Context, t *testing.T, c *sei.Client, ts sei.Ta
 	if err != nil {
 		t.Fatalf("run task %s (%s): %v", ts.Name, ts.Kind, err)
 	}
-	t.Cleanup(func() {
-		delCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
-		defer cancel()
-		_ = task.Delete(delCtx)
-	})
+	registerTaskCleanup(t, task)
 	if _, err := task.WaitComplete(ctx); err != nil {
 		t.Fatalf("task %s (%s): %v", ts.Name, ts.Kind, err)
 	}
 }
 
+// registerTaskCleanup best-effort deletes a task on a fresh context at test end.
+func registerTaskCleanup(t *testing.T, task *sei.Task) {
+	t.Helper()
+	t.Cleanup(func() {
+		delCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		_ = task.Delete(delCtx)
+	})
+}
+
 // validatorName is the SeiNetwork child-naming contract (controller labels.go):
-// validator SeiNodes are <network>-<ordinal>.
+// validator SeiNodes are <network>-<ordinal>, 0-based.
 func validatorName(chainID string, ordinal int) string {
 	return fmt.Sprintf("%s-%d", chainID, ordinal)
 }
@@ -303,8 +375,10 @@ func taskName(chainID, step string) string {
 
 // --- chain-as-medium gov queries (harness-level: Cosmos gov REST, not SDK) ---
 
-// govProposal models just enough of a gov v1beta1 proposal to resolve an upgrade
-// proposal by its plan name and read its status.
+// govProposal models just enough of a proposal to resolve an upgrade proposal by
+// its plan name and read its status. The legacy (v1beta1) shape carries the plan
+// at content.plan.name; the v1 shape carries it under messages[].content.plan.name
+// — both are accepted, matching the scenario's resolver.
 type govProposal struct {
 	ProposalID string `json:"proposal_id"`
 	Status     string `json:"status"`
@@ -313,35 +387,57 @@ type govProposal struct {
 			Name string `json:"name"`
 		} `json:"plan"`
 	} `json:"content"`
+	Messages []struct {
+		Content struct {
+			Plan struct {
+				Name string `json:"name"`
+			} `json:"plan"`
+		} `json:"content"`
+	} `json:"messages"`
+}
+
+// planName returns the upgrade plan name from whichever shape carries it.
+func (p govProposal) planName() string {
+	if p.Content.Plan.Name != "" {
+		return p.Content.Plan.Name
+	}
+	for _, m := range p.Messages {
+		if m.Content.Plan.Name != "" {
+			return m.Content.Plan.Name
+		}
+	}
+	return ""
 }
 
 // resolveProposalID polls the gov REST endpoint for the voting-period proposal
-// whose upgrade plan name matches upgradeName and returns its ID. The proposal
-// appears a few blocks after submission, so this polls until it shows up or ctx
-// fires.
+// whose upgrade plan name matches upgradeName and returns its ID.
 func resolveProposalID(ctx context.Context, hc *http.Client, rest, upgradeName string) (uint64, error) {
 	// proposal_status=2 is PROPOSAL_STATUS_VOTING_PERIOD.
 	endpoint := rest + "/cosmos/gov/v1beta1/proposals?proposal_status=2"
+	what := fmt.Sprintf("resolve proposal id for %q", upgradeName)
 	var found uint64
-	err := pollREST(ctx, "resolve proposal id", func(ctx context.Context) (bool, error) {
+	err := pollREST(ctx, what, func(ctx context.Context) (bool, string, error) {
 		var body struct {
 			Proposals []govProposal `json:"proposals"`
 		}
 		if !getJSONInto(ctx, hc, endpoint, &body) {
-			return false, nil
+			return false, restUnreachable, nil
 		}
 		for _, p := range body.Proposals {
-			if p.Content.Plan.Name != upgradeName {
+			if p.planName() != upgradeName {
 				continue
 			}
 			id, err := strconv.ParseUint(p.ProposalID, 10, 64)
 			if err != nil {
-				return false, fmt.Errorf("unparseable proposal id %q: %w", p.ProposalID, err)
+				return false, "", fmt.Errorf("unparseable proposal id %q: %w", p.ProposalID, err)
 			}
 			found = id
-			return true, nil
+			return true, "", nil
 		}
-		return false, nil
+		// None matched: a proposal stuck in the deposit period (deposit below
+		// min_deposit) never reaches the status=2 set polled here.
+		seen := fmt.Sprintf("%d voting-period proposals, none match plan %q", len(body.Proposals), upgradeName)
+		return false, seen, nil
 	})
 	return found, err
 }
@@ -350,81 +446,84 @@ func resolveProposalID(ctx context.Context, hc *http.Client, rest, upgradeName s
 // fast if it lands in a terminal non-passed state (REJECTED/FAILED).
 func waitProposalPassed(ctx context.Context, hc *http.Client, rest string, id uint64) error {
 	endpoint := fmt.Sprintf("%s/cosmos/gov/v1beta1/proposals/%d", rest, id)
-	return pollREST(ctx, fmt.Sprintf("proposal %d passed", id), func(ctx context.Context) (bool, error) {
+	return pollREST(ctx, fmt.Sprintf("proposal %d passed", id), func(ctx context.Context) (bool, string, error) {
 		var body struct {
 			Proposal govProposal `json:"proposal"`
 		}
 		if !getJSONInto(ctx, hc, endpoint, &body) {
-			return false, nil
+			return false, restUnreachable, nil
 		}
 		switch body.Proposal.Status {
 		case "PROPOSAL_STATUS_PASSED":
-			return true, nil
+			return true, "", nil
 		case "PROPOSAL_STATUS_REJECTED", "PROPOSAL_STATUS_FAILED":
-			return false, fmt.Errorf("proposal %d reached terminal status %s", id, body.Proposal.Status)
+			return false, "", fmt.Errorf("proposal %d reached terminal status %s", id, body.Proposal.Status)
 		default:
-			return false, nil
+			return false, "status " + body.Proposal.Status, nil
 		}
 	})
 }
 
-// --- height polling (harness-level TM /status) ---
-
-// pollHeight returns the chain's current latest block height once.
-func pollHeight(ctx context.Context, hc *http.Client, tmRPC string) (int64, error) {
-	var h int64
-	err := pollREST(ctx, "read height", func(ctx context.Context) (bool, error) {
+// waitUpgradeApplied polls the x/upgrade applied-plan endpoint until the named
+// upgrade reports a non-zero applied height — proof the upgrade handler ran at the
+// scheduled height (not merely that the chain is alive).
+func waitUpgradeApplied(ctx context.Context, hc *http.Client, rest, upgradeName string) error {
+	endpoint := fmt.Sprintf("%s/cosmos/upgrade/v1beta1/applied_plan/%s", rest, upgradeName)
+	return pollREST(ctx, fmt.Sprintf("upgrade %q applied", upgradeName), func(ctx context.Context) (bool, string, error) {
 		var body struct {
-			Result struct {
-				SyncInfo struct {
-					LatestBlockHeight string `json:"latest_block_height"`
-				} `json:"sync_info"`
-			} `json:"result"`
+			Height string `json:"height"`
 		}
-		if !getJSONInto(ctx, hc, tmRPC+"/status", &body) {
-			return false, nil
+		if !getJSONInto(ctx, hc, endpoint, &body) {
+			return false, restUnreachable, nil
 		}
-		v, err := strconv.ParseInt(body.Result.SyncInfo.LatestBlockHeight, 10, 64)
-		if err != nil {
-			return false, nil
+		h, err := strconv.ParseInt(body.Height, 10, 64)
+		if err != nil || h <= 0 {
+			return false, "applied height " + body.Height, nil
 		}
-		h = v
-		return true, nil
+		return true, "", nil
 	})
-	return h, err
 }
+
+// --- height polling (harness-level, via the SDK's dual-shape /status reader) ---
 
 // pollHeightAtLeast blocks until the chain's latest height reaches target. Unlike
-// sei.WaitHeightAdvances (a relative +delta) this waits for an absolute height —
-// used to detect the chain arriving at the upgrade halt.
+// sei.WaitHeightAdvances (a relative +delta) this waits for an absolute height,
+// reading via sei.LatestHeight so it handles both /status shapes the Sei fork
+// emits.
 func pollHeightAtLeast(ctx context.Context, hc *http.Client, tmRPC string, target int64) error {
-	return pollREST(ctx, fmt.Sprintf("height >= %d", target), func(ctx context.Context) (bool, error) {
-		h, err := pollHeight(ctx, hc, tmRPC)
-		if err != nil {
-			return false, nil
+	return pollREST(ctx, fmt.Sprintf("height >= %d", target), func(ctx context.Context) (bool, string, error) {
+		h, ok := sei.LatestHeight(ctx, hc, tmRPC)
+		if !ok {
+			return false, "RPC unreachable", nil
 		}
-		return h >= target, nil
+		return h >= target, fmt.Sprintf("height %d", h), nil
 	})
 }
 
 // --- small polling + HTTP helpers ---
 
-// pollREST ticks done() every 3s until it returns true or ctx fires. A done()
-// error aborts (a terminal condition); a false keeps polling.
-func pollREST(ctx context.Context, what string, done func(context.Context) (bool, error)) error {
+// pollREST ticks done() every 3s until it returns true or ctx fires. done returns
+// (satisfied, lastSeen, err): a non-nil err aborts (a terminal condition); else
+// false keeps polling and lastSeen is folded into the timeout error so an
+// unattended deadline is debuggable (e.g. "height 1187" or "status VOTING").
+func pollREST(ctx context.Context, what string, done func(context.Context) (bool, string, error)) error {
 	tick := time.NewTicker(3 * time.Second)
 	defer tick.Stop()
+	var lastSeen string
 	for {
-		ok, err := done(ctx)
+		ok, seen, err := done(ctx)
 		if err != nil {
 			return fmt.Errorf("%s: %w", what, err)
 		}
 		if ok {
 			return nil
 		}
+		if seen != "" {
+			lastSeen = seen
+		}
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("%s: not satisfied before deadline: %w", what, ctx.Err())
+			return fmt.Errorf("%s: not satisfied before deadline (last: %s): %w", what, lastSeen, ctx.Err())
 		case <-tick.C:
 		}
 	}

--- a/test/integration/upgrade_test.go
+++ b/test/integration/upgrade_test.go
@@ -1,0 +1,450 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
+)
+
+// Gov tx parameters for the upgrade flow, ported from the major-upgrade scenario
+// (scenarios/major-upgrade.yaml). usei-only; the deposit must clear the chain's
+// min_deposit so the proposal enters voting immediately.
+const (
+	upgradeDeposit = "20000000usei"
+	govFees        = "10000usei"
+	proposeGas     = 500000
+	voteGas        = 200000
+)
+
+// upgradeHeightDelta is how many blocks ahead of the current height the upgrade
+// is scheduled — wide enough that the proposal clears the (shortened) voting
+// period and passes before the chain reaches it. Env-overridable for faster or
+// slower chains.
+const defaultUpgradeHeightDelta = 200
+
+// votingPeriodOverride shortens the genesis gov voting period so the proposal
+// passes within the upgradeHeightDelta window rather than the multi-day default.
+var votingPeriodGenesis = map[string]string{
+	"gov.voting_params.voting_period": "60s",
+}
+
+// TestChainUpgrade drives a Sei major software upgrade end-to-end through the SDK
+// task surface, replacing the Chaos-Mesh Workflow DAG: provision a 4-validator
+// chain on the pre-upgrade image -> submit a GovSoftwareUpgrade proposal ->
+// resolve its ID from the chain (chain-as-medium) -> vote yes from every
+// validator -> wait for it to pass -> let the chain halt at the upgrade height ->
+// bump the SeiNetwork image to the post-upgrade build -> assert the chain
+// resumes past the upgrade height. The upgrade height is chosen so the proposal
+// passes before the chain reaches it.
+//
+// Inputs (env): SEI_CHAIN_ID (base), SEID_IMAGE (pre-upgrade) [required],
+// SEID_UPGRADE_IMAGE (post-upgrade) [required], SEI_UPGRADE_NAME (the upgrade
+// handler name registered in the post image) [required]; SEI_NAMESPACE,
+// UPGRADE_HEIGHT_DELTA [optional]. Run with -test.timeout 0 (see TestBenchmark).
+func TestChainUpgrade(t *testing.T) {
+	requireCluster(t)
+	chainID := mustEnv(t, "SEI_CHAIN_ID")
+	preImage := mustEnv(t, "SEID_IMAGE")
+	postImage := mustEnv(t, "SEID_UPGRADE_IMAGE")
+	upgradeName := mustEnv(t, "SEI_UPGRADE_NAME")
+	ns := envOr("SEI_NAMESPACE", "")
+	delta := int64(envInt(t, "UPGRADE_HEIGHT_DELTA", defaultUpgradeHeightDelta))
+
+	const validators = 4
+	s := spec{
+		chainID:    chainID,
+		runID:      chainID,
+		namespace:  ns,
+		seidImage:  preImage,
+		validators: validators,
+		// No RPC followers: the aggregate network endpoints serve the gov REST
+		// queries + height polls, and the validators are the vote targets.
+		rpcNodes: 0,
+		timeout:  60 * time.Minute,
+		// No storageConfig override: the upgrade/migration path is what this suite
+		// exercises, so it runs the controller's default storage mode.
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	defer cancel()
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	c := openClient(ctx, t)
+	cs := clientset(t)
+
+	// Provision on the pre-upgrade image with a shortened voting period so the
+	// proposal can pass inside the upgrade-height window.
+	ch, err := provisionUpgrade(ctx, t, c, s)
+	cleanupChain(t, ch)
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	netNS := ch.network.Namespace()
+	tmRPC := ch.network.TendermintRPC()
+	rest := ch.network.REST()
+	hc := &http.Client{Timeout: 15 * time.Second}
+
+	// Schedule the upgrade comfortably ahead of the current height so the 60s
+	// voting period elapses and the proposal passes before the chain halts.
+	cur, err := pollHeight(ctx, hc, tmRPC)
+	if err != nil {
+		t.Fatalf("read current height: %v", err)
+	}
+	upgradeHeight := cur + delta
+	t.Logf("current height %d; scheduling upgrade %q at height %d", cur, upgradeName, upgradeHeight)
+
+	// 1) Submit the upgrade proposal from validator-0.
+	proposer := validatorName(chainID, 0)
+	runTaskComplete(ctx, t, c, sei.TaskSpec{
+		Name:      taskName(chainID, "propose"),
+		Namespace: ns,
+		Node:      proposer,
+		Kind:      sei.TaskGovSoftwareUpgrade,
+		Timeout:   8 * time.Minute,
+		GovSoftwareUpgrade: &sei.GovSoftwareUpgrade{
+			ChainID:        chainID,
+			Title:          "integration upgrade " + upgradeName,
+			Description:    "harness major-upgrade scenario",
+			UpgradeName:    upgradeName,
+			UpgradeHeight:  upgradeHeight,
+			InitialDeposit: upgradeDeposit,
+			Fees:           govFees,
+			Gas:            proposeGas,
+		},
+	})
+	t.Logf("upgrade proposal submitted from %s", proposer)
+
+	// 2) Resolve the proposal ID from the chain — the controller does not surface
+	// it as a task output (chain-as-medium).
+	proposalID, err := resolveProposalID(ctx, hc, rest, upgradeName)
+	if err != nil {
+		t.Fatalf("resolve proposal id: %v", err)
+	}
+	t.Logf("resolved proposal id %d", proposalID)
+
+	// 3) Vote yes from every validator in parallel.
+	voteAllValidators(ctx, t, c, chainID, ns, validators, proposalID)
+	t.Logf("all %d validators voted yes on proposal %d", validators, proposalID)
+
+	// 4) Wait for the proposal to pass.
+	if err := waitProposalPassed(ctx, hc, rest, proposalID); err != nil {
+		t.Fatalf("proposal %d did not pass: %v", proposalID, err)
+	}
+	t.Logf("proposal %d passed", proposalID)
+
+	// 5) Let the chain reach the upgrade height and halt (it commits up to
+	// upgradeHeight-1 and stops producing the upgrade block).
+	haltCtx, cancelHalt := context.WithTimeout(ctx, 15*time.Minute)
+	err = pollHeightAtLeast(haltCtx, hc, tmRPC, upgradeHeight-1)
+	cancelHalt()
+	if err != nil {
+		t.Fatalf("chain did not reach the upgrade halt height %d: %v", upgradeHeight-1, err)
+	}
+	t.Logf("chain reached the upgrade height %d and halted", upgradeHeight)
+
+	// 6) Bump the image by re-applying the SeiNetwork with the post-upgrade build.
+	// A single SeiNetwork patch (not per-node UpdateNodeImage) lets the controller
+	// cascade the new binary to every validator without fighting its own image
+	// re-assertion — the canonical major-upgrade mechanism.
+	bumpNetworkImage(ctx, t, c, s, postImage)
+	t.Logf("SeiNetwork %s image bumped to %s", chainID, postImage)
+
+	// 7) Recovery: every validator returns to Ready on the new binary, and the
+	// chain produces blocks past the upgrade height.
+	recCtx, cancelRec := context.WithTimeout(ctx, 15*time.Minute)
+	waitValidatorsReady(recCtx, t, cs, netNS, chainID, validators)
+	cancelRec()
+
+	progCtx, cancelProg := context.WithTimeout(ctx, 10*time.Minute)
+	err = sei.WaitHeightAdvances(progCtx, hc, tmRPC, 5)
+	cancelProg()
+	if err != nil {
+		t.Fatalf("chain did not produce blocks past the upgrade: %v", err)
+	}
+	t.Logf("chain advanced past the upgrade — TestChainUpgrade OK")
+}
+
+// provisionUpgrade provisions the genesis chain with the shortened voting period.
+// It mirrors provision() but stamps the gov genesis override (CreateNetwork's
+// Genesis map, not Config) and creates no RPC followers.
+func provisionUpgrade(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain, error) {
+	t.Helper()
+	ch := &chain{}
+	net, err := c.CreateNetwork(ctx, sei.NetworkSpec{
+		Name:           s.chainID,
+		Namespace:      s.namespace,
+		Image:          s.seidImage,
+		Validators:     s.validators,
+		Labels:         map[string]string{runLabelKey: s.runID},
+		Genesis:        votingPeriodGenesis,
+		DeletionPolicy: sei.DeletionDelete,
+	})
+	if err != nil {
+		return ch, fmt.Errorf("create network %q: %w", s.chainID, err)
+	}
+	ch.network = net
+	if err := net.WaitReady(ctx); err != nil {
+		return ch, fmt.Errorf("network %q ready: %w", s.chainID, err)
+	}
+	t.Logf("network %s: ready (%d validators, pre-upgrade image)", s.chainID, s.validators)
+	return ch, nil
+}
+
+// bumpNetworkImage re-applies the SeiNetwork with the post-upgrade image. The SDK
+// applies server-side, so re-applying the same spec with a new image patches
+// spec.image and the controller rolls every validator onto the new binary; the
+// unchanged fields (validators, genesis, deletion policy) re-apply idempotently.
+func bumpNetworkImage(ctx context.Context, t *testing.T, c *sei.Client, s spec, image string) {
+	t.Helper()
+	_, err := c.CreateNetwork(ctx, sei.NetworkSpec{
+		Name:           s.chainID,
+		Namespace:      s.namespace,
+		Image:          image,
+		Validators:     s.validators,
+		Labels:         map[string]string{runLabelKey: s.runID},
+		Genesis:        votingPeriodGenesis,
+		DeletionPolicy: sei.DeletionDelete,
+	})
+	if err != nil {
+		t.Fatalf("bump network image to %q: %v", image, err)
+	}
+}
+
+// voteAllValidators runs a GovVote task against each validator in parallel and
+// fails the suite if any vote does not complete. A vote clears 2/3 once enough
+// validators have voted; the suite votes all of them.
+func voteAllValidators(
+	ctx context.Context, t *testing.T, c *sei.Client, chainID, ns string, validators int, proposalID uint64,
+) {
+	t.Helper()
+	var wg sync.WaitGroup
+	errs := make([]error, validators)
+	for i := range validators {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			node := validatorName(chainID, i)
+			task, err := c.RunTask(ctx, sei.TaskSpec{
+				Name:      taskName(chainID, fmt.Sprintf("vote-%d", i)),
+				Namespace: ns,
+				Node:      node,
+				Kind:      sei.TaskGovVote,
+				Timeout:   8 * time.Minute,
+				GovVote: &sei.GovVote{
+					ChainID:    chainID,
+					ProposalID: proposalID,
+					Option:     sei.VoteYes,
+					Fees:       govFees,
+					Gas:        voteGas,
+				},
+			})
+			if err != nil {
+				errs[i] = fmt.Errorf("%s: run vote: %w", node, err)
+				return
+			}
+			t.Cleanup(func() {
+				delCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+				_ = task.Delete(delCtx)
+			})
+			if _, err := task.WaitComplete(ctx); err != nil {
+				errs[i] = fmt.Errorf("%s: vote: %w", node, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			t.Fatalf("vote: %v", err)
+		}
+	}
+}
+
+// runTaskComplete runs one task to completion, registering its deletion for
+// cleanup, and fails the suite if it does not complete.
+func runTaskComplete(ctx context.Context, t *testing.T, c *sei.Client, ts sei.TaskSpec) {
+	t.Helper()
+	task, err := c.RunTask(ctx, ts)
+	if err != nil {
+		t.Fatalf("run task %s (%s): %v", ts.Name, ts.Kind, err)
+	}
+	t.Cleanup(func() {
+		delCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		_ = task.Delete(delCtx)
+	})
+	if _, err := task.WaitComplete(ctx); err != nil {
+		t.Fatalf("task %s (%s): %v", ts.Name, ts.Kind, err)
+	}
+}
+
+// validatorName is the SeiNetwork child-naming contract (controller labels.go):
+// validator SeiNodes are <network>-<ordinal>.
+func validatorName(chainID string, ordinal int) string {
+	return fmt.Sprintf("%s-%d", chainID, ordinal)
+}
+
+// taskName builds a stable, DNS-safe SeiNodeTask name for a run + step.
+func taskName(chainID, step string) string {
+	return fmt.Sprintf("%s-%s", chainID, step)
+}
+
+// --- chain-as-medium gov queries (harness-level: Cosmos gov REST, not SDK) ---
+
+// govProposal models just enough of a gov v1beta1 proposal to resolve an upgrade
+// proposal by its plan name and read its status.
+type govProposal struct {
+	ProposalID string `json:"proposal_id"`
+	Status     string `json:"status"`
+	Content    struct {
+		Plan struct {
+			Name string `json:"name"`
+		} `json:"plan"`
+	} `json:"content"`
+}
+
+// resolveProposalID polls the gov REST endpoint for the voting-period proposal
+// whose upgrade plan name matches upgradeName and returns its ID. The proposal
+// appears a few blocks after submission, so this polls until it shows up or ctx
+// fires.
+func resolveProposalID(ctx context.Context, hc *http.Client, rest, upgradeName string) (uint64, error) {
+	// proposal_status=2 is PROPOSAL_STATUS_VOTING_PERIOD.
+	endpoint := rest + "/cosmos/gov/v1beta1/proposals?proposal_status=2"
+	var found uint64
+	err := pollREST(ctx, "resolve proposal id", func(ctx context.Context) (bool, error) {
+		var body struct {
+			Proposals []govProposal `json:"proposals"`
+		}
+		if !getJSONInto(ctx, hc, endpoint, &body) {
+			return false, nil
+		}
+		for _, p := range body.Proposals {
+			if p.Content.Plan.Name != upgradeName {
+				continue
+			}
+			id, err := strconv.ParseUint(p.ProposalID, 10, 64)
+			if err != nil {
+				return false, fmt.Errorf("unparseable proposal id %q: %w", p.ProposalID, err)
+			}
+			found = id
+			return true, nil
+		}
+		return false, nil
+	})
+	return found, err
+}
+
+// waitProposalPassed polls a single proposal until it reaches PASSED, failing
+// fast if it lands in a terminal non-passed state (REJECTED/FAILED).
+func waitProposalPassed(ctx context.Context, hc *http.Client, rest string, id uint64) error {
+	endpoint := fmt.Sprintf("%s/cosmos/gov/v1beta1/proposals/%d", rest, id)
+	return pollREST(ctx, fmt.Sprintf("proposal %d passed", id), func(ctx context.Context) (bool, error) {
+		var body struct {
+			Proposal govProposal `json:"proposal"`
+		}
+		if !getJSONInto(ctx, hc, endpoint, &body) {
+			return false, nil
+		}
+		switch body.Proposal.Status {
+		case "PROPOSAL_STATUS_PASSED":
+			return true, nil
+		case "PROPOSAL_STATUS_REJECTED", "PROPOSAL_STATUS_FAILED":
+			return false, fmt.Errorf("proposal %d reached terminal status %s", id, body.Proposal.Status)
+		default:
+			return false, nil
+		}
+	})
+}
+
+// --- height polling (harness-level TM /status) ---
+
+// pollHeight returns the chain's current latest block height once.
+func pollHeight(ctx context.Context, hc *http.Client, tmRPC string) (int64, error) {
+	var h int64
+	err := pollREST(ctx, "read height", func(ctx context.Context) (bool, error) {
+		var body struct {
+			Result struct {
+				SyncInfo struct {
+					LatestBlockHeight string `json:"latest_block_height"`
+				} `json:"sync_info"`
+			} `json:"result"`
+		}
+		if !getJSONInto(ctx, hc, tmRPC+"/status", &body) {
+			return false, nil
+		}
+		v, err := strconv.ParseInt(body.Result.SyncInfo.LatestBlockHeight, 10, 64)
+		if err != nil {
+			return false, nil
+		}
+		h = v
+		return true, nil
+	})
+	return h, err
+}
+
+// pollHeightAtLeast blocks until the chain's latest height reaches target. Unlike
+// sei.WaitHeightAdvances (a relative +delta) this waits for an absolute height —
+// used to detect the chain arriving at the upgrade halt.
+func pollHeightAtLeast(ctx context.Context, hc *http.Client, tmRPC string, target int64) error {
+	return pollREST(ctx, fmt.Sprintf("height >= %d", target), func(ctx context.Context) (bool, error) {
+		h, err := pollHeight(ctx, hc, tmRPC)
+		if err != nil {
+			return false, nil
+		}
+		return h >= target, nil
+	})
+}
+
+// --- small polling + HTTP helpers ---
+
+// pollREST ticks done() every 3s until it returns true or ctx fires. A done()
+// error aborts (a terminal condition); a false keeps polling.
+func pollREST(ctx context.Context, what string, done func(context.Context) (bool, error)) error {
+	tick := time.NewTicker(3 * time.Second)
+	defer tick.Stop()
+	for {
+		ok, err := done(ctx)
+		if err != nil {
+			return fmt.Errorf("%s: %w", what, err)
+		}
+		if ok {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s: not satisfied before deadline: %w", what, ctx.Err())
+		case <-tick.C:
+		}
+	}
+}
+
+// getJSONInto GETs url and decodes a 200 body into out, returning false on any
+// transient failure (unreachable, non-200, decode error) so the caller keeps
+// polling.
+func getJSONInto(ctx context.Context, hc *http.Client, url string, out any) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	return json.NewDecoder(resp.Body).Decode(out) == nil
+}


### PR DESCRIPTION
## What

Ports the major-upgrade scenario (`scenarios/major-upgrade.yaml`) to a Go-native suite, replacing the Chaos-Mesh Workflow DAG + workflow-vars ConfigMap with statement order + local state. Consumes the merged WS-G SDK task surface.

**Flow:** provision a 4-validator chain on the pre-upgrade image (short gov voting period, REST + kv-indexing enabled) → `RunTask(GovSoftwareUpgrade)` from validator-0 → resolve the proposal ID from the chain's gov REST (chain-as-medium — the controller doesn't surface it as a task output) → `RunTask(GovVote)` from every validator → wait for it to pass → approach the upgrade height and settle for the halt → bump the SeiNetwork image (single re-apply, controller cascades) → assert the **x/upgrade handler actually ran** → `RunTask(AwaitNodesAtHeight)` per validator to prove each resumed on the new binary.

Small reviewer-prescribed SDK additions: `sei.LatestHeight` (exported, dual-shape `/status`) and `TaskSpec.Labels` (harness-run GC label on tasks).

## Review

Full Coral slate (sei-network-specialist **dissenter** + systems-engineer + kubernetes-specialist + idiomatic-reviewer), blinded. The dissenter **blocked the first cut** and caught three hang paths + a false-pass — all fixed:

- **Halt detection** — validators stop serving RPC at the halt (the scenario uses a fixed wait for this reason); now polls the aggregate only to a pre-halt height, then settles.
- **Gov JSON shape** — decode both `content.plan.name` and `messages[].content.plan.name`; the legacy-only decode hung on gov v1.
- **Recovery gate** — `PodReady` ≠ rejoined-on-new-binary; replaced with per-validator `AwaitNodesAtHeight` (semantic, NodeRef-targeted) + an x/upgrade applied-plan assertion that fails loud on the fast-block false-pass.
- Diagnostics (last-seen folded into deadline errors), `errors.Join`, shared spec-builder.

Ledger: `test/integration/.xreview/upgrade-suite.md`

## Test

`go build/vet -tags integration`, `golangci-lint` — 0 issues. **Smoke-proven live on harbor** with the real `a05b00b2`→`fbc0d934` / `v6.5` image pair: `--- PASS: TestChainUpgrade (319s)` — proposal passed, image bumped, `upgrade "v6.5" applied on-chain`, all 4 validators advanced past the upgrade. Clean self-teardown. (Live smoke also caught a REST-API-disabled provisioning gap, now fixed in `upgradeConfig`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)