### PR TITLE
fix(seid): decouple seid --home from the container HOME env

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -39,11 +39,13 @@ const (
 
 	dataDir = platform.DataDir
 
-	// homeVarRef is the K8s VariableReference form of HOME, substituted from
-	// container.Env at pod-create. Spelled `$(HOME)` (not `$HOME`) — only the
-	// K8s syntax is expanded by kubelet; shell-style refs are passed through
-	// literally and fail at exec.
-	homeVarRef = "$(HOME)"
+	// homeMountPath is the container HOME — an emptyDir, deliberately NOT the
+	// seid data dir. Cosmos-SDK derives DefaultNodeHome = $HOME/.sei, so
+	// HOME=/.sei made a bare `seid` resolve to /.sei/.sei (nested home) and drop
+	// shell files (.bash_history) onto the data PVC. Every seid invocation now
+	// passes an explicit `--home <dataDir>`, so HOME is decoupled from the data dir.
+	homeMountPath  = "/home/nonroot"
+	homeVolumeName = "home"
 
 	// seidHomeFlag is the cosmos-sdk flag that sets seid's working dir.
 	seidHomeFlag = "--home"
@@ -437,8 +439,14 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) (corev1.PodSp
 		Name:         sidecarTmpVolumeName,
 		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 	}
-	volumes := make([]corev1.Volume, 0, 3+len(signingVolumes)+len(nodeVolumes)+len(keyringVolumes))
-	volumes = append(volumes, dataVolume, sidecarTmpVolume, proxyConfigVolume)
+	// homeVolume backs the container HOME (an emptyDir off the data PVC) so
+	// shell/home writes never land on /.sei and bare `seid` never nests at $HOME/.sei.
+	homeVolume := corev1.Volume{
+		Name:         homeVolumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
+	volumes := make([]corev1.Volume, 0, 4+len(signingVolumes)+len(nodeVolumes)+len(keyringVolumes))
+	volumes = append(volumes, dataVolume, sidecarTmpVolume, homeVolume, proxyConfigVolume)
 	volumes = append(volumes, signingVolumes...)
 	volumes = append(volumes, nodeVolumes...)
 	volumes = append(volumes, keyringVolumes...)
@@ -686,10 +694,10 @@ func buildCosmosExporterContainer(p PlatformConfig) (corev1.Container, error) {
 }
 
 func sidecarWaitCommand(node *seiv1alpha1.SeiNode) (command []string, args []string) {
-	// Canonical seid invocation. "$HOME" (shell-expanded inside bash -c)
-	// resolves from the container env declared in buildNodeMainContainer.
+	// Canonical seid invocation with an explicit --home <dataDir>, decoupled
+	// from the container HOME (a non-data-dir emptyDir).
 	cmd := "seid"
-	cmdArgs := []string{seidStartSubcommand, seidHomeFlag, "$HOME"}
+	cmdArgs := []string{seidStartSubcommand, seidHomeFlag, dataDir}
 
 	var b strings.Builder
 	b.WriteString(cmd)
@@ -715,25 +723,26 @@ func sidecarWaitCommand(node *seiv1alpha1.SeiNode) (command []string, args []str
 func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	signingMounts := signingKeyMounts(node)
 	nodeMounts := nodeKeyMounts(node)
-	mounts := make([]corev1.VolumeMount, 0, 1+len(signingMounts)+len(nodeMounts))
+	mounts := make([]corev1.VolumeMount, 0, 2+len(signingMounts)+len(nodeMounts))
 	mounts = append(mounts, corev1.VolumeMount{Name: "data", MountPath: dataDir})
+	mounts = append(mounts, corev1.VolumeMount{Name: homeVolumeName, MountPath: homeMountPath})
 	mounts = append(mounts, signingMounts...)
 	mounts = append(mounts, nodeMounts...)
-	// HOME must appear before TMPDIR so K8s VariableReference $(HOME) in
-	// args[] resolves at pod-create. K8s reads container.Env (not the
-	// process env) for variable substitution, ordered top-down.
 	container := corev1.Container{
 		Name:            containerNameSeid,
 		Image:           node.Spec.Image,
 		SecurityContext: seidNonRootSecurityContext(),
+		// HOME is a non-data-dir emptyDir; TMPDIR is the data dir's tmp. seid is
+		// invoked with an explicit --home <dataDir> (see sidecarWaitCommand), so
+		// HOME never determines seid's home — that's why it's safe off /.sei.
 		Env: []corev1.EnvVar{
-			{Name: "HOME", Value: dataDir},
+			{Name: "HOME", Value: homeMountPath},
 			{Name: "TMPDIR", Value: dataDir + "/tmp"},
 		},
-		// Canonical invocation. $(HOME) is K8s VariableReference syntax,
-		// substituted from container.Env before exec.
+		// Explicit --home <dataDir>; overridden at the call site by
+		// sidecarWaitCommand, kept here for a coherent standalone container.
 		Command:      []string{"seid"},
-		Args:         []string{seidStartSubcommand, seidHomeFlag, homeVarRef},
+		Args:         []string{seidStartSubcommand, seidHomeFlag, dataDir},
 		VolumeMounts: mounts,
 		Ports:        ContainerPorts(),
 		StartupProbe: &corev1.Probe{
@@ -755,14 +764,14 @@ func buildNodeMainContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	return container
 }
 
-// buildSeidInitContainer materializes $HOME/config on first boot via
-// `seid init` and ensures $HOME/tmp exists. The script uses shell
-// $HOME (the script runs via /bin/sh -c) so the path stays in lock-step
-// with the HOME env var.
+// buildSeidInitContainer materializes <dataDir>/config on first boot via
+// `seid init` and ensures <dataDir>/tmp exists. Paths are the literal data
+// dir, decoupled from HOME (which is a non-data-dir emptyDir) so the guard
+// and init target the seid home regardless of $HOME.
 func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 	script := fmt.Sprintf(
-		`if [ -f "$HOME/config/genesis.json" ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home "$HOME" --overwrite; fi && mkdir -p "$HOME/tmp"`,
-		node.Spec.ChainID, node.Spec.ChainID,
+		`if [ -f "%s/config/genesis.json" ]; then echo "data directory already initialized, skipping seid init"; else seid init %s --chain-id %s --home "%s" --overwrite; fi && mkdir -p "%s/tmp"`,
+		dataDir, node.Spec.ChainID, node.Spec.ChainID, dataDir, dataDir,
 	)
 	return corev1.Container{
 		Name:  "seid-init",
@@ -771,10 +780,11 @@ func buildSeidInitContainer(node *seiv1alpha1.SeiNode) corev1.Container {
 			"/bin/sh", "-c", script,
 		},
 		Env: []corev1.EnvVar{
-			{Name: "HOME", Value: dataDir},
+			{Name: "HOME", Value: homeMountPath},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: dataDir},
+			{Name: homeVolumeName, MountPath: homeMountPath},
 		},
 		SecurityContext: seidNonRootSecurityContext(),
 	}

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -1,6 +1,7 @@
 package noderesource
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -194,12 +195,14 @@ func TestBuildNodePodSpec_Genesis_MountsExistingPVC(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(spec.ServiceAccountName).To(Equal(platformtest.Config().ServiceAccount))
-	g.Expect(spec.Volumes).To(HaveLen(3)) // data PVC + sidecar-tmp emptyDir + rbac-proxy-config ConfigMap
+	g.Expect(spec.Volumes).To(HaveLen(4)) // data PVC + sidecar-tmp emptyDir + home emptyDir + rbac-proxy-config ConfigMap
 	g.Expect(spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("data-mynet-0"))
 	g.Expect(spec.Volumes[1].Name).To(Equal(sidecarTmpVolumeName))
 	g.Expect(spec.Volumes[1].EmptyDir).NotTo(BeNil())
-	g.Expect(spec.Volumes[2].Name).To(Equal(rbacProxyConfigVolumeName))
-	g.Expect(spec.Volumes[2].ConfigMap).NotTo(BeNil())
+	g.Expect(spec.Volumes[2].Name).To(Equal(homeVolumeName))
+	g.Expect(spec.Volumes[2].EmptyDir).NotTo(BeNil())
+	g.Expect(spec.Volumes[3].Name).To(Equal(rbacProxyConfigVolumeName))
+	g.Expect(spec.Volumes[3].ConfigMap).NotTo(BeNil())
 }
 
 func TestBuildNodePodSpec_Snapshot_MountsNodePVC(t *testing.T) {
@@ -265,15 +268,15 @@ func TestBuildNodeMainContainer_ImageAndEnv(t *testing.T) {
 	g.Expect(c.Name).To(Equal("seid"))
 	g.Expect(c.Image).To(Equal("ghcr.io/sei-protocol/seid:latest"))
 	g.Expect(c.Command).To(Equal([]string{"seid"}))
-	g.Expect(c.Args).To(Equal([]string{seidStartSubcommand, seidHomeFlag, homeVarRef}),
-		"controller injects canonical command; $(HOME) is K8s VariableReference, resolved from container.Env at pod-create")
+	g.Expect(c.Args).To(Equal([]string{seidStartSubcommand, seidHomeFlag, dataDir}),
+		"controller injects canonical command with an explicit --home <dataDir>, decoupled from HOME")
 
 	env := map[string]string{}
 	for _, e := range c.Env {
 		env[e.Name] = e.Value
 	}
-	g.Expect(env).To(HaveKeyWithValue("HOME", dataDir),
-		"HOME must be declared first so $(HOME) in args resolves correctly")
+	g.Expect(env).To(HaveKeyWithValue("HOME", homeMountPath),
+		"HOME is a non-data-dir emptyDir; seid home is set via explicit --home, not $HOME")
 	g.Expect(env).To(HaveKeyWithValue("TMPDIR", dataDir+"/tmp"))
 }
 
@@ -282,9 +285,11 @@ func TestBuildNodeMainContainer_DataVolumeMount(t *testing.T) {
 	node := newGenesisNode("mynet-0", "default")
 	c := buildNodeMainContainer(node)
 
-	g.Expect(c.VolumeMounts).To(HaveLen(1))
+	g.Expect(c.VolumeMounts).To(HaveLen(2))
 	g.Expect(c.VolumeMounts[0].Name).To(Equal("data"))
 	g.Expect(c.VolumeMounts[0].MountPath).To(Equal(dataDir))
+	g.Expect(c.VolumeMounts[1].Name).To(Equal(homeVolumeName))
+	g.Expect(c.VolumeMounts[1].MountPath).To(Equal(homeMountPath))
 }
 
 func TestBuildNodeMainContainer_StartupProbe_Genesis(t *testing.T) {
@@ -545,9 +550,8 @@ func TestSidecarMainContainer_WaitWrapper_DefaultsSeidStart(t *testing.T) {
 	seid := findContainer(sts.Spec.Template.Spec.Containers, "seid")
 
 	g.Expect(seid.Command).To(Equal([]string{"/bin/bash", "-c"}))
-	// "$HOME" is shell-expanded inside the bash -c script; the HOME env
-	// var on the container resolves it to dataDir at exec time.
-	g.Expect(seid.Args[0]).To(ContainSubstring(`exec seid "start" "--home" "$HOME"`))
+	// seid is started with an explicit --home <dataDir>, decoupled from HOME.
+	g.Expect(seid.Args[0]).To(ContainSubstring(fmt.Sprintf(`exec seid "start" "--home" %q`, dataDir)))
 }
 
 func TestSidecarMainContainer_NilSidecarConfig_UsesDefaults(t *testing.T) {
@@ -1136,19 +1140,21 @@ func TestSeidInitContainer_BareScript(t *testing.T) {
 	// fsGroup OnRootMismatch — not in this script.
 	g.Expect(script).NotTo(ContainSubstring("chown"))
 	g.Expect(script).NotTo(ContainSubstring("chmod"))
-	// Script uses shell $HOME (runs via /bin/sh -c) so it stays in
-	// lock-step with the HOME env var declared on the container.
-	g.Expect(script).To(ContainSubstring(`seid init sei-test --chain-id sei-test --home "$HOME" --overwrite`))
-	g.Expect(script).To(ContainSubstring(`mkdir -p "$HOME/tmp"`))
-	g.Expect(script).NotTo(ContainSubstring(dataDir),
-		"no hardcoded data dir — script must route through $HOME")
+	// Script targets the literal data dir for --home + the genesis guard + tmp,
+	// decoupled from HOME (a non-data-dir emptyDir).
+	g.Expect(script).To(ContainSubstring(fmt.Sprintf(`seid init sei-test --chain-id sei-test --home "%s" --overwrite`, dataDir)))
+	g.Expect(script).To(ContainSubstring(fmt.Sprintf(`mkdir -p "%s/tmp"`, dataDir)))
+	g.Expect(script).To(ContainSubstring(fmt.Sprintf(`[ -f "%s/config/genesis.json" ]`, dataDir)),
+		"the init skip-guard must check the data dir, not $HOME")
+	g.Expect(script).NotTo(ContainSubstring("$HOME"),
+		"script must not depend on $HOME for the seid home")
 
 	env := map[string]string{}
 	for _, e := range seidInit.Env {
 		env[e.Name] = e.Value
 	}
-	g.Expect(env).To(HaveKeyWithValue("HOME", dataDir),
-		"HOME env var must match the seid main container so shell $HOME resolves consistently")
+	g.Expect(env).To(HaveKeyWithValue("HOME", homeMountPath),
+		"HOME is a non-data-dir emptyDir; the init script targets --home <dataDir> explicitly")
 }
 
 func expectSeidNonRootSecurityContext(g Gomega, sc *corev1.SecurityContext) {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -9,11 +9,12 @@ import (
 )
 
 const (
-	// DataDir is the mount path for the sei data volume inside node pods.
-	// `/.sei` follows the conventional Cosmos SDK home layout (`~/.sei`),
-	// resolved against the seid container's HOME env var. Lock-step with
-	// the SEI_HOME env var injected on the sidecar container; both flow
-	// from this single constant.
+	// DataDir is the mount path for the sei data volume inside node pods, and
+	// the seid home passed explicitly via `--home <DataDir>` on every seid
+	// invocation. It is deliberately NOT the container HOME: Cosmos-SDK derives
+	// DefaultNodeHome = $HOME/.sei, so setting HOME=/.sei made a bare `seid`
+	// resolve to /.sei/.sei (nested). HOME is a separate emptyDir; the sidecar's
+	// SEI_HOME env also points here. All flow from this single constant.
 	DataDir = "/.sei"
 
 	// modeArchive matches seiconfig.ModeArchive without importing sei-config.


### PR DESCRIPTION
## Problem
seid containers set `HOME=/.sei` (the data dir). Cosmos-SDK computes `DefaultNodeHome = filepath.Join(os.UserHomeDir(), ".sei")` = `$HOME/.sei`, so `HOME=/.sei` makes **any bare `seid`** (e.g. a human `kubectl exec` running `seid keys list`) resolve its home to **`/.sei/.sei`**. Result: a nested `/.sei/.sei/config`, `.bash_history` written onto the data PVC, and bare keyring commands looking in the wrong place. (Reported by Masih.)

The controller's own `start`/`init` already pass `--home`, but they took the value *from* `$HOME` — so we can't just move `HOME` without repointing them.

## Fix (atomic)
Every seid invocation now passes an explicit `--home /.sei`, independent of `$HOME`:
- `sidecarWaitCommand` (the live `seid start`), the base `buildNodeMainContainer` args, and the `seid-init` script — **including the `genesis.json` skip-guard and the `tmp` mkdir**.
- `HOME` → `/home/nonroot`, backed by a per-pod **emptyDir** (guaranteed writable, off the data PVC). Shell/home writes no longer touch `/.sei`; a bare `seid` no longer nests at `$HOME/.sei`.

> **Why atomic:** a partial change (moving `HOME` without repointing an invocation) would run `seid start --home <wronghome>` → boot against an empty dir → validator wipe / state-sync redo. All the refs move together.

## Deliberately not changed
- signing-key / node-key mounts; the **sidecar-only** operator keyring (`assertNoOperatorKeyringOnSeidContainers`); `TMPDIR` (=`/.sei/tmp`, literal).
- **`SEI_HOME` is intentionally NOT added to the seid container** — the seid CLI doesn't honor it (viper prefix is `SEID`, and client `keys` reads the raw `--home` pflag). Only explicit `--home` works. (This was a false start in the original proposal, caught in review.)

## Remediation for existing pods
`/.sei/.sei` and `/.sei/.bash_history` are **inert junk** (seid reads `/.sei/config` via explicit `--home`); no migration needed, optional one-time `rm -rf` to reclaim disk. The init guard now checks `/.sei/config/genesis.json`, so an OnDelete rolling restart does **not** re-init.

## Follow-ups (separate)
- `internal/task/bootstrap_resources.go` mirrors the same `HOME`/`$HOME` pattern on the ephemeral bootstrap pod — deferred (TTL-bounded, rarely exec'd).
- Operator-keyring DX (`client.toml keyring-backend = os` vs the sidecar's `file` keyring) — separate item.

## Verification
`go build ./...`, `go vet ./...`, and `go test ./internal/...` all green. Root-caused + fix designed/endorsed by systems-engineer + kubernetes-specialist review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)