### PR TITLE
feat(noderesource): sei.io/dedicated-node annotation for exclusive-node scheduling

### DIFF
--- a/internal/noderesource/noderesource.go
+++ b/internal/noderesource/noderesource.go
@@ -32,6 +32,21 @@ const (
 	chainLabel = "sei.io/chain"
 	roleLabel  = "sei.io/role"
 
+	// DedicatedNodeKey is the well-known key used both as a SeiNode annotation
+	// (the opt-in) and as the pod-template label it is mirrored to. Value
+	// "true" opts the node into single-tenant scheduling: its pod refuses to
+	// share a Kubernetes node with any other Sei-managed pod, and every other
+	// Sei-managed pod refuses to share a node with it. Experimental and
+	// annotation-driven so it needs no CRD schema bump — see the dedicated-node
+	// runbook. It is mirrored to a label because pod anti-affinity selects on
+	// labels, not annotations.
+	DedicatedNodeKey   = "sei.io/dedicated-node"
+	dedicatedNodeValue = "true"
+
+	// hostnameTopologyKey is the standard per-node topology domain; anti-affinity
+	// keyed on it enforces isolation at the granularity of a single K8s node.
+	hostnameTopologyKey = "kubernetes.io/hostname"
+
 	roleValidator = "validator"
 	roleArchive   = "archive"
 	roleReplayer  = "replayer"
@@ -136,7 +151,69 @@ func ResourceLabels(node *seiv1alpha1.SeiNode) map[string]string {
 		labels[chainLabel] = node.Spec.ChainID
 	}
 	labels[roleLabel] = deriveRole(node)
+	if IsDedicatedNode(node) {
+		labels[DedicatedNodeKey] = dedicatedNodeValue
+	}
 	return labels
+}
+
+// IsDedicatedNode reports whether the SeiNode opts into single-tenant node
+// scheduling via the sei.io/dedicated-node annotation.
+//
+// A pod that can never be scheduled (no available single-tenant node) stays
+// Pending with no SeiNode condition reflecting it; check the pod's own
+// PodScheduled condition or events directly. See the dedicated-node runbook.
+func IsDedicatedNode(node *seiv1alpha1.SeiNode) bool {
+	return node.Annotations[DedicatedNodeKey] == dedicatedNodeValue
+}
+
+// BuildPodAntiAffinity assembles the pod anti-affinity for a Sei pod.
+//
+// The isolation guarantee is bidirectional and requires two terms because a
+// pod anti-affinity is evaluated only from the perspective of the pod being
+// scheduled — a running pod does not retroactively repel later arrivals.
+//
+//   - The defensive term is on EVERY Sei pod (dedicated or not): don't land on
+//     a node already hosting a dedicated-node pod. This is what protects a
+//     dedicated pod from a LATER pod scheduling next to it. It is near-free —
+//     its selector matches nothing unless a dedicated pod exists.
+//   - The requester term is added only when dedicated is true: don't land on a
+//     node already hosting ANY Sei-managed pod. This protects the dedicated pod
+//     at its own schedule time. It keys on sei.io/node (present on both
+//     StatefulSet and bootstrap pods) via Exists, so it catches every Sei pod,
+//     not just those with a sei.io/role value.
+//
+// Both terms match across all namespaces (an empty, non-nil NamespaceSelector)
+// because co-tenants routinely live in other namespaces (per-engineer
+// namespaces on shared benchmarking nodepools); the default same-namespace
+// scope would silently miss them.
+func BuildPodAntiAffinity(dedicated bool) *corev1.PodAntiAffinity {
+	terms := []corev1.PodAffinityTerm{{
+		TopologyKey:       hostnameTopologyKey,
+		NamespaceSelector: &metav1.LabelSelector{},
+		LabelSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      DedicatedNodeKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{dedicatedNodeValue},
+			}},
+		},
+	}}
+	if dedicated {
+		terms = append(terms, corev1.PodAffinityTerm{
+			TopologyKey:       hostnameTopologyKey,
+			NamespaceSelector: &metav1.LabelSelector{},
+			LabelSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      NodeLabel,
+					Operator: metav1.LabelSelectorOpExists,
+				}},
+			},
+		})
+	}
+	return &corev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: terms,
+	}
 }
 
 // deriveRole returns the role label value for the node's mode. Stamped
@@ -476,6 +553,7 @@ func buildNodePodSpec(node *seiv1alpha1.SeiNode, p PlatformConfig) (corev1.PodSp
 					}},
 				},
 			},
+			PodAntiAffinity: BuildPodAntiAffinity(IsDedicatedNode(node)),
 		},
 		Volumes: volumes,
 	}

--- a/internal/noderesource/noderesource_test.go
+++ b/internal/noderesource/noderesource_test.go
@@ -722,6 +722,49 @@ func TestBuildNodePodSpec_FullNode_SchedulesOnDefaultNodepool(t *testing.T) {
 	g.Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf("sei-node"))
 }
 
+func TestBuildNodePodSpec_NonDedicated_OnlyDefensiveAntiAffinity(t *testing.T) {
+	g := NewWithT(t)
+	node := newSnapshotNode("syncer-0", "pacific-1")
+
+	spec, err := buildNodePodSpec(node, platformtest.Config())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	terms := spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	g.Expect(terms).To(HaveLen(1))
+	g.Expect(terms[0].TopologyKey).To(Equal("kubernetes.io/hostname"))
+	g.Expect(terms[0].NamespaceSelector).NotTo(BeNil()) // empty = all namespaces
+	g.Expect(terms[0].LabelSelector.MatchExpressions[0].Key).To(Equal(DedicatedNodeKey))
+
+	// Non-exclusive pods are not labeled exclusive.
+	g.Expect(ResourceLabels(node)).NotTo(HaveKey(DedicatedNodeKey))
+}
+
+func TestBuildNodePodSpec_Dedicated_AddsRequesterTermAndLabel(t *testing.T) {
+	g := NewWithT(t)
+	node := newSnapshotNode("syncer-0", "pacific-1")
+	node.Annotations = map[string]string{DedicatedNodeKey: "true"}
+
+	spec, err := buildNodePodSpec(node, platformtest.Config())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	terms := spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	g.Expect(terms).To(HaveLen(2))
+	// Defensive term keys on the exclusive label; requester term keys on
+	// sei.io/node Exists (spans StatefulSet + bootstrap pods).
+	g.Expect(terms[0].LabelSelector.MatchExpressions[0].Key).To(Equal(DedicatedNodeKey))
+	g.Expect(terms[1].LabelSelector.MatchExpressions[0].Key).To(Equal(NodeLabel))
+	g.Expect(terms[1].LabelSelector.MatchExpressions[0].Operator).To(Equal(metav1.LabelSelectorOpExists))
+	for _, term := range terms {
+		g.Expect(term.TopologyKey).To(Equal("kubernetes.io/hostname"))
+		g.Expect(term.NamespaceSelector).NotTo(BeNil())
+	}
+
+	// The annotation is mirrored to a pod-template label so anti-affinity
+	// selectors on other pods can match it.
+	g.Expect(spec).NotTo(BeNil())
+	g.Expect(ResourceLabels(node)).To(HaveKeyWithValue(DedicatedNodeKey, "true"))
+}
+
 func TestDefaultStorageForMode_Archive(t *testing.T) {
 	g := NewWithT(t)
 	cfg := platformtest.Config()

--- a/internal/task/bootstrap_resources.go
+++ b/internal/task/bootstrap_resources.go
@@ -19,7 +19,6 @@ import (
 const (
 	bootstrapTerminationGracePeriod = int64(120)
 	bootstrapDataDir                = platform.DataDir
-	bootstrapNodeLabel              = "sei.io/node"
 	bootstrapComponentLabel         = "sei.io/component"
 )
 
@@ -36,7 +35,7 @@ func BootstrapJobName(node *seiv1alpha1.SeiNode) string {
 // BootstrapLabels returns labels for bootstrap Job resources.
 func BootstrapLabels(node *seiv1alpha1.SeiNode) map[string]string {
 	return map[string]string{
-		bootstrapNodeLabel:      node.Name,
+		noderesource.NodeLabel:  node.Name,
 		bootstrapComponentLabel: "bootstrap",
 	}
 }
@@ -224,6 +223,10 @@ func buildBootstrapPodSpec(node *seiv1alpha1.SeiNode, snap *seiv1alpha1.Snapshot
 					}},
 				},
 			},
+			// Defensive term only: a bootstrap Job pod must not land on a node
+			// reserved by a dedicated-node pod. Bootstrap is not itself a
+			// requester (no exclusive term, not labeled exclusive).
+			PodAntiAffinity: noderesource.BuildPodAntiAffinity(false),
 		},
 		Volumes:        []corev1.Volume{dataVolume, proxyConfigVolume},
 		InitContainers: []corev1.Container{seidInit, sidecar, rbacProxy},


### PR DESCRIPTION
## Summary

Adds an opt-in `sei.io/dedicated-node` annotation on `SeiNode` — no CRD schema change, so it ships without a version bump. When set, the controller renders bidirectional `PodAntiAffinity`:

- A **defensive term on every Sei-managed pod** (dedicated or not): never land on a node already hosting a `sei.io/dedicated-node` pod.
- A **requester term, only on the dedicated pod itself**: never land on a node already hosting *any* Sei-managed pod (matched via `sei.io/node` Exists — spans both StatefulSet and bootstrap pods — scoped across all namespaces, since co-tenants live in per-engineer namespaces on harbor).

Both terms are needed because pod anti-affinity is evaluated only from the perspective of the pod being scheduled — a running pod can't retroactively repel a later arrival.

**Motivation:** a real incident during a benchmarking exercise — a SeiNode requesting the default 4 vCPU landed on a 32-vCPU node already shared with three other engineers' SeiNode pods, which would corrupt any wall-clock timing measurement taken against it.

## Review

Independently reviewed via `/xreview` (ledger: `.xreview/dedicated-node-annotation.md`, not committed per this repo's existing convention for the two prior ledgers):

- **kubernetes-specialist** — verified Kubernetes anti-affinity semantics against the vendored `k8s.io/api@v0.35.0` godoc (the empty-vs-nil `NamespaceSelector` distinction this design depends on). Caught and fixed a latent-coupling issue: `task.bootstrapNodeLabel` and `noderesource.NodeLabel` were independently-defined identical string literals with no compile/test-time guarantee of staying in sync — now the former references the latter directly.
- **idiomatic-reviewer** — two style-only findings, both fixed: roadmap language in a comment, and an `exclusive`/`dedicated` vocabulary inconsistency (parameter renamed for consistency).
- **systems-engineer (assigned dissenter)** — attacked on deadlock/TOCTOU and bootstrap-lifecycle-continuity grounds; both failed against verified scheduler/controller mechanics (real code traced, not asserted). Found one genuine gap: no SeiNode-level observability if a dedicated pod is permanently unschedulable (`observe-image` polls with no timeout; no condition reflects "unschedulable"). Investigated a fix (mirroring the pod's own `PodScheduled` condition) and found it requires new Pod-fetch machinery that doesn't exist anywhere in this reconciler today, plus non-trivial NotFound/Unschedulable/Scheduled tri-state handling — over the "very simple" bar set for this low-audience feature. Punted per explicit scope call; documented as a known gap in the `IsDedicatedNode` doc comment, with a runbook callout to follow.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/noderesource/... ./internal/task/...` — includes two new tests covering non-dedicated (defensive term only) and dedicated (both terms + label mirroring) cases
- [ ] Live validation on harbor once this image rolls out (tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)