### PR TITLE
test(integration): nightly genesis-ceremony state-sync e2e + SDK sidecar-image pin

### DIFF
--- a/sdk/sei/provider/k8s/render.go
+++ b/sdk/sei/provider/k8s/render.go
@@ -61,6 +61,12 @@ func renderNetwork(spec sei.NetworkSpec, namespace string) *seiv1alpha1.SeiNetwo
 		net.Spec.Genesis.Accounts = append(net.Spec.Genesis.Accounts,
 			seiv1alpha1.GenesisAccount{Address: a.Address, Balance: a.Balance})
 	}
+	if spec.SidecarImage != "" {
+		// Pin the seictl sidecar image on this network; the controller propagates
+		// spec.sidecar to the child validators. "" leaves spec.sidecar unset, so
+		// EffectiveSidecarImage falls back to the platform default.
+		net.Spec.Sidecar = &seiv1alpha1.SidecarConfig{Image: spec.SidecarImage}
+	}
 	return net
 }
 

--- a/sdk/sei/provider/k8s/render_test.go
+++ b/sdk/sei/provider/k8s/render_test.go
@@ -51,6 +51,19 @@ func TestRenderNetwork_ChainIDDefaultsToName(t *testing.T) {
 	}
 }
 
+func TestRenderNetwork_SidecarImage(t *testing.T) {
+	// Set: pins spec.sidecar.image, which the controller propagates to children.
+	set := renderNetwork(sei.NetworkSpec{Name: testNet, Image: testImage, Validators: 4, SidecarImage: "seictl:dev"}, testNS)
+	if set.Spec.Sidecar == nil || set.Spec.Sidecar.Image != "seictl:dev" {
+		t.Errorf("sidecar = %+v, want image seictl:dev", set.Spec.Sidecar)
+	}
+	// Empty: leaves spec.sidecar unset so the platform default resolves.
+	unset := renderNetwork(sei.NetworkSpec{Name: testNet, Image: testImage, Validators: 4}, testNS)
+	if unset.Spec.Sidecar != nil {
+		t.Errorf("sidecar = %+v, want nil (platform default)", unset.Spec.Sidecar)
+	}
+}
+
 func TestRenderNode_LabelsAndPeerWiring(t *testing.T) {
 	spec := sei.NodeSpec{Name: rpc1Name, Network: testNet, Image: testImage}
 	node := renderNode(spec, testNS, testNS)

--- a/sdk/sei/spec.go
+++ b/sdk/sei/spec.go
@@ -28,6 +28,10 @@ type NetworkSpec struct {
 	// DeletionPolicy controls child-validator deletion; "" leaves the CRD Retain
 	// default. Set DeletionDelete for ephemeral chains. -> spec.deletionPolicy.
 	DeletionPolicy string
+
+	// SidecarImage overrides the platform-default seictl sidecar image on this
+	// network and its children; "" => platform default. -> spec.sidecar.image.
+	SidecarImage string
 }
 
 // GenesisAccount is a non-validator genesis account to fund.

--- a/test/integration/genesis_test.go
+++ b/test/integration/genesis_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/http"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
+)
+
+// TestGenesisCeremonyProducesBlocks proves the slice-6 genesis-completion fix end
+// to end: a fresh, self-created SeiNetwork collect-gentxs ceremony must boot its
+// founding validators and produce blocks past height 1, asserted on the founding
+// validators' OWN RPC.
+//
+// Why this topology (rpcNodes: 0, validators >= 2):
+//   - rpcNodes: 0 makes the verdict depend SOLELY on the founding validators. A
+//     genesis/InitChain divergence cannot be masked by a follower that merely
+//     replays committed blocks — there is no follower. The aggregate TM RPC the
+//     assertions hit IS the validator service.
+//   - validators >= 2 exercises the ceremony's distinct-power + dedup path:
+//     each founding validator is a distinct SeiNode that runs its own
+//     ValidateNodeKey + GenerateGentx tasks, so it contributes a distinct
+//     consensus key and voting power to the collected gentx set. A single
+//     validator would never surface a set-assembly bug.
+//
+// Why height > 1 on the validators' own RPC is the end-to-end InitChain-parity
+// proof (the load-bearing assertion):
+//
+//	sei-chain's replay.go:224 hard-errors EVERY validator at boot if
+//	genDoc.Validators != the InitChain output validator set. So a block committed
+//	past height 1 by the founding validators is only possible if the two sets
+//	agree — i.e. a committed height > 1 is the executed proto.Equal set-equality
+//	witness for the pure-Go validator-set derivation in seictl's
+//	assemble_genesis_validators.go. If that derivation drifts from what seid's
+//	InitChain produces, consensus never advances past height 1 and WaitCaughtUp
+//	times out here rather than being papered over by a follower.
+//
+// WaitCaughtUp gates height > 1 with catching_up == false (the ceremony produced
+// AND the validators joined consensus); WaitHeightAdvances(+2) then proves
+// SUSTAINED production, catching a chain that commits a block or two and then
+// stalls (a stalled node still reports catching_up == false at a frozen height).
+//
+// A UNIQUE runChainID per run is mandatory: genesis is keyed by chain id and a
+// reused static id collides with a prior run's persisted genesis (harness_test.go
+// §runChainID), which itself halts a fresh validator set at height 1 — a false
+// positive for the very failure this scenario hunts. runChainID appends a
+// nanosecond token so every run gets a fresh genesis and node keys.
+//
+// memiavl is pinned explicitly: the controller default write-mode is rejected by
+// the nightly image, so without it the founding validators never reach Ready
+// (harness_test.go §memiavlStorageConfig).
+//
+// Inputs (env): SEID_IMAGE [required]; SEI_CHAIN_ID (base id, a per-run token is
+// appended) [default: genesis-ceremony]; SEI_NAMESPACE [default: SDK default];
+// SEI_VALIDATORS (>= 2) [default: 2]; SEI_SIDECAR_IMAGE (pin the seictl sidecar
+// build under test) [default: platform default]. Run as the nightly CronJob with
+// -test.timeout 0 (see TestBenchmark for why the scenario ctx, not the test-runner
+// alarm, owns the deadline):
+//
+//	["-test.run", "TestGenesisCeremonyProducesBlocks", "-test.v", "-test.timeout", "0"]
+func TestGenesisCeremonyProducesBlocks(t *testing.T) {
+	requireCluster(t)
+
+	chainID := runChainID(envOr("SEI_CHAIN_ID", "genesis-ceremony"))
+	seid := mustEnv(t, "SEID_IMAGE")
+	ns := envOr("SEI_NAMESPACE", "")
+	// Pin the seictl sidecar image so the ceremony assembles genesis with the
+	// build under test; "" => platform default (the normal nightly path).
+	sidecar := envOr("SEI_SIDECAR_IMAGE", "")
+
+	// The scenario's premise is a multi-validator ceremony (distinct-power + dedup);
+	// a below-2 override would silently degrade it to a single-validator boot that
+	// never exercises set assembly. Fail fast rather than pass vacuously.
+	validators := envInt(t, "SEI_VALIDATORS", 2)
+	if validators < 2 {
+		t.Fatalf("SEI_VALIDATORS=%d: this scenario needs >= 2 to exercise the distinct-power + dedup ceremony path", validators)
+	}
+
+	// Short envelope: this is a boot + first-few-blocks assertion, not a load run.
+	// The scenario ctx owns the deadline (nested under the CronJob
+	// activeDeadlineSeconds); a -test.timeout breach would bypass t.Cleanup.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	// SIGTERM (activeDeadlineSeconds grace, or a manual delete) cancels ctx so the
+	// SDK calls unwind and teardown runs before SIGKILL; SIGKILL itself is
+	// backstopped by the label-GC sweep.
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	c := openClient(ctx, t)
+
+	// rpcNodes: 0 — the founding validators are the sole subject of the verdict.
+	ch, err := provision(ctx, t, c, spec{
+		chainID:       chainID,
+		runID:         chainID,
+		namespace:     ns,
+		seidImage:     seid,
+		sidecarImage:  sidecar,
+		validators:    validators,
+		rpcNodes:      0,
+		storageConfig: memiavlStorageConfig,
+	})
+	cleanupChain(t, ch)
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	t.Logf("network %s: ready (%d founding validators, no followers)", chainID, validators)
+
+	// Assert directly on the founding validators' aggregate RPC — never a follower.
+	tmRPC := ch.network.TendermintRPC()
+	if tmRPC == "" {
+		t.Fatalf("network %s exposes no Tendermint RPC after Ready", chainID)
+	}
+	hc := &http.Client{Timeout: 10 * time.Second}
+
+	// InitChain-parity proof: a committed height > 1 (not catching up) on the
+	// validators' own RPC witnesses genDoc.Validators == InitChain output
+	// (replay.go:224 would have hard-errored the validators at boot otherwise).
+	if err := sei.WaitCaughtUp(ctx, hc, tmRPC); err != nil {
+		t.Fatalf("founding validators never committed past height 1 (genesis/InitChain divergence?): %v", err)
+	}
+	t.Logf("network %s: founding validators committed past height 1 — genesis validator set matches InitChain output", chainID)
+
+	// Sustained production: +2 heights from the first observed height proves the
+	// ceremony chain keeps making blocks, not that it committed once and stalled.
+	if err := sei.WaitHeightAdvances(ctx, hc, tmRPC, 2); err != nil {
+		t.Fatalf("founding validators stalled after boot (no sustained block production): %v", err)
+	}
+	t.Logf("network %s: sustained block production confirmed — TestGenesisCeremonyProducesBlocks OK", chainID)
+}

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -75,6 +75,7 @@ type spec struct {
 	runID         string               // unique per run; the sei.io/harness-run label value
 	namespace     string               // shared nightly namespace; "" => the SDK client's resolved default
 	seidImage     string               // seid container image under test
+	sidecarImage  string               // seictl sidecar image under test; "" => platform default
 	validators    int                  // genesis validator count (>= 1)
 	rpcNodes      int                  // standalone RPC followers; named <chain>-rpc-0..N-1
 	timeout       time.Duration        // overall scenario deadline (drives ctx, kept < CronJob activeDeadlineSeconds)
@@ -128,13 +129,14 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 	runLabels := map[string]string{runLabelKey: s.runID}
 
 	net, err := c.CreateNetwork(ctx, sei.NetworkSpec{
-		Name:       s.chainID,
-		Namespace:  s.namespace,
-		Image:      s.seidImage,
-		Validators: s.validators,
-		Labels:     runLabels,
-		Config:     maps.Clone(s.storageConfig),
-		Accounts:   s.accounts,
+		Name:         s.chainID,
+		Namespace:    s.namespace,
+		Image:        s.seidImage,
+		SidecarImage: s.sidecarImage,
+		Validators:   s.validators,
+		Labels:       runLabels,
+		Config:       maps.Clone(s.storageConfig),
+		Accounts:     s.accounts,
 		// Ephemeral chain: cascade-delete the controller-created validators (+
 		// their PVCs) on teardown. The CRD default Retain would orphan them —
 		// they never carry sei.io/harness-run, so neither t.Cleanup nor the


### PR DESCRIPTION
Nightly end-to-end guard for the seictl genesis-completion fix (sei-protocol/seictl#227).

## What
- **`TestGenesisCeremonyProducesBlocks`** (`test/integration/genesis_test.go`): stands up a fresh SeiNetwork collect-gentxs ceremony with `rpcNodes: 0` (so the founding validators are the sole subject — no follower can mask a divergence) and asserts they commit **height > 1** on their own RPC. Because `sei-tendermint replay.go` hard-errors every validator at boot when `genDoc.Validators != InitChain output`, a committed height > 1 is the end-to-end witness that the assembled genesis validator set matches InitChain.
- **`NetworkSpec.SidecarImage`** (`sdk/sei/spec.go` + `render.go`): optional; renders to `spec.sidecar.image` and propagates to the network's children. Empty preserves the platform default — so the change is additive and affects no existing scenario. Required so the nightly exercises the **seictl build under change** (via `SEI_SIDECAR_IMAGE`) rather than the prod sidecar image.

## Validation
Manually exercised end-to-end in `eng-fromtherain`: a fresh 4-validator ceremony (dev seictl pinned) produced blocks, served state-sync snapshots, and an RPC node state-synced from it — then the `SeiNodeTaskWorkflow state-sync` workflow ran on that RPC node to completion (wipe → reconfigure → re-sync). `go build`/`vet -tags integration` green; `render_test.go` covers the new field both ways.

## Follow-up (separate)
The nightly CronJob manifest that selects this suite (`-test.run TestGenesisCeremonyProducesBlocks`) lives in the deploy repo and is added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)