### PR TITLE
feat(nodetask): consume gov task results — outputs, conditions, pending loop

### DIFF
--- a/api/v1alpha1/seinodetask_types.go
+++ b/api/v1alpha1/seinodetask_types.go
@@ -569,10 +569,7 @@ type GovSoftwareUpgradeOutputs struct {
 }
 
 // GovParamChangeOutputs are the typed results for a completed
-// GovParamChange task. Like the other sidecar-backed gov outputs, these
-// fields are defined for forward compatibility but are NOT populated in
-// this PR (the sidecar TaskResult has no typed-output channel; downstream
-// consumers read the proposalId from the chain — see populateOutputs).
+// GovParamChange task, parsed from the sidecar's structured task result.
 type GovParamChangeOutputs struct {
 	// TxHash is the upper-case hex-encoded transaction hash.
 	// +optional

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.39.1
 	github.com/sei-protocol/sei-config v0.0.20
-	github.com/sei-protocol/seictl v0.0.58
+	github.com/sei-protocol/seictl v0.0.61
 	github.com/urfave/cli/v3 v3.6.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
@@ -41,6 +41,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/DataDog/zstd v1.5.7 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/RaduBerinde/axisds v0.0.0-20250419182453-5135a0650657 // indirect
 	github.com/RaduBerinde/btreemap v0.0.0-20250419174037-3d62b7205d54 // indirect
@@ -91,6 +92,7 @@ require (
 	github.com/creachadair/taskgroup v0.3.2 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/dgraph-io/badger/v3 v3.2103.2 // indirect
@@ -109,6 +111,7 @@ require (
 	github.com/go-kit/kit v0.13.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.2 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect
@@ -184,6 +187,7 @@ require (
 	github.com/sei-protocol/sei-chain v0.0.29-fix.0.20260326202429-c9b42951fef7 // indirect
 	github.com/sei-protocol/sei-tm-db v0.0.5 // indirect
 	github.com/sei-protocol/seilog v0.0.3 // indirect
+	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
@@ -203,7 +207,10 @@ require (
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/tinylru v1.1.0 // indirect
 	github.com/tidwall/wal v1.2.1 // indirect
+	github.com/tklauser/go-sysconf v0.3.15 // indirect
+	github.com/tklauser/numcpus v0.10.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zbiljic/go-filelock v0.0.0-20170914061330-1dbf7103ab7d // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
 	github.com/zondax/golem v0.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1796,6 +1796,8 @@ github.com/sei-protocol/seictl v0.0.58-0.20260613152615-8dce7890a3c3 h1:2d0cKtxl
 github.com/sei-protocol/seictl v0.0.58-0.20260613152615-8dce7890a3c3/go.mod h1:EnEHAT5/egP4aIB4Ir4tg5eK2150RfB9Ohw5xmpZQGE=
 github.com/sei-protocol/seictl v0.0.58 h1:nsnPFXscdKCynFQ9ST2AK25xHD9FNkDnkquYmeF945o=
 github.com/sei-protocol/seictl v0.0.58/go.mod h1:4biVFBVsrMSRQi4G8UNiIEAbOgzFySUJ4q8I2oBSstg=
+github.com/sei-protocol/seictl v0.0.61 h1:QRIYYL9mBCx3041YMssVOnJ8np6kzsqMoV/FpngGZlQ=
+github.com/sei-protocol/seictl v0.0.61/go.mod h1:3rC0pyCBN5BFt4d9FewYCBECC7QUZobMO+UcFE0Wz58=
 github.com/sei-protocol/seilog v0.0.3 h1:Zi7oWXdX5jv92dY8n482xH032LtNebC89Y+qYZlBn0Y=
 github.com/sei-protocol/seilog v0.0.3/go.mod h1:CKg58wraWnB3gRxWQ0v1rIVr0gmDHjkfP1bM2giKFFU=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/internal/controller/nodetask/controller.go
+++ b/internal/controller/nodetask/controller.go
@@ -282,36 +282,83 @@ func (r *SeiNodeTaskReconciler) driveTask(ctx context.Context, cr *seiv1alpha1.S
 	defer cancel()
 	switch exec.Status(statusCtx) {
 	case task.ExecutionComplete:
-		cr.Status.Task.Status = seiv1alpha1.TaskComplete
-		populateOutputs(cr, target)
-		r.setPhase(cr, seiv1alpha1.SeiNodeTaskPhaseComplete, now)
-		setCondition(cr, metav1.Condition{
-			Type:   seiv1alpha1.ConditionSeiNodeTaskReady,
-			Status: metav1.ConditionTrue, Reason: "TaskComplete",
-		})
+		r.markComplete(cr, exec, target, now)
 	case task.ExecutionFailed:
-		msg := ""
-		if e := exec.Err(); e != nil {
-			msg = e.Error()
-		}
-		cr.Status.Task.Status = seiv1alpha1.TaskFailed
-		cr.Status.Task.Err = msg
-		r.markFailed(cr, now, "TaskFailed", msg)
+		r.handleFailure(cr, exec, now)
 	default:
-		// Still running; enforce the execution timeout against
-		// ExecutionStartedAt (not status.startedAt — keeps the requirePhase wait
-		// off the budget).
-		if timeout := effectiveTimeout(cr); timeout > 0 && cr.Status.Task.ExecutionStartedAt != nil {
-			deadline := cr.Status.Task.ExecutionStartedAt.Add(timeout)
-			if now.After(deadline) {
-				r.markFailed(cr, now, "Timeout",
-					fmt.Sprintf("task did not complete within %s", timeout))
-				cr.Status.Task.Status = seiv1alpha1.TaskFailed
-				cr.Status.Task.Err = "timeout"
-			}
+		// Still running; enforce the execution timeout against ExecutionStartedAt
+		// (not status.startedAt — keeps the requirePhase wait off the budget).
+		if r.execTimedOut(cr, now) {
+			cr.Status.Task.Status = seiv1alpha1.TaskFailed
+			cr.Status.Task.Err = "timeout"
+			r.markFailed(cr, now, "Timeout",
+				fmt.Sprintf("task did not complete within %s", effectiveTimeout(cr)))
 		}
 	}
 	return nil
+}
+
+// markComplete records a committed-ok terminal: stamp outputs and latch Ready.
+// Gov kinds latch reason Confirmed (on-chain confirmed); others keep TaskComplete.
+func (r *SeiNodeTaskReconciler) markComplete(cr *seiv1alpha1.SeiNodeTask, exec task.TaskExecution, target *seiv1alpha1.SeiNode, now time.Time) {
+	cr.Status.Task.Status = seiv1alpha1.TaskComplete
+	populateOutputs(cr, target, decodeGovResult(exec))
+	r.setPhase(cr, seiv1alpha1.SeiNodeTaskPhaseComplete, now)
+	reason := "TaskComplete"
+	if isGovKind(cr.Spec.Kind) {
+		reason = "Confirmed"
+	}
+	setCondition(cr, metav1.Condition{
+		Type:   seiv1alpha1.ConditionSeiNodeTaskReady,
+		Status: metav1.ConditionTrue, Reason: reason,
+	})
+}
+
+// handleFailure resolves an engine-Failed task. For gov kinds it decodes the
+// result to distinguish a committed-but-failed tx and an inclusion-undetermined
+// (pending) result — which is re-checked, not terminal — from a hard failure.
+func (r *SeiNodeTaskReconciler) handleFailure(cr *seiv1alpha1.SeiNodeTask, exec task.TaskExecution, now time.Time) {
+	msg := ""
+	if e := exec.Err(); e != nil {
+		msg = e.Error()
+	}
+
+	if gr := decodeGovResult(exec); gr != nil {
+		switch gr.InclusionStatus {
+		case inclusionPending:
+			// Undetermined: re-submit (same task ID → engine re-run → marker
+			// adopt re-checks) until the execution timeout, then latch Failed.
+			if r.execTimedOut(cr, now) {
+				populateGovOutputs(cr, gr)
+				cr.Status.Task.Status = seiv1alpha1.TaskFailed
+				cr.Status.Task.Err = msg
+				r.markFailed(cr, now, "InclusionUndetermined", msg)
+				return
+			}
+			cr.Status.Task.Status = seiv1alpha1.TaskPending
+			return
+		case inclusionCommittedFailed:
+			populateGovOutputs(cr, gr)
+			cr.Status.Task.Status = seiv1alpha1.TaskFailed
+			cr.Status.Task.Err = msg
+			r.markFailed(cr, now, "TxFailed", msg)
+			return
+		}
+	}
+
+	cr.Status.Task.Status = seiv1alpha1.TaskFailed
+	cr.Status.Task.Err = msg
+	r.markFailed(cr, now, "TaskFailed", msg)
+}
+
+// execTimedOut reports whether the execution budget (from ExecutionStartedAt)
+// has elapsed. 0 timeout means unbounded.
+func (r *SeiNodeTaskReconciler) execTimedOut(cr *seiv1alpha1.SeiNodeTask, now time.Time) bool {
+	timeout := effectiveTimeout(cr)
+	if timeout <= 0 || cr.Status.Task.ExecutionStartedAt == nil {
+		return false
+	}
+	return now.After(cr.Status.Task.ExecutionStartedAt.Add(timeout))
 }
 
 // effectiveTimeout returns the execution timeout (measured from
@@ -352,15 +399,10 @@ func taskParamsForKind(cr *seiv1alpha1.SeiNodeTask, target *seiv1alpha1.SeiNode)
 	return p.Type, raw, nil
 }
 
-// populateOutputs stamps the typed per-kind outputs on Complete.
-//
-// Sidecar-backed kinds (GovVote, GovSoftwareUpgrade, AwaitCondition,
-// AwaitNodesAtHeight) leave their typed output fields unset for now: surfacing
-// the values the sidecar's TaskResult carries needs typed per-task result
-// payloads on the sidecar side, which is deferred. The CRD fields stay
-// forward-compatible, and downstream consumers coordinate via chain queries
-// (chain-as-medium) rather than task-to-task currying.
-func populateOutputs(cr *seiv1alpha1.SeiNodeTask, target *seiv1alpha1.SeiNode) {
+// populateOutputs stamps the typed per-kind outputs on the committed-ok path.
+// Gov kinds read the sidecar's structured result (gr); UpdateNodeImage reads
+// the target's observed image. gr is nil for non-gov kinds.
+func populateOutputs(cr *seiv1alpha1.SeiNodeTask, target *seiv1alpha1.SeiNode, gr *govResult) {
 	switch cr.Spec.Kind {
 	case seiv1alpha1.SeiNodeTaskKindUpdateNodeImage:
 		if cr.Status.Outputs == nil {
@@ -368,6 +410,10 @@ func populateOutputs(cr *seiv1alpha1.SeiNodeTask, target *seiv1alpha1.SeiNode) {
 		}
 		cr.Status.Outputs.UpdateNodeImage = &seiv1alpha1.UpdateNodeImageOutputs{
 			AppliedImage: target.Status.CurrentImage,
+		}
+	default:
+		if isGovKind(cr.Spec.Kind) {
+			populateGovOutputs(cr, gr)
 		}
 	}
 }

--- a/internal/controller/nodetask/controller_gov_test.go
+++ b/internal/controller/nodetask/controller_gov_test.go
@@ -1,0 +1,260 @@
+package nodetask
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sidecar "github.com/sei-protocol/seictl/sidecar/client"
+	sidecartasks "github.com/sei-protocol/seictl/sidecar/tasks"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+)
+
+// setResultPayload stages a terminal task result carrying a structured result
+// payload (the gov completion-contract channel).
+func (f *fakeSidecarClient) setResultPayload(id uuid.UUID, status sidecar.TaskResultStatus, errMsg string, payload json.RawMessage) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	res := &sidecar.TaskResult{Id: id, Status: status, Type: "test", SubmittedAt: time.Now()}
+	if errMsg != "" {
+		res.Error = &errMsg
+	}
+	if len(payload) > 0 {
+		p := payload
+		res.Result = &p
+	}
+	f.results[id] = res
+}
+
+func newGovUpgradeTask() *seiv1alpha1.SeiNodeTask {
+	return &seiv1alpha1.SeiNodeTask{
+		ObjectMeta: metav1.ObjectMeta{Name: testTaskName, Namespace: testNS, UID: "task-uid-govupgrade", Generation: 1},
+		Spec: seiv1alpha1.SeiNodeTaskSpec{
+			Kind: seiv1alpha1.SeiNodeTaskKindGovSoftwareUpgrade,
+			Target: seiv1alpha1.SeiNodeTaskTarget{
+				NodeRef:      seiv1alpha1.SeiNodeTaskNodeRef{Name: testNodeName},
+				RequirePhase: seiv1alpha1.PhaseRunning,
+			},
+			GovSoftwareUpgrade: &seiv1alpha1.GovSoftwareUpgradePayload{
+				ChainID: testChainID, KeyName: testKeyName,
+				Title: "t", Description: "d", UpgradeName: "v2", UpgradeHeight: 1000,
+				InitialDeposit: "10000000usei", Fees: testFees, Gas: 200000,
+			},
+		},
+	}
+}
+
+func readyReasonOf(cr *seiv1alpha1.SeiNodeTask) string {
+	for _, c := range cr.Status.Conditions {
+		if c.Type == seiv1alpha1.ConditionSeiNodeTaskReady && c.Status == metav1.ConditionTrue {
+			return c.Reason
+		}
+	}
+	return ""
+}
+
+func failedReasonOf(cr *seiv1alpha1.SeiNodeTask) string {
+	for _, c := range cr.Status.Conditions {
+		if c.Type == seiv1alpha1.ConditionSeiNodeTaskFailed && c.Status == metav1.ConditionTrue {
+			return c.Reason
+		}
+	}
+	return ""
+}
+
+func TestReconcile_GovUpgrade_Confirmed(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	fakeSC := newFakeSidecarClient()
+	r, c := newReconcilerWithSidecar(t, time.Now(), fakeSC, newGovUpgradeTask(), newRunningNode())
+
+	_, err := r.Reconcile(ctx, req()) // R1 synth
+	g.Expect(err).NotTo(HaveOccurred())
+	taskID, perr := uuid.Parse(getTask(t, ctx, c).Status.Task.ID)
+	g.Expect(perr).NotTo(HaveOccurred())
+
+	_, err = r.Reconcile(ctx, req()) // R2 submit
+	g.Expect(err).NotTo(HaveOccurred())
+
+	fakeSC.setResultPayload(taskID, sidecar.Completed, "",
+		json.RawMessage(`{"txHash":"ABC","height":10,"proposalId":42,"inclusionStatus":"committed_ok"}`))
+
+	_, err = r.Reconcile(ctx, req()) // R3 poll → confirmed
+	g.Expect(err).NotTo(HaveOccurred())
+	got := getTask(t, ctx, c)
+	g.Expect(got.Status.Phase).To(Equal(seiv1alpha1.SeiNodeTaskPhaseComplete))
+	g.Expect(readyReasonOf(got)).To(Equal("Confirmed"))
+	g.Expect(got.Status.Outputs).NotTo(BeNil())
+	g.Expect(got.Status.Outputs.GovSoftwareUpgrade).NotTo(BeNil())
+	g.Expect(got.Status.Outputs.GovSoftwareUpgrade.ProposalID).To(Equal(uint64(42)))
+	g.Expect(got.Status.Outputs.GovSoftwareUpgrade.TxHash).To(Equal("ABC"))
+	g.Expect(got.Status.Outputs.GovSoftwareUpgrade.Height).To(Equal(int64(10)))
+}
+
+func TestReconcile_GovUpgrade_CommittedFailed(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	fakeSC := newFakeSidecarClient()
+	r, c := newReconcilerWithSidecar(t, time.Now(), fakeSC, newGovUpgradeTask(), newRunningNode())
+
+	_, err := r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	taskID, _ := uuid.Parse(getTask(t, ctx, c).Status.Task.ID)
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	fakeSC.setResultPayload(taskID, sidecar.Failed, "committed but failed: code=11",
+		json.RawMessage(`{"txHash":"ABC","code":11,"inclusionStatus":"committed_failed"}`))
+
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	got := getTask(t, ctx, c)
+	g.Expect(got.Status.Phase).To(Equal(seiv1alpha1.SeiNodeTaskPhaseFailed))
+	g.Expect(failedReasonOf(got)).To(Equal("TxFailed"))
+	g.Expect(got.Status.Outputs).NotTo(BeNil())
+	g.Expect(got.Status.Outputs.GovSoftwareUpgrade.TxHash).To(Equal("ABC"))
+}
+
+func TestReconcile_GovUpgrade_Pending_ReSubmits(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	fakeSC := newFakeSidecarClient()
+	// No spec.timeoutSeconds → unbounded → pending always re-submits.
+	r, c := newReconcilerWithSidecar(t, time.Now(), fakeSC, newGovUpgradeTask(), newRunningNode())
+
+	_, err := r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	taskID, _ := uuid.Parse(getTask(t, ctx, c).Status.Task.ID)
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	fakeSC.setResultPayload(taskID, sidecar.Failed, "inclusion undetermined",
+		json.RawMessage(`{"txHash":"ABC","inclusionStatus":"pending"}`))
+
+	_, err = r.Reconcile(ctx, req()) // R3: pending → reset to Pending, stay Running
+	g.Expect(err).NotTo(HaveOccurred())
+	got := getTask(t, ctx, c)
+	g.Expect(got.Status.Phase).To(Equal(seiv1alpha1.SeiNodeTaskPhaseRunning))
+	g.Expect(got.Status.Task.Status).To(Equal(seiv1alpha1.TaskPending))
+
+	before := fakeSC.submitCount()
+	_, err = r.Reconcile(ctx, req()) // R4: re-submits (same task ID → engine re-run)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(fakeSC.submitCount()).To(Equal(before + 1))
+
+	// Convergence: the re-checked tx now commits → Complete/Confirmed.
+	fakeSC.setResultPayload(taskID, sidecar.Completed, "",
+		json.RawMessage(`{"txHash":"ABC","proposalId":7,"inclusionStatus":"committed_ok"}`))
+	_, err = r.Reconcile(ctx, req()) // R5: re-submit then poll → confirmed
+	g.Expect(err).NotTo(HaveOccurred())
+	got = getTask(t, ctx, c)
+	g.Expect(got.Status.Phase).To(Equal(seiv1alpha1.SeiNodeTaskPhaseComplete))
+	g.Expect(readyReasonOf(got)).To(Equal("Confirmed"))
+	g.Expect(got.Status.Outputs.GovSoftwareUpgrade.ProposalID).To(Equal(uint64(7)))
+}
+
+// TestGovResultMirrorMatchesWire guards the local govResult mirror against
+// drift from seictl's GovTxResult: a field/constant rename there would decode
+// to zero here and silently misroute outcomes (the cost of not importing the
+// type). This test fails loudly if the wire shape diverges.
+func TestGovResultMirrorMatchesWire(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(inclusionCommittedOK).To(Equal(sidecartasks.InclusionCommittedOK))
+	g.Expect(inclusionCommittedFailed).To(Equal(sidecartasks.InclusionCommittedFailed))
+	g.Expect(inclusionPending).To(Equal(sidecartasks.InclusionPending))
+
+	raw, err := json.Marshal(sidecartasks.GovTxResult{
+		TxHash: "ABC", Height: 9, ProposalID: 42, Code: 5,
+		Codespace: "sdk", RawLog: "boom", InclusionStatus: sidecartasks.InclusionCommittedFailed,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	var gr govResult
+	g.Expect(json.Unmarshal(raw, &gr)).To(Succeed())
+	g.Expect(gr).To(Equal(govResult{
+		TxHash: "ABC", Height: 9, ProposalID: 42, Code: 5,
+		Codespace: "sdk", RawLog: "boom", InclusionStatus: inclusionCommittedFailed,
+	}))
+}
+
+// A gov Failed with no result payload (e.g. CheckTx reject) is a generic
+// terminal failure, not committed_failed/pending.
+func TestReconcile_GovUpgrade_NoResult_GenericFailure(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	fakeSC := newFakeSidecarClient()
+	r, c := newReconcilerWithSidecar(t, time.Now(), fakeSC, newGovUpgradeTask(), newRunningNode())
+
+	_, err := r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	taskID, _ := uuid.Parse(getTask(t, ctx, c).Status.Task.ID)
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	fakeSC.setResult(taskID, sidecar.Failed, "checkTx rejected: code=5")
+
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	got := getTask(t, ctx, c)
+	g.Expect(got.Status.Phase).To(Equal(seiv1alpha1.SeiNodeTaskPhaseFailed))
+	g.Expect(failedReasonOf(got)).To(Equal("TaskFailed"))
+}
+
+func TestReconcile_GovVote_Confirmed(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	fakeSC := newFakeSidecarClient()
+	r, c := newReconcilerWithSidecar(t, time.Now(), fakeSC, newGovVoteTask(), newRunningNode())
+
+	_, err := r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	taskID, _ := uuid.Parse(getTask(t, ctx, c).Status.Task.ID)
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	fakeSC.setResultPayload(taskID, sidecar.Completed, "",
+		json.RawMessage(`{"txHash":"V1","height":3,"inclusionStatus":"committed_ok"}`))
+
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	got := getTask(t, ctx, c)
+	g.Expect(got.Status.Phase).To(Equal(seiv1alpha1.SeiNodeTaskPhaseComplete))
+	g.Expect(readyReasonOf(got)).To(Equal("Confirmed"))
+	g.Expect(got.Status.Outputs).NotTo(BeNil())
+	g.Expect(got.Status.Outputs.GovVote).NotTo(BeNil())
+	g.Expect(got.Status.Outputs.GovVote.TxHash).To(Equal("V1"))
+	g.Expect(got.Status.Outputs.GovVote.Height).To(Equal(int64(3)))
+}
+
+func TestReconcile_GovUpgrade_PendingTimeout_Fails(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	fakeSC := newFakeSidecarClient()
+	clock := time.Now()
+	cr := newGovUpgradeTask()
+	cr.Spec.TimeoutSeconds = 1
+	r, c := newReconcilerWithSidecar(t, clock, fakeSC, cr, newRunningNode())
+	r.Now = func() time.Time { return clock }
+
+	_, err := r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	taskID, _ := uuid.Parse(getTask(t, ctx, c).Status.Task.ID)
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	fakeSC.setResultPayload(taskID, sidecar.Failed, "inclusion undetermined",
+		json.RawMessage(`{"txHash":"ABC","inclusionStatus":"pending"}`))
+
+	clock = clock.Add(2 * time.Second) // past spec.timeoutSeconds
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	got := getTask(t, ctx, c)
+	g.Expect(got.Status.Phase).To(Equal(seiv1alpha1.SeiNodeTaskPhaseFailed))
+	g.Expect(failedReasonOf(got)).To(Equal("InclusionUndetermined"))
+	g.Expect(got.Status.Outputs.GovSoftwareUpgrade.TxHash).To(Equal("ABC")) // txHash retained
+}

--- a/internal/controller/nodetask/controller_test.go
+++ b/internal/controller/nodetask/controller_test.go
@@ -617,13 +617,11 @@ func TestReconcile_GovVote_EndToEnd(t *testing.T) {
 	g.Expect(got.Status.Phase).To(Equal(seiv1alpha1.SeiNodeTaskPhaseComplete))
 	g.Expect(got.Status.Task.Status).To(Equal(seiv1alpha1.TaskComplete))
 
-	// Regression guard: typed GovVote outputs intentionally stay nil in
-	// this PR. populateOutputs only stamps UpdateNodeImage today; flipping
-	// that without updating the LLD (chain-as-medium, no task-to-task
-	// currying) should fail this assertion loudly.
+	// This run stages no result payload, so no GovVote output is stamped.
+	// (Gov outputs are populated when the sidecar returns a result — see the
+	// dedicated completion-contract tests in controller_gov_test.go.)
 	if got.Status.Outputs != nil {
-		g.Expect(got.Status.Outputs.GovVote).To(BeNil(),
-			"populateOutputs unexpectedly populated GovVote — see PR 3 scope notes in controller.go")
+		g.Expect(got.Status.Outputs.GovVote).To(BeNil())
 	}
 }
 

--- a/internal/controller/nodetask/govoutputs.go
+++ b/internal/controller/nodetask/govoutputs.go
@@ -1,0 +1,85 @@
+package nodetask
+
+import (
+	"encoding/json"
+
+	seiv1alpha1 "github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/internal/task"
+)
+
+// govResult mirrors the sidecar's tasks.GovTxResult wire shape (decoded from
+// the task-result channel) without importing the heavy sidecar tasks package.
+type govResult struct {
+	TxHash          string `json:"txHash"`
+	Height          int64  `json:"height"`
+	ProposalID      uint64 `json:"proposalId"`
+	Code            uint32 `json:"code"`
+	Codespace       string `json:"codespace"`
+	RawLog          string `json:"rawLog"`
+	InclusionStatus string `json:"inclusionStatus"`
+}
+
+// Inclusion outcomes — the sidecar's stable wire enum (seictl tasks.Inclusion*).
+const (
+	inclusionCommittedOK     = "committed_ok"
+	inclusionCommittedFailed = "committed_failed"
+	inclusionPending         = "pending"
+)
+
+// resulter is the optional accessor sidecarExecution implements to surface the
+// handler's structured result.
+type resulter interface{ Result() json.RawMessage }
+
+// decodeGovResult extracts the gov result from a terminal execution, or nil if
+// it carries none or doesn't parse.
+func decodeGovResult(exec task.TaskExecution) *govResult {
+	r, ok := exec.(resulter)
+	if !ok {
+		return nil
+	}
+	raw := r.Result()
+	if len(raw) == 0 {
+		return nil
+	}
+	var gr govResult
+	if err := json.Unmarshal(raw, &gr); err != nil {
+		return nil
+	}
+	return &gr
+}
+
+func isGovKind(k seiv1alpha1.SeiNodeTaskKind) bool {
+	switch k {
+	case seiv1alpha1.SeiNodeTaskKindGovVote,
+		seiv1alpha1.SeiNodeTaskKindGovSoftwareUpgrade,
+		seiv1alpha1.SeiNodeTaskKindGovParamChange:
+		return true
+	}
+	return false
+}
+
+// populateGovOutputs maps a decoded gov result into the matching CRD Outputs
+// sub-field. Called on both the confirmed and failed terminal paths so txHash
+// (and proposalId, when known) are always surfaced.
+func populateGovOutputs(cr *seiv1alpha1.SeiNodeTask, gr *govResult) {
+	if gr == nil {
+		return
+	}
+	if cr.Status.Outputs == nil {
+		cr.Status.Outputs = &seiv1alpha1.SeiNodeTaskOutputs{}
+	}
+	switch cr.Spec.Kind {
+	case seiv1alpha1.SeiNodeTaskKindGovSoftwareUpgrade:
+		cr.Status.Outputs.GovSoftwareUpgrade = &seiv1alpha1.GovSoftwareUpgradeOutputs{
+			TxHash: gr.TxHash, Height: gr.Height, ProposalID: gr.ProposalID,
+		}
+	case seiv1alpha1.SeiNodeTaskKindGovParamChange:
+		cr.Status.Outputs.GovParamChange = &seiv1alpha1.GovParamChangeOutputs{
+			TxHash: gr.TxHash, Height: gr.Height, ProposalID: gr.ProposalID,
+		}
+	case seiv1alpha1.SeiNodeTaskKindGovVote:
+		cr.Status.Outputs.GovVote = &seiv1alpha1.GovVoteOutputs{
+			TxHash: gr.TxHash, Height: gr.Height,
+		}
+	}
+}

--- a/internal/task/sidecar.go
+++ b/internal/task/sidecar.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -23,6 +24,9 @@ type sidecarExecution[T sidecar.TaskBuilder] struct {
 	fireAndForget bool
 	status        ExecutionStatus
 	err           error
+	// result is the handler's structured output from the terminal GetTask,
+	// surfaced to the controller via Result(). Nil for tasks that emit none.
+	result json.RawMessage
 }
 
 func (e *sidecarExecution[T]) ensureClient() (SidecarClient, error) {
@@ -102,6 +106,13 @@ func (e *sidecarExecution[T]) Status(ctx context.Context) ExecutionStatus {
 		return e.status
 	}
 
+	// Capture the handler's structured result on any terminal outcome — it is
+	// stamped on both Completed and Failed (e.g. a gov submit carries txHash /
+	// inclusionStatus even when it fails).
+	if result.Result != nil {
+		e.result = *result.Result
+	}
+
 	switch result.Status {
 	case sidecar.Completed:
 		e.status = ExecutionComplete
@@ -117,3 +128,7 @@ func (e *sidecarExecution[T]) Status(ctx context.Context) ExecutionStatus {
 }
 
 func (e *sidecarExecution[T]) Err() error { return e.err }
+
+// Result returns the handler's structured output from the terminal GetTask, or
+// nil. Only sidecarExecution implements it; the controller type-asserts for it.
+func (e *sidecarExecution[T]) Result() json.RawMessage { return e.result }

--- a/sdk/sei/provider/k8s/handle.go
+++ b/sdk/sei/provider/k8s/handle.go
@@ -283,10 +283,24 @@ func taskFailureReason(task *seiv1alpha1.SeiNodeTask) string {
 // kind the controller's populateOutputs writes; gov/await kinds coordinate via
 // chain queries (chain-as-medium), so the SDK exposes no always-empty fields.
 func translateTaskOutputs(out *seiv1alpha1.SeiNodeTaskOutputs) *sei.TaskOutputs {
-	if out == nil || out.UpdateNodeImage == nil {
+	if out == nil {
 		return nil
 	}
-	return &sei.TaskOutputs{
-		UpdateNodeImage: &sei.UpdateNodeImageOutputs{AppliedImage: out.UpdateNodeImage.AppliedImage},
+	t := &sei.TaskOutputs{}
+	if o := out.UpdateNodeImage; o != nil {
+		t.UpdateNodeImage = &sei.UpdateNodeImageOutputs{AppliedImage: o.AppliedImage}
 	}
+	if o := out.GovSoftwareUpgrade; o != nil {
+		t.GovSoftwareUpgrade = &sei.GovProposalOutputs{TxHash: o.TxHash, Height: o.Height, ProposalID: o.ProposalID}
+	}
+	if o := out.GovParamChange; o != nil {
+		t.GovParamChange = &sei.GovProposalOutputs{TxHash: o.TxHash, Height: o.Height, ProposalID: o.ProposalID}
+	}
+	if o := out.GovVote; o != nil {
+		t.GovVote = &sei.GovVoteOutputs{TxHash: o.TxHash, Height: o.Height}
+	}
+	if *t == (sei.TaskOutputs{}) {
+		return nil
+	}
+	return t
 }

--- a/sdk/sei/task.go
+++ b/sdk/sei/task.go
@@ -11,13 +11,9 @@ import (
 // node image. A caller drives a major-upgrade or release flow by running these
 // in statement order.
 //
-// Cross-task coordination is chain-as-medium, NOT task-to-task output currying:
-// the controller surfaces typed Outputs only for UpdateNodeImage today (the gov
-// and await kinds leave them unset — surfacing the sidecar's TaskResult needs
-// typed per-task result payloads that are deferred). So a harness that needs a
-// minted proposal ID for a follow-on GovVote queries the chain for it (e.g. the
-// first proposal on a fresh chain is #1), rather than reading it off the upgrade
-// task. TaskOutputs therefore carries only the kinds the controller populates.
+// Completed tasks surface typed Outputs: a gov proposal submission returns its
+// proposal ID and tx hash, so a follow-on GovVote reads the ID off the upgrade
+// task rather than querying the chain.
 //
 // SeiNodeTask is SeiNode-specific, so it belongs in the SDK. The surface mirrors
 // CreateNetwork/CreateNode: a typed spec with SDK-native payloads (core stays
@@ -140,19 +136,32 @@ type UpdateNodeImage struct {
 	Image string // desired seid image (with tag/digest)
 }
 
-// TaskOutputs carries a completed task's typed results. Only the kinds the
-// controller actually populates are surfaced — today just UpdateNodeImage; the
-// gov and await kinds coordinate via chain queries (see the package doc), so
-// their output fields are intentionally absent rather than present-but-always-
-// empty. Outputs are populated only on a completed task; a nil sub-field means
-// the task produced no typed output.
+// TaskOutputs carries a completed task's typed results. A nil sub-field means
+// that kind produced no typed output.
 type TaskOutputs struct {
-	UpdateNodeImage *UpdateNodeImageOutputs
+	UpdateNodeImage    *UpdateNodeImageOutputs
+	GovSoftwareUpgrade *GovProposalOutputs
+	GovParamChange     *GovProposalOutputs
+	GovVote            *GovVoteOutputs
 }
 
 // UpdateNodeImageOutputs are the results of an UpdateNodeImage task.
 type UpdateNodeImageOutputs struct {
 	AppliedImage string // image now observed on target.status.currentImage
+}
+
+// GovProposalOutputs are the results of a gov proposal submission
+// (software-upgrade or param-change).
+type GovProposalOutputs struct {
+	TxHash     string
+	Height     int64
+	ProposalID uint64
+}
+
+// GovVoteOutputs are the results of a gov vote (no proposal is minted).
+type GovVoteOutputs struct {
+	TxHash string
+	Height int64
 }
 
 // RunTask creates a SeiNodeTask and returns a handle immediately — it does NOT

--- a/test/integration/upgrade_test.go
+++ b/test/integration/upgrade_test.go
@@ -153,9 +153,10 @@ func TestChainUpgrade(t *testing.T) {
 	upgradeHeight := cur + delta
 	t.Logf("current height %d; scheduling upgrade %q at height %d", cur, upgradeName, upgradeHeight)
 
-	// 1) Submit the upgrade proposal from validator-0.
+	// 1) Submit the upgrade proposal from validator-0 and read the minted
+	// proposal ID straight off the task output (no chain-as-medium scan).
 	proposer := validatorName(chainID, 0)
-	runTaskComplete(ctx, t, c, sei.TaskSpec{
+	out := runTaskComplete(ctx, t, c, sei.TaskSpec{
 		Name:      taskName(chainID, "propose"),
 		Namespace: ns,
 		Node:      proposer,
@@ -173,15 +174,11 @@ func TestChainUpgrade(t *testing.T) {
 			Gas:            proposeGas,
 		},
 	})
-	t.Logf("upgrade proposal submitted from %s", proposer)
-
-	// 2) Resolve the proposal ID from the chain — the controller does not surface
-	// it as a task output (chain-as-medium).
-	proposalID, err := resolveProposalID(ctx, hc, rest, upgradeName)
-	if err != nil {
-		t.Fatalf("resolve proposal id: %v", err)
+	if out == nil || out.GovSoftwareUpgrade == nil || out.GovSoftwareUpgrade.ProposalID == 0 {
+		t.Fatalf("upgrade task did not surface a proposal ID: %+v", out)
 	}
-	t.Logf("resolved proposal id %d", proposalID)
+	proposalID := out.GovSoftwareUpgrade.ProposalID
+	t.Logf("upgrade proposal submitted from %s; proposal id %d (from task output)", proposer, proposalID)
 
 	// 3) Vote yes from every validator in parallel.
 	voteAllValidators(ctx, t, c, chainID, ns, validators, proposalID, runLabels)
@@ -348,17 +345,20 @@ func awaitAllValidatorsAtHeight(
 }
 
 // runTaskComplete runs one task to completion, registering its deletion for
-// cleanup, and fails the suite if it does not complete.
-func runTaskComplete(ctx context.Context, t *testing.T, c *sei.Client, ts sei.TaskSpec) {
+// cleanup, and fails the suite if it does not complete. Returns the task's
+// typed outputs (nil for kinds that emit none).
+func runTaskComplete(ctx context.Context, t *testing.T, c *sei.Client, ts sei.TaskSpec) *sei.TaskOutputs {
 	t.Helper()
 	task, err := c.RunTask(ctx, ts)
 	if err != nil {
 		t.Fatalf("run task %s (%s): %v", ts.Name, ts.Kind, err)
 	}
 	registerTaskCleanup(t, task)
-	if _, err := task.WaitComplete(ctx); err != nil {
+	out, err := task.WaitComplete(ctx)
+	if err != nil {
 		t.Fatalf("task %s (%s): %v", ts.Name, ts.Kind, err)
 	}
+	return out
 }
 
 // registerTaskCleanup best-effort deletes a task on a fresh context at test end.
@@ -382,74 +382,7 @@ func taskName(chainID, step string) string {
 	return fmt.Sprintf("%s-%s", chainID, step)
 }
 
-// --- chain-as-medium gov queries (harness-level: Cosmos gov REST, not SDK) ---
-
-// govProposal models just enough of a proposal to resolve an upgrade proposal by
-// its plan name and read its status. The legacy (v1beta1) shape carries the plan
-// at content.plan.name; the v1 shape carries it under messages[].content.plan.name
-// — both are accepted.
-type govProposal struct {
-	ProposalID string `json:"proposal_id"`
-	Status     string `json:"status"`
-	Content    struct {
-		Plan struct {
-			Name string `json:"name"`
-		} `json:"plan"`
-	} `json:"content"`
-	Messages []struct {
-		Content struct {
-			Plan struct {
-				Name string `json:"name"`
-			} `json:"plan"`
-		} `json:"content"`
-	} `json:"messages"`
-}
-
-// planName returns the upgrade plan name from whichever shape carries it.
-func (p govProposal) planName() string {
-	if p.Content.Plan.Name != "" {
-		return p.Content.Plan.Name
-	}
-	for _, m := range p.Messages {
-		if m.Content.Plan.Name != "" {
-			return m.Content.Plan.Name
-		}
-	}
-	return ""
-}
-
-// resolveProposalID polls the gov REST endpoint for the voting-period proposal
-// whose upgrade plan name matches upgradeName and returns its ID.
-func resolveProposalID(ctx context.Context, hc *http.Client, rest, upgradeName string) (uint64, error) {
-	// proposal_status=2 is PROPOSAL_STATUS_VOTING_PERIOD.
-	endpoint := rest + "/cosmos/gov/v1beta1/proposals?proposal_status=2"
-	what := fmt.Sprintf("resolve proposal id for %q", upgradeName)
-	var found uint64
-	err := pollREST(ctx, what, func(ctx context.Context) (bool, string, error) {
-		var body struct {
-			Proposals []govProposal `json:"proposals"`
-		}
-		if !getJSONInto(ctx, hc, endpoint, &body) {
-			return false, restUnreachable, nil
-		}
-		for _, p := range body.Proposals {
-			if p.planName() != upgradeName {
-				continue
-			}
-			id, err := strconv.ParseUint(p.ProposalID, 10, 64)
-			if err != nil {
-				return false, "", fmt.Errorf("unparseable proposal id %q: %w", p.ProposalID, err)
-			}
-			found = id
-			return true, "", nil
-		}
-		// None matched: a proposal stuck in the deposit period (deposit below
-		// min_deposit) never reaches the status=2 set polled here.
-		seen := fmt.Sprintf("%d voting-period proposals, none match plan %q", len(body.Proposals), upgradeName)
-		return false, seen, nil
-	})
-	return found, err
-}
+// --- chain gov queries (harness-level: Cosmos gov REST, not SDK) ---
 
 // waitProposalPassed polls a single proposal until it reaches PASSED, failing
 // fast if it lands in a terminal non-passed state (REJECTED/FAILED).
@@ -457,7 +390,9 @@ func waitProposalPassed(ctx context.Context, hc *http.Client, rest string, id ui
 	endpoint := fmt.Sprintf("%s/cosmos/gov/v1beta1/proposals/%d", rest, id)
 	return pollREST(ctx, fmt.Sprintf("proposal %d passed", id), func(ctx context.Context) (bool, string, error) {
 		var body struct {
-			Proposal govProposal `json:"proposal"`
+			Proposal struct {
+				Status string `json:"status"`
+			} `json:"proposal"`
 		}
 		if !getJSONInto(ctx, hc, endpoint, &body) {
 			return false, restUnreachable, nil


### PR DESCRIPTION
The controller half of the SeiNodeTask governance UX work (design: sei-protocol/bdchatham-designs#98) — consumes the seictl **v0.0.61** gov completion contract. This is the payoff: a completed gov task now surfaces its proposal ID / tx hash, a task reports Failed instead of a false Complete when a tx doesn't commit, and the integration test's brittle proposal-ID REST scan is deleted.

Depends on: seictl#219 (v0.0.61). Follows PR #450 (stop-resubmit).

## Changes
- `go.mod` → seictl v0.0.61.
- `sidecarExecution.Result()` captures the terminal task result (both success and failure paths).
- `driveTask` decodes the gov result and branches: **committed_ok** → Complete + Ready/`Confirmed` + outputs; **committed_failed** → Failed/`TxFailed` + outputs; **pending** → reset to Pending and re-submit (same task ID → engine run+1 → marker adopt re-checks), bounded by `spec.timeoutSeconds`; on timeout → Failed/`InclusionUndetermined` (txHash retained). Non-gov failures unchanged.
- `populateOutputs` stamps proposalId/txHash/height into the existing CRD Outputs (decode-by-kind, via a local wire-mirror — no heavy sidecar-tasks import). No CRD schema change.
- SDK `TaskOutputs` gains gov arms; **integration test reads the proposal ID off the task output and deletes `resolveProposalID`** (the plan-name REST scan).
- Refreshed the stale "outputs deferred / chain-as-medium" docs.

## Tests
`controller_gov_test.go`: Confirmed / CommittedFailed / Pending→resubmit→converge / PendingTimeout / GovVote-confirmed / no-result→generic-failure, plus `TestGovResultMirrorMatchesWire` (guards the local mirror against seictl `GovTxResult` drift).

## Sign-off
systems-engineer (pending loop, decode, idempotency — logic correct, no changes) and kubernetes-specialist (condition discipline, single-patch, contract-safe) — both green.

## ⚠️ Deploy-order (one-way-door adjacent)
Roll **this controller before** the seictl v0.0.61 sidecar image. A pre-2b controller treats the new sidecar's `pending`→Failed as terminal and would prematurely fail an in-flight gov tx. New-controller + old-sidecar is graceful (nil result → today's behavior).

## Reviewer flag for confirmation
Gov-kind success now emits Ready `reason=Confirmed` (was `TaskComplete`). Confirm no PromQL/runbook filters the old reason for gov kinds (gov-ops is a newer surface, likely safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
