### PR TITLE
fix(harness): unique chain id for the major-upgrade suite too

### DIFF
--- a/test/integration/upgrade_test.go
+++ b/test/integration/upgrade_test.go
@@ -93,7 +93,7 @@ const restUnreachable = "REST unreachable / non-200"
 // UPGRADE_HEIGHT_DELTA [optional]. Run with -test.timeout 0 (see TestBenchmark).
 func TestChainUpgrade(t *testing.T) {
 	requireCluster(t)
-	chainID := mustEnv(t, "SEI_CHAIN_ID")
+	chainID := runChainID(mustEnv(t, "SEI_CHAIN_ID"))
 	preImage := mustEnv(t, "SEID_IMAGE")
 	postImage := mustEnv(t, "SEID_UPGRADE_IMAGE")
 	upgradeName := mustEnv(t, "SEI_UPGRADE_NAME")


### PR DESCRIPTION
#446 wired `runChainID` into the load/release/chaos suites but **missed `TestChainUpgrade`** — it provisions a 4-validator chain on a *static* `SEI_CHAIN_ID` (`upg`), so it's exposed to the same stale-genesis halt on any same-id collision (back-to-back run, or a SIGKILL leaving genesis behind). It passed earlier only on a clean slate. Its own doc already calls `SEI_CHAIN_ID` "(base)"; this makes the code match.

Completes the per-run unique chain id across all four suites (load/release/chaos already done in #446).

```
test/integration/upgrade_test.go:96  chainID := runChainID(mustEnv(t, "SEI_CHAIN_ID"))
```

This is the identical one-line pattern #446's xreview ratified unanimously (sei-network dissenter held, idiomatic RATIFY). `go vet -tags integration` + gofmt clean. PLT-762 / PLT-758.