### PR TITLE
fix(test): enable REST API for the upgrade chain (TestChainUpgrade)

### DIFF
--- a/test/integration/upgrade_test.go
+++ b/test/integration/upgrade_test.go
@@ -62,6 +62,15 @@ var votingPeriodGenesis = map[string]string{
 	"gov.voting_params.voting_period": "60s",
 }
 
+// upgradeConfig are the seid runtime overrides the upgrade flow needs: the REST
+// API serves the gov proposal queries (off by default), and kv tx-indexing lets
+// the proposal-submission tx be found. Ported from the major-upgrade scenario's
+// SeiNetwork configOverrides.
+var upgradeConfig = map[string]string{
+	"api.rest.enable":  "true",
+	"tx_index.indexer": "kv",
+}
+
 // restUnreachable is the last-seen note when a gov REST poll gets no 200.
 const restUnreachable = "REST unreachable / non-200"
 
@@ -243,6 +252,7 @@ func networkSpec(s spec, image string, labels map[string]string) sei.NetworkSpec
 		Image:          image,
 		Validators:     s.validators,
 		Labels:         labels,
+		Config:         upgradeConfig,
 		Genesis:        votingPeriodGenesis,
 		DeletionPolicy: sei.DeletionDelete,
 	}


### PR DESCRIPTION
## What

`TestChainUpgrade` (merged in #438) resolves the proposal ID and polls the upgrade state over the Cosmos **gov REST API**, which is **off by default**. The generic provisioning omitted the override, so port 1317 was connection-refused and `resolveProposalID` polled a dead endpoint to the deadline. Adds the `configOverrides` the major-upgrade scenario uses: `api.rest.enable=true`, `tx_index.indexer=kv`.

## Why it missed #438

This fix landed in my working tree *after* the #438 branch was pushed (the live smoke surfaced the gap), so the smoke-proven binary had it but the merged commit did not. This restores parity between main and the version that passed live.

## Test

Smoke-proven: this is exactly the change that made `--- PASS: TestChainUpgrade (319s)` on harbor with the real `v6.5` image pair. `go build/vet -tags integration` + `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)