### PR TITLE
test(integration): fold release provisioning onto shared provision

### DIFF
--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -71,15 +71,16 @@ func mergeConfig(base, extra map[string]string) map[string]string {
 // spec is the typed input shared by the suites — the local-Go-state replacement
 // for the per-run workflow-vars contract.
 type spec struct {
-	chainID       string            // SeiNetwork name == genesis chain id; also peer-selector value + run discriminator
-	runID         string            // unique per run; the sei.io/harness-run label value
-	namespace     string            // shared nightly namespace; "" => the SDK client's resolved default
-	seidImage     string            // seid container image under test
-	validators    int               // genesis validator count (>= 1)
-	rpcNodes      int               // standalone RPC followers; named <chain>-rpc-0..N-1
-	timeout       time.Duration     // overall scenario deadline (drives ctx, kept < CronJob activeDeadlineSeconds)
-	storageConfig map[string]string // per-suite seid storage config (load/release set memiavl; upgrade leaves the default)
-	rpcConfig     map[string]string // extra per-RPC-node config overlaid on storageConfig (e.g. EVM tuning)
+	chainID       string               // SeiNetwork name == genesis chain id; also peer-selector value + run discriminator
+	runID         string               // unique per run; the sei.io/harness-run label value
+	namespace     string               // shared nightly namespace; "" => the SDK client's resolved default
+	seidImage     string               // seid container image under test
+	validators    int                  // genesis validator count (>= 1)
+	rpcNodes      int                  // standalone RPC followers; named <chain>-rpc-0..N-1
+	timeout       time.Duration        // overall scenario deadline (drives ctx, kept < CronJob activeDeadlineSeconds)
+	storageConfig map[string]string    // per-suite seid storage config (load/release set memiavl; upgrade omits it)
+	rpcConfig     map[string]string    // extra per-RPC-node config overlaid on storageConfig (e.g. EVM tuning)
+	accounts      []sei.GenesisAccount // genesis-funded non-validator accounts (release funds an admin); nil funds none
 
 	// seiload inputs (load suite)
 	seiloadImage   string // sei-load benchmark image
@@ -133,6 +134,7 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 		Validators: s.validators,
 		Labels:     runLabels,
 		Config:     maps.Clone(s.storageConfig),
+		Accounts:   s.accounts,
 		// Ephemeral chain: cascade-delete the controller-created validators (+
 		// their PVCs) on teardown. The CRD default Retain would orphan them —
 		// they never carry sei.io/harness-run, so neither t.Cleanup nor the

--- a/test/integration/release_test.go
+++ b/test/integration/release_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"context"
-	"maps"
 	"net/http"
 	"os/signal"
 	"syscall"
@@ -86,43 +85,27 @@ func TestRelease(t *testing.T) {
 	}
 
 	// Provision: 4 validators with the admin funded in genesis, + 1 RPC follower.
-	ch := &chain{}
-	cleanupChain(t, ch)
-	net, err := c.CreateNetwork(ctx, sei.NetworkSpec{
-		Name:           chainID,
-		Namespace:      ns,
-		Image:          seid,
-		Validators:     4,
-		Labels:         runLabels,
-		Config:         maps.Clone(releaseBaseConfig), // package-global; clone before handing to the SDK
-		Accounts:       []sei.GenesisAccount{{Address: admin.Address, Balance: releaseAdminBalance}},
-		DeletionPolicy: sei.DeletionDelete,
+	ch, err := provision(ctx, t, c, spec{
+		chainID:       chainID,
+		runID:         chainID,
+		namespace:     ns,
+		seidImage:     seid,
+		validators:    4,
+		rpcNodes:      1,
+		storageConfig: releaseBaseConfig,
+		rpcConfig:     releaseRPCConfig,
+		accounts:      []sei.GenesisAccount{{Address: admin.Address, Balance: releaseAdminBalance}},
 	})
+	cleanupChain(t, ch)
 	if err != nil {
-		t.Fatalf("create network %q: %v", chainID, err)
+		t.Fatalf("provision: %v", err)
 	}
-	ch.network = net
-	if err := net.WaitReady(ctx); err != nil {
-		t.Fatalf("network %q ready: %v", chainID, err)
-	}
+	node := ch.rpcNodes[0]
+	net := ch.network
+	rpcName := node.Name()
 	t.Logf("network %s: ready (4 validators, admin %s funded)", chainID, admin.Address)
 
-	rpcName := rpcNodeName(chainID, 0)
 	hc := &http.Client{Timeout: 10 * time.Second}
-	node, err := bringUpRPCNode(ctx, t, c, hc, sei.NodeSpec{
-		Name:      rpcName,
-		Network:   chainID,
-		Namespace: ns,
-		Image:     seid,
-		Labels:    runLabels,
-		Config:    mergeConfig(releaseBaseConfig, releaseRPCConfig),
-	})
-	if node != nil {
-		ch.rpcNodes = append(ch.rpcNodes, node)
-	}
-	if err != nil {
-		t.Fatal(err)
-	}
 	rest := node.REST()
 	if rest == "" {
 		t.Fatalf("rpc node %q exposes no REST endpoint (release-test needs SEI_REST_ENDPOINT)", rpcName)


### PR DESCRIPTION
## What

`release_test.go` was the last suite open-coding network + RPC-node provisioning (`CreateNetwork → WaitReady → bringUpRPCNode`) instead of the shared `provision` helper the other three suites (benchmark, chaossuite, workflow) already use. The only thing blocking it was a missing knob — `provision` threaded no genesis `Accounts`. Add it, fold release in.

## Changes (2 files)

- **`harness_test.go`** — `spec` gains one field `accounts []sei.GenesisAccount` (nil funds none), threaded into `provision`'s `CreateNetwork` as `Accounts: s.accounts`. Nil for the other three callers → **zero behavior change** for them.
- **`release_test.go`** — now calls `provision(spec{… accounts: [{admin}]})` and runs its **site-specific tail** (`node.REST()` guard, `WaitRESTServing`, admin Secret, Job) on `ch.rpcNodes[0]`. Drops the now-unused `maps` import.

Removes a **~34-line second copy** of the network-provisioning contract — including the duplicated ephemeral-chain `DeletionPolicy` teardown rationale that lived in *both* `provision` and release. release's network/node config maps onto the existing `storageConfig`/`rpcConfig` fields (the same overload `workflow` already uses for snapshot config), so **no new config field** is needed — the gap was genuinely just `Accounts`.

## Scope boundary
`upgrade_test.go`'s two-phase image re-apply legitimately can't fold onto single-`CreateNetwork` `provision` and is left as-is; the four post-perturbation liveness assertions are untouched. This is the last piece of the harness-cleanup arc (after #465 fan-out, #466 seiload lint, #467 `bringUpRPCNode`).

## Verification
- `gofmt -l`, `go vet -tags integration`, `golangci-lint run --build-tags integration` — all clean (0 issues)
- **/xreview merge gate: RESOLVED** — idiomatic-reviewer (COMPATIBLE / reads native) + systems-engineer as assigned dissenter, which attacked eight behavior-equivalence axes (field-by-field NetworkSpec/NodeSpec, `runLabels` value, teardown LIFO order, the three untouched callers' `nil` accounts, rpc-node identity, scope, compile) and **RATIFIED**.

Net −15 lines (26 insert / 41 delete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)