### PR TITLE
fix(harness): route nightly state store to flatkv, not memiavl_only

### DIFF
--- a/test/integration/benchmark_test.go
+++ b/test/integration/benchmark_test.go
@@ -46,7 +46,7 @@ func TestBenchmark(t *testing.T) {
 		seiloadProfile: envOr("SEILOAD_PROFILE", "nightly_evm_transfer"),
 		seiloadCommit:  envOr("SEILOAD_COMMIT_ID", ""),
 		durationMin:    envInt(t, "DURATION_MINUTES", 10),
-		storageConfig:  memiavlStorageConfig,
+		storageConfig:  flatkvStorageConfig,
 		// EVM tuning the followers need to absorb the load (matches the load
 		// scenario's rpc overrides).
 		rpcConfig: map[string]string{

--- a/test/integration/chaossuite_test.go
+++ b/test/integration/chaossuite_test.go
@@ -97,7 +97,7 @@ func TestChaosSuite(t *testing.T) {
 				validators:    4,
 				rpcNodes:      1, // an unfaulted observer of liveness + recovery
 				timeout:       40 * time.Minute,
-				storageConfig: memiavlStorageConfig,
+				storageConfig: flatkvStorageConfig,
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), s.timeout)

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -42,11 +42,11 @@ const runLabelKey = "sei.io/harness-run"
 
 // flatkvStorageConfig pins storage write-modes for the load/release/chaos suites
 // (the major-upgrade suite omits it — exercising the migration path is what that
-// suite tests). State commitment stays on memiavl (the controller default
-// cosmos_only is rejected by the nightly image). The state store routes to
-// flatkv: the latest image builds the FlatKV state store for full nodes, and
-// memiavl_only routes all data away from that store and deadlocks its open path,
-// so RPC followers wedge before binding listeners.
+// suite tests). State commitment stays pinned to memiavl (the controller default
+// is rejected by the nightly image). The state store routes to flatkv: the latest
+// image builds the FlatKV state store for full nodes, and memiavl_only routes all
+// data away from that store and deadlocks its open path, so RPC followers wedge
+// before binding listeners.
 var flatkvStorageConfig = map[string]string{
 	"storage.state_commit.write_mode": "memiavl_only",
 	"storage.state_store.write_mode":  "flatkv_only",

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -40,14 +40,16 @@ import (
 // DeletionPolicy cascade are the cleanup path.
 const runLabelKey = "sei.io/harness-run"
 
-// memiavlStorageConfig is the storage write-mode the load + release suites run
-// with — the controller default (cosmos_only) is rejected by the nightly image.
-// NOT universal: the major-upgrade suite deliberately omits it (the storage /
-// migration path is what that suite tests), so it's applied per-suite via
-// spec.storageConfig, never globally.
-var memiavlStorageConfig = map[string]string{
+// flatkvStorageConfig pins storage write-modes for the load/release/chaos suites
+// (the major-upgrade suite omits it — exercising the migration path is what that
+// suite tests). State commitment stays on memiavl (the controller default
+// cosmos_only is rejected by the nightly image). The state store routes to
+// flatkv: the latest image builds the FlatKV state store for full nodes, and
+// memiavl_only routes all data away from that store and deadlocks its open path,
+// so RPC followers wedge before binding listeners.
+var flatkvStorageConfig = map[string]string{
 	"storage.state_commit.write_mode": "memiavl_only",
-	"storage.state_store.write_mode":  "memiavl_only",
+	"storage.state_store.write_mode":  "flatkv_only",
 }
 
 // mergeConfig returns base overlaid with extra; extra wins on key collision.

--- a/test/integration/release_test.go
+++ b/test/integration/release_test.go
@@ -28,7 +28,7 @@ const releaseAdminBalance = "1000000000000usei"
 // releaseBaseConfig is the seid config the release chain runs with: the memiavl
 // storage baseline (the nightly image rejects the cosmos_only default) plus kv tx
 // indexing (the harness queries txs) and a short mempool TTL.
-var releaseBaseConfig = mergeConfig(memiavlStorageConfig, map[string]string{
+var releaseBaseConfig = mergeConfig(flatkvStorageConfig, map[string]string{
 	"tx_index.indexer":     "kv",
 	"mempool.ttl_duration": "60s",
 })


### PR DESCRIPTION
## Problem

The nightly load suite hangs: `TestBenchmark` provisions the chain, logs `network bench: ready`, then the RPC follower wedges and never becomes EVM-serving, so seiload never runs and `NightlyRunFailed` fires.

Root cause (root-caused on a live hung node): the RPC follower's seid parks all threads on `futex_wait_queue` right after `Found 0 WALs`, opening **no** listeners (`/proc/net/tcp` shows no `:8545/:26657/:26656`). The follower runs `ss-enable=true` (full node) with `ss-write-mode=memiavl_only`; validators run the same override but `ss-enable=false`, so they're fine.

The latest nightly seid image constructs the **FlatKV state store** for full nodes. `memiavl_only` routes all EVM data *away* from that enabled store, so the SS-store open path deadlocks before listener bind. The override is weeks-old and was benign on older images (which didn't build the SS store); the new image makes it fatal — only for full nodes (RPC followers), not validators.

## Fix

In `flatkvStorageConfig` (was `memiavlStorageConfig`), shared by the load/release/chaos suites:

- `storage.state_commit.write_mode`: **`memiavl_only`** (unchanged — commitment tree stays memiavl; the controller default `cosmos_only` is rejected by the nightly image)
- `storage.state_store.write_mode`: `memiavl_only` → **`flatkv_only`** (route state to the FlatKV store the image now builds)

The major-upgrade suite still omits this map (it tests the migration path itself). Var renamed to reflect the state store is now FlatKV.

## Validation

- `go vet -tags integration ./test/integration/` passes; gofmt clean; all 3 usages renamed.
- Post-merge: new integration-harness image build → bump the platform nightly cronjob's harness image → re-trigger load → confirm seid opens `:8545` and emits `seiload_run_duration_seconds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)