### PR TITLE
test(chaos): fail-fast fault injection + quarantine disk-io-latency

### DIFF
--- a/test/integration/chaos_test.go
+++ b/test/integration/chaos_test.go
@@ -19,6 +19,14 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// injectDeadline bounds fault injection independently of the per-scenario
+// timeout. A fault that has not reached AllInjected within this window is stuck
+// (a chaos-daemon apply erroring on every retry), not slow — fail fast rather
+// than poll the never-flipping condition until the scenario budget expires. Set
+// well above chaos-mesh's observed inject latency (seconds), with margin for
+// selector settling and daemon apply retries.
+const injectDeadline = 5 * time.Minute
+
 //go:embed faults/network_partition.yaml.tmpl
 var networkPartitionTmpl string
 
@@ -136,7 +144,16 @@ func applyFault(ctx context.Context, t *testing.T, dc dynamic.Interface, ns stri
 // wouldn't catch a future selector edit that killed 2/4 and halted the chain.
 func gateInjected(ctx context.Context, t *testing.T, dc dynamic.Interface, ns string, f fault, oneShot bool) {
 	t.Helper()
-	waitFaultCondition(ctx, t, dc, ns, f, "AllInjected")
+	// Bound injection independently of the scenario deadline: a fault that has
+	// not reached AllInjected within injectDeadline is stuck (e.g. a chaos-daemon
+	// apply erroring on every retry), not merely slow. Without this it would poll
+	// the never-flipping condition until the full scenario timeout, turning a
+	// single stuck injection into a ~40m run that reds the suite with an opaque
+	// "before deadline" at the very end. Recovery keeps the scenario ctx — it is
+	// gated on the fault's own spec.duration, not a fixed budget.
+	injectCtx, cancel := context.WithTimeout(ctx, injectDeadline)
+	defer cancel()
+	waitFaultCondition(injectCtx, t, dc, ns, f, "AllInjected")
 	u, err := dc.Resource(chaosGVR(f.resource)).Namespace(ns).Get(ctx, f.obj.GetName(), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("read injected targets for %s/%s: %v", f.resource, f.obj.GetName(), err)

--- a/test/integration/chaossuite_test.go
+++ b/test/integration/chaossuite_test.go
@@ -41,6 +41,12 @@ type chaosScenario struct {
 	resource string
 	tmpl     string
 	oneShot  bool
+	// quarantine, when non-empty, skips the scenario with this reason instead of
+	// running it. For a fault whose injection is broken by an environment change
+	// outside this suite's control (tracked separately) — keeps the scenario
+	// visible as SKIP with its reason and un-quarantine condition, rather than
+	// deleting coverage or letting it red every nightly.
+	quarantine string
 }
 
 // chaosScenarios is the ported fault set. Growing toward the platform suite's
@@ -53,7 +59,15 @@ var chaosScenarios = []chaosScenario{
 	{name: "network-latency", resource: rNetworkChaos, tmpl: networkLatencyTmpl},
 	{name: "bandwidth-limit", resource: rNetworkChaos, tmpl: bandwidthLimitTmpl},
 	{name: "memory-stress", resource: rStressChaos, tmpl: memoryStressTmpl},
-	{name: "disk-io-latency", resource: rIOChaos, tmpl: diskIOLatencyTmpl},
+	{name: "disk-io-latency", resource: rIOChaos, tmpl: diskIOLatencyTmpl,
+		// chaos-mesh IOChaos toda cannot mount over the seid data dir while it is a
+		// PVC nested inside the $HOME emptyDir (platform.DataDir = HomeDir + "/.sei",
+		// nested under the HomeDir emptyDir): every chaos-daemon apply fails
+		// "toda startup ... No such file or directory (os error 2)". The layout is
+		// intentional and test-locked, so the fix is chaos-side, not a layout revert.
+		// Un-quarantine once IOChaos injects against the nested mount again (a green
+		// disk-io-latency run).
+		quarantine: "disk-io-latency: IOChaos toda injection fails on the nested $HOME/.sei data mount"},
 	{name: "byzantine", resource: rNetworkChaos, tmpl: byzantineTmpl},
 	{name: "pod-failure", resource: rPodChaos, tmpl: podFailureTmpl, oneShot: true},
 	{name: "container-kill", resource: rPodChaos, tmpl: containerKillTmpl, oneShot: true},
@@ -83,6 +97,9 @@ func TestChaosSuite(t *testing.T) {
 
 	for _, sc := range chaosScenarios {
 		t.Run(sc.name, func(t *testing.T) {
+			if sc.quarantine != "" {
+				t.Skip(sc.quarantine)
+			}
 			id := base + "-" + sc.name
 			// The validator-0 selector value sei.io/node=<id>-0 is a k8s label
 			// value (capped at 63 chars); fail loud rather than on an opaque


### PR DESCRIPTION
Two reliability changes to the integration chaos suite (`test/integration/`).

## 1. Fail-fast fault injection
`gateInjected` now bounds injection to a dedicated `injectDeadline` (5m) rather than inheriting the full per-scenario timeout. A fault whose chaos-daemon apply errors on every retry never reaches `AllInjected`; previously it polled the never-flipping condition until the ~40m scenario budget expired — turning one stuck injection into a full-length run that reds the suite with an opaque `... not True before deadline` only at the very end. With the child deadline it fails in minutes with the same signal, close to the actual cause.

Recovery deliberately keeps the scenario `ctx` — it's gated on the fault's own `spec.duration`, not a fixed budget.

## 2. Quarantine `disk-io-latency`
Adds a `chaosScenario.quarantine` field; when set, the subtest `t.Skip`s with the reason instead of running. `disk-io-latency` (IOChaos) is quarantined: chaos-mesh `toda` fails to mount over the seid data dir while it's a PVC nested inside the `$HOME` emptyDir (`platform.DataDir = HomeDir + "/.sei"`), so every daemon apply returns `toda startup ... No such file or directory (os error 2)` and injection never completes.

The data layout is intentional and test-locked (`TestHomeDirIsDataDirParent`), so the fix is chaos-side, not a layout revert — tracked separately. Quarantine (vs. deletion) keeps the scenario visible as SKIP with its reason and un-quarantine condition; removing the field is a one-liner once IOChaos injects against the nested mount again (a green `disk-io-latency` run).

## Validation
`gofmt` clean; `go vet -tags integration ./test/integration/` passes. End-to-end validation is a green chaos run once the harness image is rebuilt from this change.

## Follow-up (not in this PR)
- The chaos-side IOChaos/nested-mount fix (un-quarantine trigger) — a tracking ticket will be linked.
- A future enhancement: on injection timeout, surface the fault's failed-apply event so the failure names the daemon error directly.