### PR TITLE
docs(api): correct SnapshotSource archive comment (block sync, not state sync)

### DIFF
--- a/api/v1alpha1/seinode_types.go
+++ b/api/v1alpha1/seinode_types.go
@@ -122,7 +122,9 @@ type DataVolumeImport struct {
 
 // SnapshotSource returns the SnapshotSource from whichever mode sub-spec is
 // populated, or nil if no snapshot is configured. Archive nodes always return
-// nil because they use state sync (configured internally by the planner).
+// nil: they bootstrap via block sync from peers (or an imported volume), never
+// by restoring from a snapshot, so ArchiveSpec carries no snapshot source — its
+// SnapshotGeneration knob only produces snapshots for other nodes to restore from.
 func (s *SeiNodeSpec) SnapshotSource() *SnapshotSource {
 	switch {
 	case s.FullNode != nil:


### PR DESCRIPTION
The `SnapshotSource()` doc comment (`api/v1alpha1/seinode_types.go`) said archive nodes return `nil` "because they use state sync (configured internally by the planner)."

That's wrong: `ArchiveSpec` (`archive_types.go:4`) documents that archive nodes **bootstrap via block sync from peers** to retain full history, and `ArchiveSpec` carries no snapshot-*source* field — its `SnapshotGeneration` only *produces* Tendermint snapshots for other nodes to restore from. So `SnapshotSource()` returns nil for archive because there's no restore source, not because of state sync.

Reworded to match. **Comment-only, no behavior change.** Surfaced by the `/xreview` on #475 as a non-blocking code-side follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)