### PR TITLE
test(envtest): fix flaky TestSeiNetwork_Paused — wait for genesis plan to settle

### DIFF
--- a/internal/controller/seinetwork/envtest/paused_test.go
+++ b/internal/controller/seinetwork/envtest/paused_test.go
@@ -31,12 +31,16 @@ func TestSeiNetwork_Paused_PropagatesAndBlocksOrchestration(t *testing.T) {
 	g.Expect(testCli.Create(testCtx, snd)).To(Succeed())
 	key := client.ObjectKeyFromObject(snd)
 
-	// 1. Initial settle. Both children exist and the SeiNetwork has
-	//    ConditionPaused=False/NotPaused seeded.
+	// 1. Initial settle — wait for Status.Plan==nil, not just children-exist.
+	//    reconcileSeiNodes creates children before reconcilePlan finishes the
+	//    genesis ceremony, so pausing while the plan is still Active freezes it
+	//    in place (paused short-circuits reconcilePlan, which never drives it to
+	//    nil) and flakes step 3's Consistently(Status.Plan==nil).
 	waitForStatus(t, key, func(s *seiv1alpha1.SeiNetwork) bool {
 		return len(listChildren(t, s)) == 2 &&
+			s.Status.Plan == nil &&
 			pausedCond(s) != nil && pausedCond(s).Status == metav1.ConditionFalse
-	}, "two children exist and ConditionPaused=False is seeded on a fresh SeiNetwork")
+	}, "two children exist, the genesis plan has settled (Status.Plan==nil), and ConditionPaused=False is seeded")
 
 	// 2. Pause the SeiNetwork. ConditionPaused flips True, Status.Phase moves
 	//    to Paused, and children pick up Spec.Paused=true on the next

--- a/internal/controller/seinetwork/envtest/paused_test.go
+++ b/internal/controller/seinetwork/envtest/paused_test.go
@@ -32,11 +32,14 @@ func TestSeiNetwork_Paused_PropagatesAndBlocksOrchestration(t *testing.T) {
 	key := client.ObjectKeyFromObject(snd)
 
 	// 1. Initial settle — wait for Status.Plan==nil, not just children-exist.
-	//    reconcileSeiNodes creates children before reconcilePlan finishes the
-	//    genesis ceremony, so pausing while the plan is still Active freezes it
-	//    in place (paused short-circuits reconcilePlan, which never drives it to
-	//    nil) and flakes step 3's Consistently(Status.Plan==nil).
-	waitForStatus(t, key, func(s *seiv1alpha1.SeiNetwork) bool {
+	//    reconcileSeiNodes creates children before reconcilePlan drives the
+	//    genesis ceremony to Complete, so pausing while the plan is still Active
+	//    freezes it (paused short-circuits reconcilePlan) and flakes step 3's
+	//    Consistently(nil). Status.Plan clears only after the plan's
+	//    await-nodes-running task (the full genesis+boot chain), so this uses
+	//    convergeTimeout like the sibling convergence waits, not the 30s
+	//    pollTimeout that chain exceeds under CI load.
+	waitForStatusWithin(t, convergeTimeout, key, func(s *seiv1alpha1.SeiNetwork) bool {
 		return len(listChildren(t, s)) == 2 &&
 			s.Status.Plan == nil &&
 			pausedCond(s) != nil && pausedCond(s).Status == metav1.ConditionFalse


### PR DESCRIPTION
## Summary

Fixes a pre-existing flake in `TestSeiNetwork_Paused_PropagatesAndBlocksOrchestration` that surfaced under CI load (it tripped `test-integration` once on #469, whose added envtest cases raised suite contention just enough to lose the race).

## Root cause

The test paused the SeiNetwork after waiting only for **children-to-exist**, then asserted `g.Consistently(Status.Plan == nil)` for 3s while paused. But in the reconcile loop `reconcileSeiNodes` (creates the children) runs **before** `reconcilePlan` (finishes the genesis ceremony), so children can exist while `Status.Plan` is still `Active`. Pausing at that point **freezes the plan in place** — `reconcilePlan` short-circuits entirely when paused (`plan.go:22`, *"Paused short-circuits entirely; an active plan freezes in place"*) and never drives it to `Complete`/`nil` — so `Status.Plan` stays non-nil and the assertion fails.

Normally the genesis ceremony wins the race (the test's own comment even notes it "completes too fast in envtest to deterministically pause against"). Under CI load it doesn't, so it flaked. The controller behavior is correct and intentional; the test asserted a post-genesis invariant without establishing the precondition.

## Fix

Gate the initial settle on `Status.Plan == nil` (genesis ceremony complete) before pausing, so the pause only ever lands on a network with no in-flight plan. Deterministic regardless of load. Test-only — no controller change.

## Test plan

- [x] `go build`, `go vet -tags=envtest`, `golangci-lint --new-from-rev` (0 issues)
- [x] Fixed test run 5× in isolation — all pass, stable
- [ ] CI `test-integration` (full-suite, authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)