### PR TITLE
fix(nodetask): stop re-submitting gov/sidecar tasks every poll

### DIFF
--- a/api/v1alpha1/seinode_types.go
+++ b/api/v1alpha1/seinode_types.go
@@ -151,11 +151,12 @@ const (
 )
 
 // TaskStatus is the lifecycle state of a single PlannedTask.
-// +kubebuilder:validation:Enum=Pending;Complete;Failed
+// +kubebuilder:validation:Enum=Pending;Running;Complete;Failed
 type TaskStatus string
 
 const (
 	TaskPending  TaskStatus = "Pending"
+	TaskRunning  TaskStatus = "Running"
 	TaskComplete TaskStatus = "Complete"
 	TaskFailed   TaskStatus = "Failed"
 )

--- a/config/crd/sei.io_seinetworks.yaml
+++ b/config/crd/sei.io_seinetworks.yaml
@@ -687,6 +687,7 @@ spec:
                           description: Status is the current state of this task.
                           enum:
                           - Pending
+                          - Running
                           - Complete
                           - Failed
                           type: string

--- a/config/crd/sei.io_seinodes.yaml
+++ b/config/crd/sei.io_seinodes.yaml
@@ -972,6 +972,7 @@ spec:
                           description: Status is the current state of this task.
                           enum:
                           - Pending
+                          - Running
                           - Complete
                           - Failed
                           type: string

--- a/config/crd/sei.io_seinodetasks.yaml
+++ b/config/crd/sei.io_seinodetasks.yaml
@@ -649,6 +649,7 @@ spec:
                     description: Status is the lifecycle state of the underlying execution.
                     enum:
                     - Pending
+                    - Running
                     - Complete
                     - Failed
                     type: string

--- a/internal/controller/nodetask/controller.go
+++ b/internal/controller/nodetask/controller.go
@@ -273,6 +273,9 @@ func (r *SeiNodeTaskReconciler) driveTask(ctx context.Context, cr *seiv1alpha1.S
 			t := metav1.NewTime(now)
 			cr.Status.Task.SubmittedAt = &t
 		}
+		// Advance off Pending so later reconciles poll instead of re-submitting
+		// every cycle.
+		cr.Status.Task.Status = seiv1alpha1.TaskRunning
 	}
 
 	statusCtx, cancel := context.WithTimeout(ctx, sidecarStatusTimeout)

--- a/internal/controller/nodetask/controller_test.go
+++ b/internal/controller/nodetask/controller_test.go
@@ -271,6 +271,18 @@ func (f *fakeSidecarClient) setResult(id uuid.UUID, status sidecar.TaskResultSta
 	f.results[id] = res
 }
 
+func (f *fakeSidecarClient) submitCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.submitted)
+}
+
+func (f *fakeSidecarClient) getCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.getCalls
+}
+
 // newReconcilerWithSidecar wires a reconciler whose ExecutionConfig.BuildSidecarClient
 // returns the supplied fake. Separate from newReconciler because the 5 existing
 // non-sidecar tests do not need (and should not pay for) a sidecar fixture.
@@ -613,6 +625,37 @@ func TestReconcile_GovVote_EndToEnd(t *testing.T) {
 		g.Expect(got.Status.Outputs.GovVote).To(BeNil(),
 			"populateOutputs unexpectedly populated GovVote — see PR 3 scope notes in controller.go")
 	}
+}
+
+// TestReconcile_StopsResubmittingAfterSubmit is the PR 2a regression guard:
+// once submitted, Task.Status advances to Running so later reconciles poll
+// instead of re-invoking SubmitTask every cycle. Before the fix Task.Status
+// stayed Pending and each poll re-submitted (the double-submit window).
+func TestReconcile_StopsResubmittingAfterSubmit(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	t0 := time.Now()
+	fakeSC := newFakeSidecarClient()
+	r, c := newReconcilerWithSidecar(t, t0, fakeSC, newGovVoteTask(), newRunningNode())
+
+	// R1: synthesize (Task set, Pending — not yet submitted).
+	_, err := r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(getTask(t, ctx, c).Status.Task.Status).To(Equal(seiv1alpha1.TaskPending))
+
+	// R2: Execute submits once; Status polls (no result staged → still Running).
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(getTask(t, ctx, c).Status.Task.Status).To(Equal(seiv1alpha1.TaskRunning))
+	g.Expect(fakeSC.submitCount()).To(Equal(1))
+
+	// R3: still no result — must poll, not re-submit.
+	getsBefore := fakeSC.getCallCount()
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(fakeSC.submitCount()).To(Equal(1), "task re-submitted on poll — stop-resubmit regressed")
+	g.Expect(getTask(t, ctx, c).Status.Task.Status).To(Equal(seiv1alpha1.TaskRunning))
+	g.Expect(fakeSC.getCallCount()).To(BeNumerically(">", getsBefore), "expected a status poll")
 }
 
 // ---------------------------------------------------------------------------

--- a/manifests/sei.io_seinetworks.yaml
+++ b/manifests/sei.io_seinetworks.yaml
@@ -687,6 +687,7 @@ spec:
                           description: Status is the current state of this task.
                           enum:
                           - Pending
+                          - Running
                           - Complete
                           - Failed
                           type: string

--- a/manifests/sei.io_seinodes.yaml
+++ b/manifests/sei.io_seinodes.yaml
@@ -972,6 +972,7 @@ spec:
                           description: Status is the current state of this task.
                           enum:
                           - Pending
+                          - Running
                           - Complete
                           - Failed
                           type: string

--- a/manifests/sei.io_seinodetasks.yaml
+++ b/manifests/sei.io_seinodetasks.yaml
@@ -649,6 +649,7 @@ spec:
                     description: Status is the lifecycle state of the underlying execution.
                     enum:
                     - Pending
+                    - Running
                     - Complete
                     - Failed
                     type: string


### PR DESCRIPTION
## What

The nodetask controller never advanced `status.task.status` off `Pending`, so the `== TaskPending` submit guard re-invoked `SubmitTask` on **every 15s poll** for a task's whole life. Deterministic task IDs make that idempotent only while the sidecar retains the task; if its store is lost, the next poll re-submits — a **double-submit / double-deposit** hazard for non-idempotent gov proposals (`GovSoftwareUpgrade`/`GovParamChange`).

## Change

- Add a `TaskRunning` value to the `TaskStatus` enum (additive; the SeiNode plan executor never writes it).
- Set `TaskRunning` after a successful `Execute`, so later reconciles poll instead of re-submitting.
- Regenerated CRDs/deepcopy; regression test asserts submit-once → poll-only.

## By-design notes (resolved for PR 2b)

- A submit whose status flush then fails still re-submits once on requeue — pre-existing, now the *only* window (shrunk from every 15s cycle).
- After this fix, a sidecar store-loss **parks** the task in `Running` rather than resubmitting — the safer behavior for non-idempotent proposals; PR 2b's inclusion re-check resolves it.

Standalone bug fix — no seictl dependency. First slice of the SeiNodeTask gov UX work.

Reviewed: idiomatic-reviewer, systems-engineer (correct, ship it). Design: sei-protocol/bdchatham-designs#98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)