### PR TITLE
fix(integration): correct sei-config snapshot keys in TestWorkflowStateSync

### DIFF
--- a/test/integration/workflow_test.go
+++ b/test/integration/workflow_test.go
@@ -17,9 +17,19 @@ import (
 // snapshots so a wiped follower can re-bootstrap from them. Overlaid on the
 // memiavl baseline for the network in this suite. Without it, the resync has
 // nothing to sync FROM and the workflow's await-caught-up step never clears.
+//
+// Keys are the sei-config storage.* overrides that sei-config.SnapshotGenerationOverrides
+// emits (storage.snapshot_interval / storage.snapshot_keep_recent, plus
+// storage.pruning=nothing — snapshotting needs unpruned state). They are
+// underscore-form enrichment keys the real sidecar validates; the earlier
+// hyphenated state-sync.* form was rejected by sei-config as unknown fields
+// (found live on harbor — see the config-intent-validation note in the CL).
+// snapshot_interval is a small test value (the sei-config default is 2000
+// blocks) so a snapshot appears early on an ephemeral chain.
 var snapshotProductionConfig = map[string]string{
-	"state-sync.snapshot-interval":    "50",
-	"state-sync.snapshot-keep-recent": "3",
+	"storage.pruning":              "nothing",
+	"storage.snapshot_interval":    "50",
+	"storage.snapshot_keep_recent": "3",
 }
 
 // TestWorkflowStateSync drives the SeiNodeTaskWorkflow StateSync recipe through
@@ -117,7 +127,7 @@ func TestWorkflowStateSync(t *testing.T) {
 	// (TestWorkflowLifecycle_ReadoptByUIDAfterRestart) and the sidecar
 	// crash-resume tests; the e2e pod-kill variant lands with that hook.
 	t.Run("InterruptResume", func(t *testing.T) {
-		t.Skip("deferred: needs a mid-recipe pod-kill injection hook; controller-restart resume is covered by the controller envtest")
+		t.Skip("deferred: needs a mid-recipe pod-kill hook; restart-resume is covered by the controller envtest")
 	})
 }
 


### PR DESCRIPTION
## What

Fix the sei-config keys in `snapshotProductionConfig` (`test/integration/workflow_test.go`, the `TestWorkflowStateSync` nightly target): `state-sync.snapshot-interval` / `state-sync.snapshot-keep-recent` → the underscore-form `storage.*` enrichment keys the real sidecar validates.

```
storage.pruning              = nothing
storage.snapshot_interval    = 50
storage.snapshot_keep_recent = 3
```

## Why

Found live on harbor during the STO-624 acceptance staging. The real seictl sidecar validates the config **intent** against sei-config, which rejects the hyphenated `state-sync.*` keys as unknown fields (`config-apply: invalid intent: unknown config field "state-sync.snapshot-interval"`). The witness validators' `config-apply` task then fails and retries forever, wedging the genesis chain at `Initializing` and starving the follower's state-sync of a source.

The controller envtest suite never caught this: its fake `SidecarClient` returns `Completed` for every task **without validating the intent**, so any config key "passes" in envtest. The break only surfaces against a real cluster.

The correct overrides are exactly what `sei-config.SnapshotGenerationOverrides` emits (source-anchored to sei-config `enrichments.go` / `defaults.go`): `storage.snapshot_interval`, `storage.snapshot_keep_recent`, plus `storage.pruning=nothing` (snapshotting needs unpruned state). Interval stays a small test value — the sei-config default is 2000 blocks — so a snapshot appears early on an ephemeral chain.

Also wraps a pre-existing over-long `t.Skip` line the integration-tagged lint flags (`make lint` doesn't pass `-tags=integration`, so integration files were previously unlinted).

## Future hardening (follow-up, not in this CL)

Give the controller/SDK envtest a fake sidecar that validates task intents against real sei-config, so a bad config key fails in envtest instead of only on a live cluster. That would have caught this at CI time.

## Test plan

`GOTOOLCHAIN=local` go1.26.0:
- `go build -tags integration ./test/integration/...` — clean.
- `go vet -tags integration ./test/integration/...` — clean.
- `gofmt -s -l test/integration/workflow_test.go` — clean.
- `golangci-lint run --build-tags=integration ./test/integration/...` — no findings in `workflow_test.go`.

The suite itself is a live-cluster nightly (build-tagged `integration`, needs `SEI_NODE_CLUSTER`); it cannot run in unit CI. Correctness of the keys is source-anchored to `sei-config.SnapshotGenerationOverrides`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
