### PR TITLE
test(integration): state-sync fixture — peer-floor fix, followers stop producing snapshots

### DIFF
--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -153,10 +153,16 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 	}
 	t.Logf("network %s: ready", s.chainID)
 
+	// Two phases: create every rpc node (so they all exist as each other's
+	// blocksync peers), then gate each on caught-up + EVM serving. Gating
+	// node i before node i+1 exists would strand a follower whose only peer
+	// is the validator — blocksync's caught-up check (sei-tendermint
+	// pool.IsCaughtUp) returns false unconditionally for a single-peer node,
+	// so its catching_up flag can never flip.
 	hc := &http.Client{Timeout: 10 * time.Second}
 	for i := range s.rpcNodes {
 		name := rpcNodeName(s.chainID, i)
-		node, err := bringUpRPCNode(ctx, t, c, hc, sei.NodeSpec{
+		node, err := createRPCNode(ctx, t, c, sei.NodeSpec{
 			Name:      name,
 			Network:   s.chainID,
 			Namespace: s.namespace,
@@ -171,17 +177,20 @@ func provision(ctx context.Context, t *testing.T, c *sei.Client, s spec) (*chain
 			return ch, err
 		}
 	}
+	for _, node := range ch.rpcNodes {
+		if err := gateRPCNode(ctx, t, hc, node); err != nil {
+			return ch, err
+		}
+	}
 	return ch, nil
 }
 
-// bringUpRPCNode creates an RPC SeiNode and blocks until it is fully serving:
-// running, caught up to the chain, then answering EVM RPC. Each gate is logged
-// as it passes so a stall is localizable in real time from the pod log (which
-// node, which gate) rather than a single terminal error. Returns the node
-// non-nil once created — even if a later gate fails — so the caller can still
-// register it for teardown; nil only when creation itself fails.
-func bringUpRPCNode(
-	ctx context.Context, t *testing.T, c *sei.Client, hc *http.Client, nodeSpec sei.NodeSpec,
+// createRPCNode creates an RPC SeiNode and blocks until it is running (config
+// applied, sidecar ready — discoverability, not serve-readiness). Returns the
+// node non-nil once created — even if the running gate fails — so the caller
+// can still register it for teardown; nil only when creation itself fails.
+func createRPCNode(
+	ctx context.Context, t *testing.T, c *sei.Client, nodeSpec sei.NodeSpec,
 ) (*sei.Node, error) {
 	t.Helper()
 	node, err := c.CreateNode(ctx, nodeSpec)
@@ -192,15 +201,24 @@ func bringUpRPCNode(
 		return node, fmt.Errorf("rpc node %q running: %w", nodeSpec.Name, err)
 	}
 	t.Logf("rpc node %s: running", nodeSpec.Name)
-	if err := sei.WaitCaughtUp(ctx, hc, node.TendermintRPC()); err != nil {
-		return node, fmt.Errorf("rpc node %q caught up: %w", nodeSpec.Name, err)
-	}
-	t.Logf("rpc node %s: caught up", nodeSpec.Name)
-	if err := sei.WaitEVMServing(ctx, hc, node.EVMRPC()); err != nil {
-		return node, fmt.Errorf("rpc node %q EVM serving: %w", nodeSpec.Name, err)
-	}
-	t.Logf("rpc node %s: EVM serving", nodeSpec.Name)
 	return node, nil
+}
+
+// gateRPCNode blocks until a running RPC node is fully serving: caught up to
+// the chain, then answering EVM RPC. Each gate is logged as it passes so a
+// stall is localizable in real time from the pod log (which node, which gate)
+// rather than a single terminal error.
+func gateRPCNode(ctx context.Context, t *testing.T, hc *http.Client, node *sei.Node) error {
+	t.Helper()
+	if err := sei.WaitCaughtUp(ctx, hc, node.TendermintRPC()); err != nil {
+		return fmt.Errorf("rpc node %q caught up: %w", node.Name(), err)
+	}
+	t.Logf("rpc node %s: caught up", node.Name())
+	if err := sei.WaitEVMServing(ctx, hc, node.EVMRPC()); err != nil {
+		return fmt.Errorf("rpc node %q EVM serving: %w", node.Name(), err)
+	}
+	t.Logf("rpc node %s: EVM serving", node.Name())
+	return nil
 }
 
 // teardown deletes the provisioned resources — the normal-exit fast path, wired

--- a/test/integration/workflow_test.go
+++ b/test/integration/workflow_test.go
@@ -20,11 +20,12 @@ import (
 	"github.com/sei-protocol/sei-k8s-controller/sdk/sei"
 )
 
-// snapshotProductionConfig makes the witness nodes emit CometBFT state-sync
+// snapshotProductionConfig makes the genesis validator emit CometBFT state-sync
 // snapshots so a wiped follower can re-bootstrap from them. Overlaid on the
-// memiavl baseline for the network in this suite, it reaches BOTH witnesses: it
-// is applied to the network (so the genesis validator inherits it) and to the
-// rpc follower via provision's storageConfig, so both witnesses serve chunks.
+// memiavl baseline for the network, it reaches the validator only: rpc followers
+// override the interval to 0 (see bringUpStateSyncFollower) because a
+// light-client witness serves RPC trust points while snapshot chunks travel
+// over p2p from the producing validator.
 // Without it, the resync has nothing to sync FROM and the node-side
 // WaitCaughtUp assertion after workflow Complete never clears (the workflow
 // itself completes at mark-ready and does not gate on catch-up).
@@ -60,8 +61,9 @@ var snapshotProductionConfig = map[string]string{
 // baseline: it stays independent and carries no migration.
 //
 // Witnesses: the follower's RpcServers are TWO DISTINCT full-node RPC endpoints —
-// genesis validator-0 and the provisioned rpc follower (rpcNodes[0]) — each a
-// caught-up node that serves snapshot chunks (nodeRPC below). Two DISTINCT
+// genesis validator-0 and rpc follower 0 (rpcNodes[0]) — each a live node
+// serving RPC trust points (nodeRPC below); chunks come from the
+// snapshot-producing validator over p2p. Two DISTINCT
 // witnesses drawn from different nodes (rather than two equal validators) keeps
 // liveness robust: the chain needs only its single validator online, and there is
 // no 2-validator genesis blocksync-bootstrap deadlock to stall on. The
@@ -77,8 +79,9 @@ var snapshotProductionConfig = map[string]string{
 // Cluster dependencies the CronJob wiring owns (documented, not asserted here):
 //   - the deployed controller + seid image carry the hold-aware start gate and
 //     the mark-not-ready/stop-seid/reset-data sidecar tasks;
-//   - both witnesses (validator-0 and the rpc follower) produce state-sync
-//     snapshots (snapshotProductionConfig, applied to both — see above).
+//   - validator-0 produces state-sync snapshots (snapshotProductionConfig);
+//     the rpc-follower witness serves RPC trust points only, chunks arrive
+//     over p2p from the validator.
 //
 // Inputs (env): SEI_CHAIN_ID, SEID_IMAGE [required]; SEI_NAMESPACE,
 // SEI_VALIDATORS [optional]. Run as the nightly CronJob:
@@ -99,7 +102,8 @@ func TestWorkflowStateSync(t *testing.T) {
 
 	// State-sync needs >=2 DISTINCT light-client witnesses (nodeRPC below). This
 	// suite draws them from TWO DIFFERENT nodes — the single genesis validator and
-	// the one provisioned rpc follower — so a single validator suffices. A second
+	// rpc follower 0 (of two; the sibling exists as a blocksync peer) — so a
+	// single validator suffices. A second
 	// equal validator would be strictly more fragile (both must stay online for
 	// 2/3, and some seid images stall a 2-validator genesis in a blocksync
 	// bootstrap deadlock), so keep the default at one.
@@ -193,15 +197,16 @@ type stateSyncFollower struct {
 }
 
 // bringUpStateSyncFollower provisions the snapshot-producing chain (1 validator +
-// N rpc followers, all memiavl + snapshot-producing) and brings up a plain
-// state-sync RPC follower against TWO DISTINCT witnesses, blocking until it is
-// running + caught up and verified to have started FROM a snapshot (earliest > 1).
+// two plain rpc followers, memiavl everywhere; only the validator produces
+// snapshots) and brings up a plain state-sync RPC follower against TWO DISTINCT
+// witnesses, blocking until it is running + caught up and verified to have
+// started FROM a snapshot (earliest > 1).
 // It registers teardown for everything it creates and t.Fatalf's on any failure,
 // so the caller gets a ready fixture or a failed test — never a half-built one.
 //
 // The two DISTINCT full-node RPC endpoints (bare host:port, the CRD
 // SnapshotSource.RpcServers shape) are genesis validator-0 (service <chainID>-0)
-// and the provisioned rpc follower (rpcNodeName(chainID,0) = <chainID>-rpc-0).
+// and the first provisioned rpc follower (rpcNodeName(chainID,0) = <chainID>-rpc-0).
 // The witness namespace is derived from the aggregate RPC host rather than the ns
 // input, which may be "" — the SDK resolves an empty namespace to a
 // kubeconfig/SA default that only the served endpoint reflects. The aggregate
@@ -210,14 +215,20 @@ type stateSyncFollower struct {
 func bringUpStateSyncFollower(ctx context.Context, t *testing.T, c *sei.Client, chainID, ns, seid string, validators int) stateSyncFollower {
 	t.Helper()
 
+	// Two followers: blocksync's caught-up check needs >1 peer (sei-tendermint
+	// pool.IsCaughtUp), so a lone follower peered only with the validator never
+	// reports caught up. Followers produce no snapshots (rpcConfig zeroes the
+	// interval): a witness serves RPC trust points; chunks come from the
+	// validator over p2p.
 	ch, err := provision(ctx, t, c, spec{
 		chainID:       chainID,
 		runID:         chainID,
 		namespace:     ns,
 		seidImage:     seid,
 		validators:    validators,
-		rpcNodes:      1,
+		rpcNodes:      2,
 		storageConfig: mergeConfig(memiavlStorageConfig, snapshotProductionConfig),
+		rpcConfig:     map[string]string{"storage.snapshot_interval": "0"},
 	})
 	cleanupChain(t, ch)
 	if err != nil {
@@ -250,7 +261,7 @@ func bringUpStateSyncFollower(ctx context.Context, t *testing.T, c *sei.Client, 
 	witnessNS := hostLabels[1]
 	witnesses := []string{
 		nodeRPC(fmt.Sprintf("%s-0", chainID), witnessNS), // genesis validator-0
-		nodeRPC(rpcNodeName(chainID, 0), witnessNS),      // the provisioned rpc follower
+		nodeRPC(rpcNodeName(chainID, 0), witnessNS),      // rpc follower 0
 	}
 
 	// Bring up a state-sync-bootstrapped follower: it must fetch a snapshot from a


### PR DESCRIPTION
## Summary

The state-sync suites (TestWorkflowStateSync, TestGigaStoreMigration) stalled unconditionally in their shared fixture: sei-tendermint's blocksync caught-up check has a hard >1-peer floor (`pool.IsCaughtUp` returns false for a single-peer node before any height math, `internal/blocksync/pool.go:211-214`, present since 2023), and the fixture's first rpc follower had exactly one peer — the lone validator — at its `WaitCaughtUp` gate. `catching_up` could never flip; both suites burned their 60m scenario deadline inside `provision`. The fixture never had a green execution: the state-sync round-trip was proven manually on a multi-peer chain, the single-validator topology landed later on review + compile gates only, and no nightly cron runs these suites.

Two changes, both required:

- **`provision` brings rpc nodes up in two phases** — create every node (`createRPCNode`: CreateNode + WaitReady), then gate each (`gateRPCNode`: WaitCaughtUp + WaitEVMServing). Gating node i before node i+1 exists strands a follower whose only peer is the validator.
- **The fixture provisions two followers, and followers produce no snapshots** (rpcConfig zeroes the interval). The sibling exists to be the second blocksync peer. A light-client witness serves RPC trust points; snapshot chunks come from the producing validator over p2p — and a producing follower at this chain's block rate requested snapshots faster than one takes to write, keeping a snapshot operation perpetually in progress (`ErrConflict` every interval).

Blast radius on the other suites sharing `provision` is nil: release/chaos/bench are 4-validator topologies (floor already cleared), genesis/upgrade have zero rpc nodes.

## Root cause

Root-caused live on harbor with blinded chain + infra lenses (/root-cause). Environment falsified by the assigned dissenter's own tests: workloads on disjoint nodes, no CPU limits, provisioned 10k-IOPS gp3, no chaos/netpol/pressure, and the co-tenant started 13 min after the stall began and completed while it persisted. Peer floor confirmed from source and live signals (n_peers=1; apply ≈14.5 blk/s vs produce ≈14.7 — a follower tracking seconds behind a bar it structurally cannot be credited with reaching).

## Review

xreview ledger: `bdchatham-designs/designs/seinode-task/xreview/workflow-complete-at-release.md` Rounds 10-11. First fix attempt (rpcNodes 1→2 alone) was caught broken by three independent blinded reviewers — provision's serial gate meant the second peer arrived too late — and repaired with the phase split. Round 11 unanimous RATIFY (sei-network-specialist as assigned dissenter, systems-engineer, idiomatic-reviewer).

**Two named empirical residuals, settled by the first live run** (this fixture has never run green, so the run is the proof):
1. With the floor cleared, `IsCaughtUp` still needs the follower to touch `maxPeerHeight-1` against ~15 blk/s production. Snapshot-drag removal is the material lever; `maxPeerHeight` is a periodically-reported (slightly stale) bar. Moderate-to-good confidence; a timeout here means the apply-rate flake persists and needs a different lever.
2. The phase split assumes `WaitReady`'s serve-probes clear pre-catch-up (they gate on liveness, not `catching_up` — `probe.go:46-48,83-85`); a seid image that errors `eth_blockNumber` until synced would re-import the stall into the create loop.

A validation run on harbor from the rebuilt harness image follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)