### PR TITLE
fix(harness): disable SeiDB state store on nightly nodes, drop dead ss write-mode

### DIFF
--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -40,14 +40,18 @@ import (
 // DeletionPolicy cascade are the cleanup path.
 const runLabelKey = "sei.io/harness-run"
 
-// memiavlStorageConfig is the storage write-mode the load + release suites run
-// with — the controller default (cosmos_only) is rejected by the nightly image.
-// NOT universal: the major-upgrade suite deliberately omits it (the storage /
-// migration path is what that suite tests), so it's applied per-suite via
-// spec.storageConfig, never globally.
+// memiavlStorageConfig pins storage for the load/release/chaos suites (the
+// major-upgrade suite omits it — it tests the migration path). State commitment
+// stays on memiavl; the SeiDB state store is disabled because the latest image
+// defaults it on for full nodes, and enabling it on a fresh-genesis RPC follower
+// deadlocks seid at store-open before it binds listeners. Matches the validators
+// (ss-enable=false); FlatKV-migration coverage is unaffected — that's the SC
+// layer, not the historical state store. (storage.state_store.write_mode is gone:
+// the SS layer has no write-mode field on current sei-chain — EVM routing is the
+// evm-split bool — so the old key was a silently-ignored no-op.)
 var memiavlStorageConfig = map[string]string{
 	"storage.state_commit.write_mode": "memiavl_only",
-	"storage.state_store.write_mode":  "memiavl_only",
+	"storage.state_store.enable":      "false",
 }
 
 // mergeConfig returns base overlaid with extra; extra wins on key collision.


### PR DESCRIPTION
## Problem

Nightly load suite hangs: the RPC follower's seid parks all threads on `futex_wait_queue` right after `Found 0 WALs`, opens no listeners (`/proc/net/tcp` has no `:8545/:26657/:26656`), so the benchmark's EVM-readiness gate never passes and `NightlyRunFailed` fires.

## Root cause (grounded in canonical sei-chain main @ `51eb1fd`, the nightly image's commit)

- `storage.state_store.write_mode` **no longer exists** — `sei-db/config/ss_config.go`'s `StateStoreConfig` has no write-mode field (EVM routing is the `evm-split` bool); seid's app.toml template renders no `ss-write-mode`. The harness's `ss-write-mode=memiavl_only` was a **silently-ignored no-op**.
- The real trigger is **`ss-enable`**: `DefaultStateStoreConfig{Enable: true}` — the latest image defaults the SeiDB state store **on** for full nodes. Enabling it on a **fresh-genesis** RPC follower deadlocks seid at store-open. Validators are fine because the controller role-defaults them to `ss-enable=false` (confirmed live: follower `ss-enable=true`, validator `ss-enable=false`; everything else identical).

## Fix — align the override with the current config schema

In `memiavlStorageConfig` (applied to validators + followers):
- **drop** `storage.state_store.write_mode` (dead key)
- **add** `storage.state_store.enable: "false"` (string→bool coerces via sei-config's typed registry, same as the existing `evm.worker_pool_size: "32"` int override)
- **keep** `storage.state_commit.write_mode: memiavl_only`

This matches the healthy validators and **costs no FlatKV-migration coverage** — that lives in the SC layer (`sc-write-mode`), not the historical state store. The major-upgrade suite still omits the map.

## Validation
- `go vet -tags integration ./test/integration/` passes; gofmt clean.
- Post-merge: new harness image → bump cronjob → re-trigger load → confirm seid opens `:8545`, the follower's startup log shows the SS store **disabled** (not wedged), and seiload emits `seiload_run_duration_seconds`.

A separate sei-chain robustness bug (a fresh-genesis `ss-enable=true` full node should boot or fail-fast, not silently deadlock) is filed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)