### PR TITLE
build(harness): package the integration suite as a container image (cutover)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,8 @@
 # entirely *_test.go (excluded above) behind the integration build tag, and its
 # fault/seiload manifests are //go:embed-ed *.tmpl (excluded by **). Without
 # these the `go test -c -tags integration ./test/integration/` build fails with
-# "directory not found".
+# "directory not found". These also enter the controller + seitask build contexts
+# (both COPY . .) but are inert there — neither build compiles ./test/integration
+# nor passes the integration tag.
 !test/integration/**/*_test.go
 !test/integration/**/*.tmpl

--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,11 @@
 # lesson as runner/templates/**: the seitask Dockerfile COPYs each
 # scenario asset dir; without the re-include, builds fail with "not found".
 !scenarios/*/**
+
+# Re-include the integration harness suite for test/integration/Dockerfile. It is
+# entirely *_test.go (excluded above) behind the integration build tag, and its
+# fault/seiload manifests are //go:embed-ed *.tmpl (excluded by **). Without
+# these the `go test -c -tags integration ./test/integration/` build fails with
+# "directory not found".
+!test/integration/**/*_test.go
+!test/integration/**/*.tmpl

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -54,3 +54,17 @@ jobs:
           tags: ${{ steps.ecr-login.outputs.registry }}/sei/seitask-runner:${{ inputs.tag || github.sha }}
           cache-from: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/sei/build-cache:shared
           cache-to: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/sei/build-cache:shared,mode=max
+
+      # The Go-native integration harness (go test -c -tags integration), run by
+      # one CronJob per target (-test.run TestX). Replaces seitask-runner + the
+      # Chaos-Mesh Workflow scenarios once the nightly CronJobs cut over.
+      - name: Build and push integration-harness image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: test/integration/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.ecr-login.outputs.registry }}/sei/integration-harness:${{ inputs.tag || github.sha }}
+          cache-from: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/sei/build-cache:shared
+          cache-to: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/sei/build-cache:shared,mode=max

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -66,5 +66,9 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: ${{ steps.ecr-login.outputs.registry }}/sei/integration-harness:${{ inputs.tag || github.sha }}
-          cache-from: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/sei/build-cache:shared
-          cache-to: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/sei/build-cache:shared,mode=max
+          # Dedicated cache ref (NOT the shared one the controller image uses):
+          # this is a test-image build over the whole test tree, so isolating its
+          # cache keeps a poisoned test-build layer out of the production
+          # controller image's build.
+          cache-from: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/sei/build-cache:integration-harness
+          cache-to: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/sei/build-cache:integration-harness,mode=max

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,0 +1,29 @@
+# The integration harness image: the build-tagged test binary, compiled once and
+# run by one in-cluster CronJob per target (args: -test.run TestX). It replaces
+# the seitask-runner image + the Chaos-Mesh Workflow scenarios — the suites carry
+# their fault/seiload templates via //go:embed, so the binary is self-contained
+# (no scenario files to COPY).
+FROM golang:1.26 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY . .
+
+# `go test -c` compiles the suite to a standalone binary whose entrypoint runs
+# the selected test; the integration build tag is what gates the suites into it.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go test -c -tags integration -ldflags="-s -w" -o harness.test ./test/integration/
+
+FROM gcr.io/distroless/static-debian12:nonroot
+WORKDIR /
+COPY --from=builder /workspace/harness.test /harness.test
+USER 65532:65532
+
+# A CronJob selects a suite + budget via args, e.g.
+#   ["-test.run", "TestBenchmark", "-test.v", "-test.timeout", "0"]
+ENTRYPOINT ["/harness.test"]


### PR DESCRIPTION
## What

First cutover step toward retiring the seitask-runner image + Chaos-Mesh Workflow nightly.

- `test/integration/Dockerfile` — `go test -c -tags integration` → distroless/nonroot binary; entrypoint runs the selected suite via `-test.run TestX`. Fault + seiload manifests are `//go:embed`-ed, so the binary is self-contained (no scenario files to COPY).
- `ecr.yml` — adds "Build and push integration-harness" (mirrors the seitask step) → pushes `sei/integration-harness:<sha>`.
- `.dockerignore` — re-includes `test/integration/**/*_test.go` + `*.tmpl` (both excluded by the existing `**/*_test.go` + `**` rules; the harness is entirely build-tagged `_test.go`).

The `sei/integration-harness` ECR repo is already provisioned (platform terraform, applied). Per the design discussion, the `go test -c` form is deliberate — it's the conventional in-cluster e2e pattern (k8s `e2e.test`), and `_test.go` + the build tag give a Go-enforced guarantee the suites can't leak into the controller binary.

## Test

Validated locally (`linux/amd64`): image builds, and the binary lists `TestBenchmark / TestChaosSuite / TestChainUpgrade / TestRelease`. The ecr.yml push step runs only on merge-to-main (the repo now exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)