### PR TITLE
refactor(seinetwork): move CR-read sites onto canonical sei.io/seinetwork keys (Wave A)

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -32,10 +32,12 @@ type PeerSource struct {
 //
 // Controller-managed labels available on every SeiNode owned by a SeiNetwork:
 //   - sei.io/chain — from .spec.genesis.chainId
-//   - sei.io/nodedeployment — owning SeiNetwork name (frozen selector key)
-//   - sei.io/nodedeployment-ordinal — replica index (frozen selector key)
-//   - sei.io/seinetwork — owning SeiNetwork name (canonical key)
+//   - sei.io/seinetwork — owning SeiNetwork name (canonical key; controller
+//     CR-selection matches on this)
 //   - sei.io/seinetwork-ordinal — replica index (canonical key)
+//   - sei.io/nodedeployment — owning SeiNetwork name (frozen selector key,
+//     still stamped for selector continuity with external consumers)
+//   - sei.io/nodedeployment-ordinal — replica index (frozen selector key)
 //   - sei.io/role — always "validator" (a SeiNetwork is a validator pool)
 //
 // These reserved keys are always controller-stamped. (There is no

--- a/api/v1alpha1/seinetwork_types.go
+++ b/api/v1alpha1/seinetwork_types.go
@@ -77,9 +77,10 @@ type SeiNetworkSpec struct {
 	Sidecar *SidecarConfig `json:"sidecar,omitempty"`
 
 	// PodLabels are additional labels merged into each child SeiNode's pod
-	// template. The controller always adds the reserved group labels
-	// (sei.io/nodedeployment{,-ordinal}, frozen GitOps selector keys, plus the
-	// canonical sei.io/seinetwork{,-ordinal} keys); these are additive.
+	// template. The controller always adds the reserved group labels — the
+	// canonical sei.io/seinetwork{,-ordinal} keys, plus the frozen
+	// sei.io/nodedeployment{,-ordinal} GitOps selector keys retained for
+	// selector continuity; these are additive.
 	// +optional
 	PodLabels map[string]string `json:"podLabels,omitempty"`
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -231,7 +231,9 @@ func main() {
 				nodes := &seiv1alpha1.SeiNodeList{}
 				if err := kc.List(ctx, nodes,
 					client.InNamespace(network.Namespace),
-					client.MatchingLabels{"sei.io/nodedeployment": network.Name},
+					// Canonical seinetwork CR-selection key (both key families
+					// are stamped on every SeiNetwork child).
+					client.MatchingLabels{"sei.io/seinetwork": network.Name},
 				); err == nil && len(nodes.Items) > 0 {
 					sort.Slice(nodes.Items, func(i, j int) bool {
 						return nodes.Items[i].Name < nodes.Items[j].Name

--- a/config/crd/sei.io_seinetworks.yaml
+++ b/config/crd/sei.io_seinetworks.yaml
@@ -220,9 +220,10 @@ spec:
                   type: string
                 description: |-
                   PodLabels are additional labels merged into each child SeiNode's pod
-                  template. The controller always adds the reserved group labels
-                  (sei.io/nodedeployment{,-ordinal}, frozen GitOps selector keys, plus the
-                  canonical sei.io/seinetwork{,-ordinal} keys); these are additive.
+                  template. The controller always adds the reserved group labels — the
+                  canonical sei.io/seinetwork{,-ordinal} keys, plus the frozen
+                  sei.io/nodedeployment{,-ordinal} GitOps selector keys retained for
+                  selector continuity; these are additive.
                 type: object
               replicas:
                 default: 1

--- a/internal/controller/seinetwork/labels.go
+++ b/internal/controller/seinetwork/labels.go
@@ -40,11 +40,20 @@ func seiNodeName(network *seiv1alpha1.SeiNetwork, ordinal int) string {
 	return fmt.Sprintf("%s-%d", network.Name, ordinal)
 }
 
-// groupSelector returns the label selector used by the internal Service and
-// child-node listing. Image changes update pods in place, so traffic must
-// always reach every network member.
+// groupSelector returns the FROZEN nodedeployment-keyed selector. It backs the
+// internal ClusterIP Service's pod selector only. The live Service selector
+// must match the frozen key stamped on running pods; selecting on the canonical
+// key instead strands traffic until every pod is re-stamped by a fleet roll.
+// CR-listing uses seinetworkSelector.
 func groupSelector(network *seiv1alpha1.SeiNetwork) map[string]string {
 	return map[string]string{groupLabel: network.Name}
+}
+
+// seinetworkSelector returns the canonical seinetwork-keyed selector used to
+// list/select child SeiNode CRs. Both key families are stamped on every child
+// (see seiNodeLabels), so this selects the same set as groupSelector today.
+func seinetworkSelector(network *seiv1alpha1.SeiNetwork) map[string]string {
+	return map[string]string{seinetworkLabel: network.Name}
 }
 
 // seiNodeLabels builds the metadata labels for a child SeiNode. The reserved

--- a/internal/controller/seinetwork/nodes.go
+++ b/internal/controller/seinetwork/nodes.go
@@ -237,7 +237,7 @@ func (r *SeiNetworkReconciler) scaleDown(ctx context.Context, network *seiv1alph
 	nodeList := &seiv1alpha1.SeiNodeList{}
 	if err := r.List(ctx, nodeList,
 		client.InNamespace(network.Namespace),
-		client.MatchingLabels(groupSelector(network)),
+		client.MatchingLabels(seinetworkSelector(network)),
 	); err != nil {
 		return fmt.Errorf("listing child SeiNodes: %w", err)
 	}
@@ -247,11 +247,11 @@ func (r *SeiNetworkReconciler) scaleDown(ctx context.Context, network *seiv1alph
 		if !metav1.IsControlledBy(node, network) {
 			continue
 		}
-		if node.Labels[groupOrdinalLabel] == "" {
+		if node.Labels[seinetworkOrdinalLabel] == "" {
 			continue
 		}
 		var ord int
-		if _, err := fmt.Sscanf(node.Labels[groupOrdinalLabel], "%d", &ord); err != nil {
+		if _, err := fmt.Sscanf(node.Labels[seinetworkOrdinalLabel], "%d", &ord); err != nil {
 			continue
 		}
 		if ord >= int(network.Spec.Replicas) {
@@ -268,7 +268,7 @@ func (r *SeiNetworkReconciler) listChildSeiNodes(ctx context.Context, network *s
 	nodeList := &seiv1alpha1.SeiNodeList{}
 	if err := r.List(ctx, nodeList,
 		client.InNamespace(network.Namespace),
-		client.MatchingLabels(groupSelector(network)),
+		client.MatchingLabels(seinetworkSelector(network)),
 	); err != nil {
 		return nil, fmt.Errorf("listing child SeiNodes: %w", err)
 	}

--- a/internal/controller/seinetwork/nodes_test.go
+++ b/internal/controller/seinetwork/nodes_test.go
@@ -376,7 +376,7 @@ func TestSyncPausedToChildren_IgnoresPlanInProgress(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testNode0,
 			Namespace: testGroupNS,
-			Labels:    map[string]string{groupLabel: testNetworkName},
+			Labels:    map[string]string{seinetworkLabel: testNetworkName},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: testAPIVersion,
 				Kind:       testKind,

--- a/internal/controller/seinetwork/per_pod_services.go
+++ b/internal/controller/seinetwork/per_pod_services.go
@@ -23,7 +23,7 @@ func populatePerPodServices(log logr.Logger, nodes []seiv1alpha1.SeiNode) []seiv
 	entries := make([]entry, 0, len(nodes))
 	for i := range nodes {
 		node := &nodes[i]
-		ordStr, ok := node.Labels[groupOrdinalLabel]
+		ordStr, ok := node.Labels[seinetworkOrdinalLabel]
 		if !ok {
 			log.V(1).Info("per-pod service: skipping node missing ordinal label", "node", node.Name)
 			continue

--- a/internal/controller/seinetwork/per_pod_services_test.go
+++ b/internal/controller/seinetwork/per_pod_services_test.go
@@ -19,8 +19,8 @@ func nodeWithOrdinal(name, ordinal string) seiv1alpha1.SeiNode {
 			Name:      name,
 			Namespace: testNamespace,
 			Labels: map[string]string{
-				groupLabel:        testGroupLabelValue,
-				groupOrdinalLabel: ordinal,
+				seinetworkLabel:        testGroupLabelValue,
+				seinetworkOrdinalLabel: ordinal,
 			},
 		},
 	}
@@ -78,7 +78,7 @@ func TestPopulatePerPodServices_MissingOrdinalLabelSkipped(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pacific-1-wave-99",
 			Namespace: testNamespace,
-			Labels:    map[string]string{groupLabel: testGroupLabelValue},
+			Labels:    map[string]string{seinetworkLabel: testGroupLabelValue},
 		},
 	}
 	nodes := []seiv1alpha1.SeiNode{

--- a/internal/task/await_nodes_running.go
+++ b/internal/task/await_nodes_running.go
@@ -16,7 +16,8 @@ const TaskTypeAwaitNodesRunning = "await-nodes-running"
 // AwaitNodesRunningParams holds the serialized parameters for the
 // await-nodes-running task. The task polls child SeiNodes until all
 // reach PhaseRunning. When NodeNames is set, only those specific nodes
-// are checked; otherwise all nodes matching the group label are checked.
+// are checked; otherwise all SeiNode CRs matching the canonical
+// sei.io/seinetwork label (value GroupName) are checked.
 type AwaitNodesRunningParams struct {
 	GroupName string   `json:"groupName"`
 	Namespace string   `json:"namespace"`
@@ -89,7 +90,9 @@ func (e *awaitNodesRunningExecution) listTargetNodes(ctx context.Context) ([]sei
 	nodeList := &seiv1alpha1.SeiNodeList{}
 	if err := e.cfg.KubeClient.List(ctx, nodeList,
 		client.InNamespace(e.params.Namespace),
-		client.MatchingLabels{"sei.io/nodedeployment": e.params.GroupName},
+		// Lists SeiNode CRs by the canonical sei.io/seinetwork key; GroupName is
+		// the SeiNetwork name.
+		client.MatchingLabels{"sei.io/seinetwork": e.params.GroupName},
 	); err != nil {
 		return nil, err
 	}

--- a/manifests/sei.io_seinetworks.yaml
+++ b/manifests/sei.io_seinetworks.yaml
@@ -220,9 +220,10 @@ spec:
                   type: string
                 description: |-
                   PodLabels are additional labels merged into each child SeiNode's pod
-                  template. The controller always adds the reserved group labels
-                  (sei.io/nodedeployment{,-ordinal}, frozen GitOps selector keys, plus the
-                  canonical sei.io/seinetwork{,-ordinal} keys); these are additive.
+                  template. The controller always adds the reserved group labels — the
+                  canonical sei.io/seinetwork{,-ordinal} keys, plus the frozen
+                  sei.io/nodedeployment{,-ordinal} GitOps selector keys retained for
+                  selector continuity; these are additive.
                 type: object
               replicas:
                 default: 1


### PR DESCRIPTION
**Wave A** of the `sei.io/nodedeployment`→`sei.io/seinetwork` nomenclature migration: move the code that reads/selects SeiNode **CRs** onto the canonical keys. Zero pod roll; the internal-Service pod selector (Wave B) and the label stamp are untouched.

## What
- **`labels.go`** — split the shared selector: `groupSelector` stays on the frozen `nodedeployment` key for the internal ClusterIP Service pod selector; new **`seinetworkSelector`** (canonical) backs CR-listing.
- Repointed the CR-read sites: `nodes.go` (`listChildSeiNodes`, `scaleDown` list + ordinal parse), `per_pod_services.go` (ordinal read), `cmd/main.go` (assembler-node select), `internal/task/await_nodes_running.go` (`listTargetNodes` — confirmed lists `SeiNodeList`, not pods).
- API doc-comments now describe `seinetwork` as primary / `nodedeployment` as retained-for-continuity; regenerated CRD YAML (**description-only**, no served-schema/CEL change).

## Why it's a no-op / zero-roll
Every SeiNetwork child is dual-stamped with both key families, and all these read-sites are **SeiNetwork-children-scoped** (list by `sei.io/seinetwork=<network.name>` within a SeiNetwork reconcile), so the selected set is identical. The internal-Service **pod** selector and the **stamp** are unchanged → nothing rolls. Standalone SeiNodes (not children of any SeiNetwork) are never selected by these sites.

## Kept for Wave B / follow-up
- `internal_service.go:94` pod-selector flip — Wave B, gated on the fleet fully cycling (`kubectl get pods -A -l 'sei.io/nodedeployment,!sei.io/seinetwork'` empty).
- Hoisting a shared `api/v1alpha1` const for `sei.io/seinetwork` (retire the raw literals + `sdk/sei`'s aspirational "single source of truth") — endorsed follow-up.

## Review
`/xreview` — Class component, T2. kubernetes-specialist (dissenter) + idiomatic-reviewer: both **RATIFY**. Verified pod-selector + stamp untouched, all migrated sites are CR readers, the selector split is correct, CRD diff description-only. **Deployment precondition empirically verified**: all 15 SeiNetwork-child SeiNodes on harbor carry the canonical label (prod's standalone nodes correctly don't, and are never selected). Build + `seinetwork`/`task` tests + envtest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)