### PR TITLE
test(integration): TestGigaStoreMigration — giga SS-store migration e2e

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cosmos/btcutil v1.0.5
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/go-logr/logr v1.4.3
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/onsi/gomega v1.39.1
 	github.com/sei-protocol/sei-config v0.0.22
@@ -73,7 +74,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/test/integration/giga_migration_test.go
+++ b/test/integration/giga_migration_test.go
@@ -1,0 +1,202 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
+	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
+)
+
+// taskTypeConfigPatch pins seictl's config-patch task wire type. The workflow
+// planner stamps it as PlannedTask.Type when it materializes a ConfigMigration
+// into the recipe (sidecar.TaskTypeConfigPatch == "config-patch"); the value is
+// a wire contract, so a literal here is the honest coupling: the suite does not
+// import internal/planner to borrow the constant (see the harness package doc
+// for the dependency boundary).
+const taskTypeConfigPatch = "config-patch"
+
+// TestGigaStoreMigration drives the giga SS-store migration through the SDK end
+// to end, as a sibling of TestWorkflowStateSync (it reuses that round trip's
+// provision + witness + follower bring-up verbatim via bringUpStateSyncFollower)
+// but with a ConfigMigration carried inside the StateSync recipe. Four signals,
+// in order:
+//
+//  1. terminal shape — the workflow reaches Complete under a tight child timeout
+//     (a wedged giga boot fails fast and legibly, not to the scenario deadline);
+//  2. THE ANCHOR — the compiled status.plan carries a config-patch step whose
+//     app.toml tree is exactly the giga enabling flags (state-store ss-enable /
+//     evm-ss-split / ss-backend, state-commit sc-enable). This proves the
+//     ConfigMigration -> render -> planner materialization end to end and cannot
+//     false-green: it inspects the persisted plan, not a log line;
+//  3. discontinuity — the block-store base jumps >= one snapshot_interval, the
+//     same genuine-wipe+resync discriminator the baseline uses;
+//  4. giga runtime — after the resync the node is Ready + caught up + EVM-serving
+//     WHILE running under evm-ss-split=true. Per the giga migration doc's startup
+//     safety checks a node with evm-ss-split=true and an unpopulated EVM-SS layout
+//     refuses to boot, so a healthy boot + catch-up + EVM-serving IS the
+//     SDK-observable evidence that giga went live.
+//
+// Assumptions / honest ceiling:
+//   - This assumes SEID_IMAGE is a giga-capable seid build (infra owns image
+//     selection; there is no image-capability gate or env flag here — the nightly
+//     runs it against the latest image).
+//   - The stronger "seid HONORED the giga config (vs silently ignored it and
+//     booted a legacy layout)" discriminator would read a seid startup log line;
+//     it is DEFERRED pending a harness pod-log affordance. Signal 4 is the current
+//     ceiling: with evm-ss-split=true a legacy-layout boot fails the safety check,
+//     so a served EVM endpoint is strong (not absolute) evidence.
+//
+// Inputs (env): SEI_CHAIN_ID, SEID_IMAGE [required]; SEI_NAMESPACE,
+// SEI_VALIDATORS [optional]. Run as the nightly CronJob:
+//
+//	["-test.run", "TestGigaStoreMigration", "-test.v", "-test.timeout", "0"]
+func TestGigaStoreMigration(t *testing.T) {
+	requireCluster(t)
+	chainID := runChainID(mustEnv(t, "SEI_CHAIN_ID"))
+	seid := mustEnv(t, "SEID_IMAGE")
+	ns := envOr("SEI_NAMESPACE", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
+	defer cancel()
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	c := openClient(ctx, t)
+	validators := envInt(t, "SEI_VALIDATORS", 1)
+
+	// Same fixture as the plain-resync baseline: snapshot-producing chain + a
+	// state-sync follower verified to have started FROM a snapshot (earliest > 1 —
+	// the PRE-migration state).
+	f := bringUpStateSyncFollower(ctx, t, c, chainID, ns, seid, validators)
+
+	// Re-bootstrap the follower through StateSync WITH a giga migration. RpcServers
+	// nil inherits the node's resolved DISTINCT witnesses (as in the baseline);
+	// Backend is pinned pebbledb so the anchor assertion has a concrete value to
+	// match, rather than relying on the CRD default having run.
+	wf, err := c.CreateWorkflow(ctx, sei.WorkflowSpec{
+		Name:      "giga-" + chainID,
+		Namespace: ns,
+		Node:      f.node.Name(),
+		Kind:      sei.WorkflowStateSync,
+		Labels:    map[string]string{runLabelKey: chainID},
+		StateSync: &sei.StateSyncWorkflow{
+			Migration: &sei.ConfigMigration{
+				Kind:      sei.ConfigMigrationGigaStore,
+				GigaStore: &sei.GigaStoreMigration{Backend: "pebbledb"},
+			},
+			RpcServers: nil,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create giga workflow: %v", err)
+	}
+	cleanupWorkflow(t, wf)
+	t.Logf("workflow %s: created against %s (giga, backend pebbledb)", wf.Name(), f.node.Name())
+
+	// (a) Terminal shape under a tight child timeout — fail fast + legibly.
+	awaitWorkflowComplete(ctx, t, wf, workflowWaitTimeout)
+	t.Logf("workflow %s: complete", wf.Name())
+
+	// (b) THE ANCHOR: the compiled plan's config-patch step carries exactly the
+	// giga app.toml tree. Reads the persisted status.plan (not a log), so it
+	// cannot false-green.
+	assertGigaConfigPatch(t, wf, "pebbledb")
+
+	// (c) Discontinuity: a genuine wipe + fresh re-sync moves the block-store base
+	// by >= one snapshot_interval (base pinned by chain.min_retain_blocks=0, so
+	// routine pruning cannot move it) — same discriminator as the baseline.
+	// WaitCaughtUp first so the freshly-restored earliest is observable.
+	if err := sei.WaitCaughtUp(ctx, f.hc, f.node.TendermintRPC()); err != nil {
+		t.Fatalf("follower %s not caught up after giga resync: %v", f.node.Name(), err)
+	}
+	postEarliest, ok := sei.EarliestHeight(ctx, f.hc, f.node.TendermintRPC())
+	if !ok {
+		t.Fatalf("read post-workflow earliest height of %q", f.node.Name())
+	}
+	if postEarliest-f.preEarliest < int64(f.interval) {
+		t.Fatalf("follower %s earliest height %d -> %d after giga resync (jump %d), want a jump >= snapshot_interval %d (a genuine wipe + re-sync lands on a snapshot at least one interval higher; a smaller move is routine pruning, not a fresh restore)",
+			f.node.Name(), f.preEarliest, postEarliest, postEarliest-f.preEarliest, f.interval)
+	}
+
+	// (d) Giga runtime: with evm-ss-split=true a node whose EVM-SS layout is
+	// unpopulated refuses to boot (giga doc startup safety checks), so a healthy
+	// Ready + caught-up + EVM-serving node IS the SDK-observable evidence giga went
+	// live. Re-affirm Ready (the resync cycled seid), then EVM must serve — a hard
+	// failure here, unlike the baseline where EVM is a soft t.Errorf, because EVM
+	// serving under the split layout is this test's whole point.
+	if err := f.node.WaitReady(ctx); err != nil {
+		t.Fatalf("follower %s not Running after giga resync: %v", f.node.Name(), err)
+	}
+	if err := sei.WaitCaughtUp(ctx, f.hc, f.node.TendermintRPC()); err != nil {
+		t.Fatalf("follower %s not caught up after giga resync: %v", f.node.Name(), err)
+	}
+	if err := sei.WaitEVMServing(ctx, f.hc, f.node.EVMRPC()); err != nil {
+		t.Fatalf("follower %s EVM not serving under evm-ss-split=true after giga resync: %v (a node with an unpopulated EVM-SS layout refuses to boot, so a non-serving EVM here means giga did not go live)", f.node.Name(), err)
+	}
+	t.Logf("follower %s: caught up + EVM serving under evm-ss-split=true, block-store base jumped %d -> %d (>= interval %d) — TestGigaStoreMigration OK", f.node.Name(), f.preEarliest, postEarliest, f.interval)
+}
+
+// assertGigaConfigPatch is the anchor: it casts the workflow's raw CR, walks the
+// compiled status.plan for the config-patch step, unmarshals its opaque Params
+// JSON, and asserts the app.toml tree equals exactly the giga enabling flags for
+// the given backend. This proves the ConfigMigration was rendered into the plan
+// (spec = intent, status.plan = the applied TOML keys — the CRD's own contract),
+// materializing the giga_store_migration.md Step-1 flags the controller pins.
+func assertGigaConfigPatch(t *testing.T, wf *sei.Workflow, backend string) {
+	t.Helper()
+
+	obj, ok := wf.Object().(*v1alpha1.SeiNodeTaskWorkflow)
+	if !ok || obj == nil {
+		t.Fatalf("workflow Object() is %T, want *v1alpha1.SeiNodeTaskWorkflow", wf.Object())
+	}
+	if obj.Status.Plan == nil {
+		t.Fatalf("workflow %s has no status.plan to inspect", wf.Name())
+	}
+
+	var patch *v1alpha1.PlannedTask
+	for i := range obj.Status.Plan.Tasks {
+		if obj.Status.Plan.Tasks[i].Type == taskTypeConfigPatch {
+			patch = &obj.Status.Plan.Tasks[i]
+			break
+		}
+	}
+	if patch == nil {
+		t.Fatalf("workflow %s plan has no %q task (the giga migration did not materialize a config-patch step)", wf.Name(), taskTypeConfigPatch)
+	}
+	if patch.Params == nil {
+		t.Fatalf("config-patch task %s has nil Params", patch.ID)
+	}
+
+	// The planner serializes task.ConfigPatchTask{Files: ...} into Params, so the
+	// payload is {"files":{"<file>":{"<section>":{...}}}}.
+	var params struct {
+		Files map[string]map[string]any `json:"files"`
+	}
+	if err := json.Unmarshal(patch.Params.Raw, &params); err != nil {
+		t.Fatalf("unmarshal config-patch params %q: %v", string(patch.Params.Raw), err)
+	}
+
+	got := params.Files["app.toml"]
+	want := map[string]any{
+		"state-store": map[string]any{
+			"ss-enable":    true,
+			"evm-ss-split": true,
+			"ss-backend":   backend,
+		},
+		"state-commit": map[string]any{
+			"sc-enable": true,
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("workflow %s config-patch app.toml tree mismatch (-want +got):\n%s", wf.Name(), diff)
+	}
+	t.Logf("workflow %s: config-patch app.toml tree matches giga enabling flags (backend %s)", wf.Name(), backend)
+}

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -10,8 +10,9 @@
 // nightly compiles it once (go test -c -tags integration) and runs each target as
 // an in-cluster CronJob (-test.run TestX).
 //
-// Depends only on sdk/sei (+ the k8s provider blank import); never internal/seitask
-// or internal/taskruntime.
+// Depends on sdk/sei (+ the k8s provider blank import), api/v1alpha1 (public API
+// types, for reading status.plan), and k8s.io/apimachinery/.../metav1 (for a
+// condition constant); never internal/seitask or internal/taskruntime.
 package integration
 
 import (

--- a/test/integration/workflow_test.go
+++ b/test/integration/workflow_test.go
@@ -14,6 +14,9 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sei-protocol/sei-k8s-controller/api/v1alpha1"
 	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
 )
 
@@ -49,6 +52,11 @@ var snapshotProductionConfig = map[string]string{
 // caught up AGAIN and its earliest height advanced past the pre-wipe floor: proof
 // of a genuine wipe + fresh re-sync to a newer snapshot, not a no-op. Acceptance
 // criterion 5.
+//
+// The provision + witness + follower bring-up is shared verbatim with
+// TestGigaStoreMigration via bringUpStateSyncFollower (that sibling reruns this
+// same round trip WITH a giga config migration). This test is the plain-resync
+// baseline: it stays independent and carries no migration.
 //
 // Witnesses: the follower's RpcServers are TWO DISTINCT full-node RPC endpoints —
 // genesis validator-0 and the provisioned rpc follower (rpcNodes[0]) — each a
@@ -96,6 +104,111 @@ func TestWorkflowStateSync(t *testing.T) {
 	// bootstrap deadlock), so keep the default at one.
 	validators := envInt(t, "SEI_VALIDATORS", 1)
 
+	// Provision the snapshot-producing chain and bring up a plain state-sync
+	// follower bootstrapped from the two DISTINCT witnesses, verified to have
+	// started FROM a snapshot (earliest > 1 — the pre-wipe floor).
+	f := bringUpStateSyncFollower(ctx, t, c, chainID, ns, seid, validators)
+
+	// Re-bootstrap that state-sync follower through the StateSync recipe. Leave the
+	// recipe's RpcServers nil: the workflow planner inherits the node's already-
+	// resolved DISTINCT witnesses (node.Status.ResolvedStateSyncers, set from this
+	// ssNode's spec rpcServers = the two witnesses above) when the recipe carries
+	// none (internal/planner/workflow.go BuildPlan). Passing the aggregate
+	// round-robin RPC twice would be an unsound duplicate witness set that the
+	// planner's raw-len count does not dedup — nil sidesteps it and reuses the
+	// vetted distinct set. No migration: this is the plain-resync baseline.
+	wf, err := c.CreateWorkflow(ctx, sei.WorkflowSpec{
+		Name:      "resync-" + chainID,
+		Namespace: ns,
+		Node:      f.node.Name(),
+		Kind:      sei.WorkflowStateSync,
+		Labels:    map[string]string{runLabelKey: chainID},
+		StateSync: &sei.StateSyncWorkflow{RpcServers: nil},
+	})
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	cleanupWorkflow(t, wf)
+	t.Logf("workflow %s: created against %s", wf.Name(), f.node.Name())
+
+	// Fast-fail terminal-shape gate: bound WaitTerminal by a TIGHT child timeout
+	// (not the 60m scenario ctx) so a wedged recipe fails FAST and legibly with the
+	// recorded status instead of hanging to the scenario deadline.
+	awaitWorkflowComplete(ctx, t, wf, workflowWaitTimeout)
+	t.Logf("workflow %s: complete", wf.Name())
+
+	// Re-bootstrap observable: after the wipe + resync the follower rejoins and
+	// catches up again (it cannot catch up to a chain it is not synced with, so
+	// this covers the wiped-then-synced round trip) and serves EVM again.
+	if err := sei.WaitCaughtUp(ctx, f.hc, f.node.TendermintRPC()); err != nil {
+		t.Fatalf("follower %s not caught up after resync: %v", f.node.Name(), err)
+	}
+	if err := sei.WaitEVMServing(ctx, f.hc, f.node.EVMRPC()); err != nil {
+		t.Errorf("follower %s EVM not serving after resync: %v", f.node.Name(), err)
+	}
+
+	// Prove a genuine wipe + fresh re-sync via a DISCONTINUITY in the block-store
+	// base, not merely a rising earliest: on a running full node routine pruning
+	// also advances earliest_block_height, so postEarliest > preEarliest alone
+	// would false-green a no-op workflow. Two things make the jump conclusive:
+	// this follower pins chain.min_retain_blocks=0 (so block-store pruning cannot
+	// move the base at all), and a fresh state-sync restore lands on a NEW snapshot
+	// at least a full snapshot_interval higher than the previous one. Incremental pruning
+	// cannot move the base a whole interval inside the test window; only a wipe +
+	// restore can. So require the base to have jumped by >= one interval.
+	postEarliest, ok := sei.EarliestHeight(ctx, f.hc, f.node.TendermintRPC())
+	if !ok {
+		t.Fatalf("read post-workflow earliest height of %q", f.node.Name())
+	}
+	if postEarliest-f.preEarliest < int64(f.interval) {
+		t.Fatalf("follower %s earliest height %d -> %d after resync (jump %d), want a jump >= snapshot_interval %d (a genuine wipe + re-sync lands on a snapshot at least one interval higher; a smaller move is routine pruning, not a fresh restore)",
+			f.node.Name(), f.preEarliest, postEarliest, postEarliest-f.preEarliest, f.interval)
+	}
+	t.Logf("follower %s: caught up + EVM serving, block-store base jumped %d -> %d (>= interval %d) after state-sync re-bootstrap — TestWorkflowStateSync OK", f.node.Name(), f.preEarliest, postEarliest, f.interval)
+
+	// Interrupt-resume variant (deferred): kill the follower pod mid-recipe and
+	// assert the workflow resumes to Complete. Deferred here — it needs a
+	// mid-step injection hook to kill the pod during a specific recipe step
+	// (racing pod-kill against the whole recipe is flaky). The controller/sidecar
+	// resume path is covered deterministically by the controller envtest
+	// (TestWorkflowLifecycle_ReadoptByUIDAfterRestart) and the sidecar
+	// crash-resume tests; the e2e pod-kill variant lands with that hook.
+	t.Run("InterruptResume", func(t *testing.T) {
+		t.Skip("deferred: needs a mid-recipe pod-kill hook; restart-resume is covered by the controller envtest")
+	})
+}
+
+// stateSyncFollower is the pre-workflow fixture the state-sync suites share: a
+// snapshot-producing chain plus a plain RPC follower bootstrapped from two
+// DISTINCT witnesses, verified to have started FROM a snapshot. preEarliest is
+// the pre-wipe block-store floor the post-workflow discontinuity assertion must
+// exceed; hc/interval carry the poll client and the snapshot cadence both suites
+// reuse.
+type stateSyncFollower struct {
+	node        *sei.Node
+	hc          *http.Client
+	interval    int
+	preEarliest int64
+}
+
+// bringUpStateSyncFollower provisions the snapshot-producing chain (1 validator +
+// N rpc followers, all memiavl + snapshot-producing) and brings up a plain
+// state-sync RPC follower against TWO DISTINCT witnesses, blocking until it is
+// running + caught up and verified to have started FROM a snapshot (earliest > 1).
+// It registers teardown for everything it creates and t.Fatalf's on any failure,
+// so the caller gets a ready fixture or a failed test — never a half-built one.
+//
+// The two DISTINCT full-node RPC endpoints (bare host:port, the CRD
+// SnapshotSource.RpcServers shape) are genesis validator-0 (service <chainID>-0)
+// and the provisioned rpc follower (rpcNodeName(chainID,0) = <chainID>-rpc-0).
+// The witness namespace is derived from the aggregate RPC host rather than the ns
+// input, which may be "" — the SDK resolves an empty namespace to a
+// kubeconfig/SA default that only the served endpoint reflects. The aggregate
+// host is <chainID>-internal.<ns>.svc[.cluster.local]; chainID carries no dots,
+// so the second dotted label is the namespace.
+func bringUpStateSyncFollower(ctx context.Context, t *testing.T, c *sei.Client, chainID, ns, seid string, validators int) stateSyncFollower {
+	t.Helper()
+
 	ch, err := provision(ctx, t, c, spec{
 		chainID:       chainID,
 		runID:         chainID,
@@ -125,17 +238,6 @@ func TestWorkflowStateSync(t *testing.T) {
 		t.Fatalf("network did not advance past the snapshot interval: %v", err)
 	}
 
-	// Two DISTINCT full-node RPC endpoints as BARE host:port (the CRD
-	// SnapshotSource.RpcServers shape; nodeRPC encodes the controller's
-	// per-node headless-service naming): genesis validator-0 (service <chainID>-0)
-	// and the provisioned rpc follower (service rpcNodeName(chainID,0) =
-	// <chainID>-rpc-0). Both are caught-up full nodes and valid light-client
-	// witnesses; the follower is otherwise dead weight since the workflow target
-	// moved to ssNode. Derive the namespace from the aggregate RPC host rather than
-	// the SEI_NAMESPACE input, which may be "" — the SDK resolves an empty
-	// namespace to a kubeconfig/SA default that only the served endpoint reflects.
-	// The aggregate host is <chainID>-internal.<ns>.svc[.cluster.local]; chainID
-	// carries no dots, so the second dotted label is the namespace.
 	u, err := url.Parse(ch.network.TendermintRPC())
 	if err != nil {
 		t.Fatalf("parse network TM RPC %q: %v", ch.network.TendermintRPC(), err)
@@ -161,7 +263,7 @@ func TestWorkflowStateSync(t *testing.T) {
 	// min_retain_blocks explicitly (it defaults to 0, but stating it makes the
 	// base-pin a fact of the recipe, not an inherited default) so earliest moves
 	// ONLY on a genuine wipe + fresh restore — which is what the discontinuity
-	// assertion below relies on. storage.pruning=nothing is kept for the state store
+	// assertion relies on. storage.pruning=nothing is kept for the state store
 	// (unpruned state is also what snapshot production needs). memiavl matches the
 	// network's write-mode (the nightly image rejects the controller default; see
 	// memiavlStorageConfig).
@@ -210,75 +312,53 @@ func TestWorkflowStateSync(t *testing.T) {
 	}
 	t.Logf("state-sync node %s: bootstrapped from snapshot (earliest %d, latest %d)", ssNode.Name(), preEarliest, preLatest)
 
-	// Re-bootstrap that state-sync follower through the StateSync recipe. Leave the
-	// recipe's RpcServers nil: the workflow planner inherits the node's already-
-	// resolved DISTINCT witnesses (node.Status.ResolvedStateSyncers, set from this
-	// ssNode's spec rpcServers = the two witnesses above) when the recipe carries
-	// none (internal/planner/workflow.go BuildPlan). Passing the aggregate
-	// round-robin RPC twice would be an unsound duplicate witness set that the
-	// planner's raw-len count does not dedup — nil sidesteps it and reuses the
-	// vetted distinct set.
-	wf, err := c.CreateWorkflow(ctx, sei.WorkflowSpec{
-		Name:      "resync-" + chainID,
-		Namespace: ns,
-		Node:      ssNode.Name(),
-		Kind:      sei.WorkflowStateSync,
-		Labels:    map[string]string{runLabelKey: chainID},
-		StateSync: &sei.StateSyncWorkflow{RpcServers: nil},
-	})
-	if err != nil {
-		t.Fatalf("create workflow: %v", err)
-	}
-	cleanupWorkflow(t, wf)
-	t.Logf("workflow %s: created against %s", wf.Name(), ssNode.Name())
+	return stateSyncFollower{node: ssNode, hc: hc, interval: interval, preEarliest: preEarliest}
+}
 
-	if err := wf.WaitTerminal(ctx); err != nil {
-		t.Fatalf("workflow %s did not complete: %v", wf.Name(), err)
+// workflowWaitTimeout is the TIGHT child budget for one resync workflow's
+// WaitTerminal — well under the 60m scenario ctx so a wedged recipe (a giga boot
+// that refuses to start, or a step whose await carries no timeout) fails FAST and
+// legibly with the recorded status instead of stalling to the scenario deadline.
+const workflowWaitTimeout = 15 * time.Minute
+
+// awaitWorkflowComplete blocks on wf.WaitTerminal under a tight child timeout and
+// asserts the terminal shape is Complete. On failure OR timeout it renders the
+// workflow's recorded status (phase + failed-task detail + Failed condition) into
+// the t.Fatalf so the cause is legible in the pod log rather than a bare
+// deadline. Shared by both state-sync suites.
+func awaitWorkflowComplete(ctx context.Context, t *testing.T, wf *sei.Workflow, timeout time.Duration) {
+	t.Helper()
+	wctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := wf.WaitTerminal(wctx); err != nil {
+		t.Fatalf("workflow %s did not reach Complete: %v%s", wf.Name(), err, workflowFailureDetail(wf))
 	}
 	if got := wf.Phase(); got != sei.WorkflowPhaseComplete {
-		t.Fatalf("workflow terminal phase = %q, want Complete", got)
+		t.Fatalf("workflow %s terminal phase = %q, want Complete%s", wf.Name(), got, workflowFailureDetail(wf))
 	}
-	t.Logf("workflow %s: complete", wf.Name())
+}
 
-	// Re-bootstrap observable: after the wipe + resync the follower rejoins and
-	// catches up again (it cannot catch up to a chain it is not synced with, so
-	// this covers the wiped-then-synced round trip) and serves EVM again.
-	if err := sei.WaitCaughtUp(ctx, hc, ssNode.TendermintRPC()); err != nil {
-		t.Fatalf("follower %s not caught up after resync: %v", ssNode.Name(), err)
+// workflowFailureDetail renders the workflow's recorded status for a failure
+// message: status.phase, the failed task's type+error, and the Failed condition's
+// reason+message. Returns "" if the raw object is unavailable. Reads the workflow's
+// raw CR via Object() to render the recorded status.
+func workflowFailureDetail(wf *sei.Workflow) string {
+	obj, ok := wf.Object().(*v1alpha1.SeiNodeTaskWorkflow)
+	if !ok || obj == nil {
+		return ""
 	}
-	if err := sei.WaitEVMServing(ctx, hc, ssNode.EVMRPC()); err != nil {
-		t.Errorf("follower %s EVM not serving after resync: %v", ssNode.Name(), err)
+	var b strings.Builder
+	fmt.Fprintf(&b, " (status.phase=%q", obj.Status.Phase)
+	if p := obj.Status.Plan; p != nil && p.FailedTaskDetail != nil {
+		fmt.Fprintf(&b, "; failed task %q: %s", p.FailedTaskDetail.Type, p.FailedTaskDetail.Error)
 	}
-
-	// Prove a genuine wipe + fresh re-sync via a DISCONTINUITY in the block-store
-	// base, not merely a rising earliest: on a running full node routine pruning
-	// also advances earliest_block_height, so postEarliest > preEarliest alone
-	// would false-green a no-op workflow. Two things make the jump conclusive:
-	// this follower pins chain.min_retain_blocks=0 (so block-store pruning cannot
-	// move the base at all), and a fresh state-sync restore lands on a NEW snapshot
-	// at least a full snapshot_interval higher than the previous one. Incremental pruning
-	// cannot move the base a whole interval inside the test window; only a wipe +
-	// restore can. So require the base to have jumped by >= one interval.
-	postEarliest, ok := sei.EarliestHeight(ctx, hc, ssNode.TendermintRPC())
-	if !ok {
-		t.Fatalf("read post-workflow earliest height of %q", ssNode.Name())
+	for i := range obj.Status.Conditions {
+		if cnd := obj.Status.Conditions[i]; cnd.Type == v1alpha1.ConditionSeiNodeTaskWorkflowFailed && cnd.Status == metav1.ConditionTrue {
+			fmt.Fprintf(&b, "; Failed=%s: %s", cnd.Reason, cnd.Message)
+		}
 	}
-	if postEarliest-preEarliest < int64(interval) {
-		t.Fatalf("follower %s earliest height %d -> %d after resync (jump %d), want a jump >= snapshot_interval %d (a genuine wipe + re-sync lands on a snapshot at least one interval higher; a smaller move is routine pruning, not a fresh restore)",
-			ssNode.Name(), preEarliest, postEarliest, postEarliest-preEarliest, interval)
-	}
-	t.Logf("follower %s: caught up + EVM serving, block-store base jumped %d -> %d (>= interval %d) after state-sync re-bootstrap — TestWorkflowStateSync OK", ssNode.Name(), preEarliest, postEarliest, interval)
-
-	// Interrupt-resume variant (deferred): kill the follower pod mid-recipe and
-	// assert the workflow resumes to Complete. Deferred here — it needs a
-	// mid-step injection hook to kill the pod during a specific recipe step
-	// (racing pod-kill against the whole recipe is flaky). The controller/sidecar
-	// resume path is covered deterministically by the controller envtest
-	// (TestWorkflowLifecycle_ReadoptByUIDAfterRestart) and the sidecar
-	// crash-resume tests; the e2e pod-kill variant lands with that hook.
-	t.Run("InterruptResume", func(t *testing.T) {
-		t.Skip("deferred: needs a mid-recipe pod-kill hook; restart-resume is covered by the controller envtest")
-	})
+	b.WriteString(")")
+	return b.String()
 }
 
 // nodeRPC is a SeiNode's CometBFT RPC as a bare host:port state-sync witness (no


### PR DESCRIPTION
Adds the nightly e2e that exercises the new typed `ConfigMigration` path (#480) end to end: walk one RPC `SeiNode` through the state-sync workflow with `Migration: GigaStore{pebbledb}`, and verify it worked.

## What it asserts
- **(a) Complete** — via a fast-fail wrapper (15m child timeout + terminal-shape assertion + rendered `status.phase`/failed-task/condition detail), so a giga boot failure fails fast and legibly instead of hanging to the scenario deadline. **Retrofitted onto the base `TestWorkflowStateSync` too** — the no-timeout `AwaitCondition` hang was latent there.
- **(b) the anchor (can't false-green)** — the persisted `status.plan` config-patch task carries the exact giga `app.toml` tree (`ss-enable`/`evm-ss-split`/`sc-enable=true`, `ss-backend`), compared with `cmp.Diff`. Proves the `ConfigMigration → render → planner` materialization.
- **(c)** earliest-height discontinuity (`≥ snapshot_interval`, base pinned) — a genuine wipe + resync.
- **(d)** EVM serving under `evm-ss-split=true` — a giga node with an unpopulated EVM-SS layout refuses to boot, so a served endpoint is SDK-observable evidence giga went live.

## Shape
Sibling of `TestWorkflowStateSync` (keeps the plain-resync baseline independent); shared setup extracted into `bringUpStateSyncFollower`. `pebbledb` only (rocksdb needs a `-tags rocksdbBackend` image → deferred). Test-only — no CRD/SDK change, no one-way door.

## Review
Blinded `/xreview` **RESOLVED — unanimous**: systems RATIFY (the prior false-green class is closed by the persisted-plan anchor; fast-fail nil-safe; no hang path), kubernetes COMPATIBLE (the anchor is byte-for-byte the planner's output; fails closed at (d) if the snapshot-import assumption is wrong), idiom RATIFY (go-cmp, comment/doc fixes applied). `go build`/`vet -tags integration`, `gofmt`, `go mod tidy` — green.

## Honest ceiling
Assumes a giga-capable `SEID_IMAGE` (infra owns image selection; no in-test gate per the maintainer). The stronger "seid *honored* vs silently *ignored* the config" seid-startup-log discriminator is **deferred** (needs a harness pod-log affordance); signal (d) is the current ceiling — strong, not absolute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)