### PR TITLE
test(integration): extract bringUpRPCNode bring-up helper

### DIFF
--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -151,7 +151,7 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 	hc := &http.Client{Timeout: 10 * time.Second}
 	for i := range s.rpcNodes {
 		name := rpcNodeName(s.chainID, i)
-		node, err := c.CreateNode(ctx, sei.NodeSpec{
+		node, err := bringUpRPCNode(ctx, t, c, hc, sei.NodeSpec{
 			Name:      name,
 			Network:   s.chainID,
 			Namespace: s.namespace,
@@ -159,27 +159,43 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 			Labels:    runLabels,
 			Config:    mergeConfig(s.storageConfig, s.rpcConfig),
 		})
+		if node != nil {
+			ch.rpcNodes = append(ch.rpcNodes, node)
+		}
 		if err != nil {
-			return ch, fmt.Errorf("create rpc node %q: %w", name, err)
+			return ch, err
 		}
-		ch.rpcNodes = append(ch.rpcNodes, node)
-
-		// Per-gate progress so a stall is localizable in real time from the pod
-		// log (which node, which gate) rather than a single terminal error.
-		if err := node.WaitReady(ctx); err != nil {
-			return ch, fmt.Errorf("rpc node %q running: %w", name, err)
-		}
-		t.Logf("rpc node %s: running", name)
-		if err := sei.WaitCaughtUp(ctx, hc, node.TendermintRPC()); err != nil {
-			return ch, fmt.Errorf("rpc node %q caught up: %w", name, err)
-		}
-		t.Logf("rpc node %s: caught up", name)
-		if err := sei.WaitEVMServing(ctx, hc, node.EVMRPC()); err != nil {
-			return ch, fmt.Errorf("rpc node %q EVM serving: %w", name, err)
-		}
-		t.Logf("rpc node %s: EVM serving", name)
 	}
 	return ch, nil
+}
+
+// bringUpRPCNode creates an RPC SeiNode and blocks until it is fully serving:
+// running, caught up to the chain, then answering EVM RPC. Each gate is logged
+// as it passes so a stall is localizable in real time from the pod log (which
+// node, which gate) rather than a single terminal error. Returns the node
+// non-nil once created — even if a later gate fails — so the caller can still
+// register it for teardown; nil only when creation itself fails.
+func bringUpRPCNode(
+	ctx context.Context, t *testing.T, c *sei.Client, hc *http.Client, nodeSpec sei.NodeSpec,
+) (*sei.Node, error) {
+	t.Helper()
+	node, err := c.CreateNode(ctx, nodeSpec)
+	if err != nil {
+		return nil, fmt.Errorf("create rpc node %q: %w", nodeSpec.Name, err)
+	}
+	if err := node.WaitReady(ctx); err != nil {
+		return node, fmt.Errorf("rpc node %q running: %w", nodeSpec.Name, err)
+	}
+	t.Logf("rpc node %s: running", nodeSpec.Name)
+	if err := sei.WaitCaughtUp(ctx, hc, node.TendermintRPC()); err != nil {
+		return node, fmt.Errorf("rpc node %q caught up: %w", nodeSpec.Name, err)
+	}
+	t.Logf("rpc node %s: caught up", nodeSpec.Name)
+	if err := sei.WaitEVMServing(ctx, hc, node.EVMRPC()); err != nil {
+		return node, fmt.Errorf("rpc node %q EVM serving: %w", nodeSpec.Name, err)
+	}
+	t.Logf("rpc node %s: EVM serving", nodeSpec.Name)
+	return node, nil
 }
 
 // teardown deletes the provisioned resources — the normal-exit fast path, wired

--- a/test/integration/release_test.go
+++ b/test/integration/release_test.go
@@ -108,7 +108,8 @@ func TestRelease(t *testing.T) {
 	t.Logf("network %s: ready (4 validators, admin %s funded)", chainID, admin.Address)
 
 	rpcName := rpcNodeName(chainID, 0)
-	node, err := c.CreateNode(ctx, sei.NodeSpec{
+	hc := &http.Client{Timeout: 10 * time.Second}
+	node, err := bringUpRPCNode(ctx, t, c, hc, sei.NodeSpec{
 		Name:      rpcName,
 		Network:   chainID,
 		Namespace: ns,
@@ -116,19 +117,11 @@ func TestRelease(t *testing.T) {
 		Labels:    runLabels,
 		Config:    mergeConfig(releaseBaseConfig, releaseRPCConfig),
 	})
+	if node != nil {
+		ch.rpcNodes = append(ch.rpcNodes, node)
+	}
 	if err != nil {
-		t.Fatalf("create rpc node %q: %v", rpcName, err)
-	}
-	ch.rpcNodes = append(ch.rpcNodes, node)
-	if err := node.WaitReady(ctx); err != nil {
-		t.Fatalf("rpc node %q running: %v", rpcName, err)
-	}
-	hc := &http.Client{Timeout: 10 * time.Second}
-	if err := sei.WaitCaughtUp(ctx, hc, node.TendermintRPC()); err != nil {
-		t.Fatalf("rpc node %q caught up: %v", rpcName, err)
-	}
-	if err := sei.WaitEVMServing(ctx, hc, node.EVMRPC()); err != nil {
-		t.Fatalf("rpc node %q EVM serving: %v", rpcName, err)
+		t.Fatal(err)
 	}
 	rest := node.REST()
 	if rest == "" {
@@ -140,7 +133,7 @@ func TestRelease(t *testing.T) {
 	if err := sei.WaitRESTServing(ctx, hc, rest); err != nil {
 		t.Fatalf("rpc node %q REST serving: %v", rpcName, err)
 	}
-	t.Logf("rpc node %s: caught up + EVM serving + REST at %s", rpcName, rest)
+	t.Logf("rpc node %s: REST serving at %s", rpcName, rest)
 
 	// Hand the admin mnemonic to the harness via a Secret (secretKeyRef), labeled
 	// for the GC sweep and deleted on cleanup.


### PR DESCRIPTION
## What

Extracts the fresh-RPC-node **bring-up tail** — `CreateNode → WaitReady → WaitCaughtUp → WaitEVMServing` with per-gate progress logs — that was duplicated verbatim in `provision`'s node loop and in `release_test.go`. What's duplicated is the **gate protocol + ordering + teardown-registration contract**, not incidental line-shape, so the two sites now share one named helper (past CLAUDE.md's "three similar lines" bar because it's a correctness-coupling that must move in lockstep).

## The helper (`harness_test.go`, next to `provision`)

```go
func bringUpRPCNode(ctx, t, c, hc, nodeSpec sei.NodeSpec) (*sei.Node, error)
```
- **Error-returning core** — `provision` propagates up its chain; `release` wraps in `t.Fatal`. Same error-core / caller-picks-severity seam as the existing `runTaskWait`/`runTaskComplete`.
- **Per-gate logging lives inside the helper** — deliberately, so "running"/"caught up"/"EVM serving" is emitted *before* the next gate starts and a multi-minute stall stays localizable from the pod log while it hangs.
- **Returns `node` non-nil once created**, even on a later gate failure, so the caller still registers it for teardown (`if node != nil { append }`). Nil only when `CreateNode` itself fails — matching the prior pre-append-then-wait semantics exactly.

## Behavior

Preserving except **one approved delta**: `release` now emits the 3 per-gate log lines it lacked (replacing its single combined line) — better stall localization. Error text, `%w` wrap chains, gate ordering, and teardown registration are unchanged at both sites. (release also *gains* a `%w` chain, strictly improving `errors.Is/As` with no output change.)

The four post-perturbation liveness assertions (post-release / -resync / -fault / -load) are intentionally left inline — a distinct concept with heterogeneous gates and fatal/non-fatal polarity; unifying them would need severity+gate-subset flags, the opposite of what the extraction is for.

## Verification
- `gofmt -l`, `go vet -tags integration`, `golangci-lint run --build-tags integration` — all clean (0 issues)
- **/xreview merge gate: RESOLVED** — two blinded independent lenses: idiomatic-reviewer (COMPATIBLE / reads native) + systems-engineer as assigned dissenter, which attacked all six invariants (teardown-registration equivalence, error-text byte-identity, real-time log ordering, `hc`-hoist inertness, scope, compile) and **RATIFIED**. Two advisory idiom nits (param-shadow rename, `t.Fatal(err)`) folded in.

Third and final piece of the integration-harness cleanup arc (after #465 fan-out/docs, #466 seiload lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)