### PR TITLE
feat(nodetask): surface terminal InclusionUnverifiable gov outcome

### DIFF
--- a/internal/controller/nodetask/controller.go
+++ b/internal/controller/nodetask/controller.go
@@ -317,8 +317,10 @@ func (r *SeiNodeTaskReconciler) markComplete(cr *seiv1alpha1.SeiNodeTask, exec t
 }
 
 // handleFailure resolves an engine-Failed task. For gov kinds it decodes the
-// result to distinguish a committed-but-failed tx and an inclusion-undetermined
-// (pending) result — which is re-checked, not terminal — from a hard failure.
+// result to distinguish a committed-but-failed tx, an inclusion-undetermined
+// (pending) result — re-checked, not terminal — and an unverifiable outcome
+// (terminal; the tx may have committed, so verify out-of-band) from a hard
+// failure.
 func (r *SeiNodeTaskReconciler) handleFailure(cr *seiv1alpha1.SeiNodeTask, exec task.TaskExecution, now time.Time) {
 	msg := ""
 	if e := exec.Err(); e != nil {
@@ -344,6 +346,15 @@ func (r *SeiNodeTaskReconciler) handleFailure(cr *seiv1alpha1.SeiNodeTask, exec 
 			cr.Status.Task.Status = seiv1alpha1.TaskFailed
 			cr.Status.Task.Err = msg
 			r.markFailed(cr, now, "TxFailed", msg)
+			return
+		case wire.InclusionUnverifiable:
+			// Terminal, but distinct from TxFailed: the tx may have committed,
+			// so the reason (and the sidecar message) steer the operator to
+			// verify out-of-band rather than blindly re-run.
+			populateGovOutputs(cr, gr)
+			cr.Status.Task.Status = seiv1alpha1.TaskFailed
+			cr.Status.Task.Err = msg
+			r.markFailed(cr, now, "InclusionUnverifiable", msg)
 			return
 		}
 	}

--- a/internal/controller/nodetask/controller_gov_test.go
+++ b/internal/controller/nodetask/controller_gov_test.go
@@ -120,6 +120,40 @@ func TestReconcile_GovUpgrade_CommittedFailed(t *testing.T) {
 	g.Expect(got.Status.Outputs.GovSoftwareUpgrade.TxHash).To(Equal("ABC"))
 }
 
+// A gov Failed carrying inclusionStatus=unverifiable (the target node's tx
+// index is off, so inclusion is unobservable) is terminal and distinct from
+// TxFailed: outputs are still populated and the reason names the unverifiable
+// state so the operator knows to verify via an indexed RPC.
+func TestReconcile_GovUpgrade_Unverifiable(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	fakeSC := newFakeSidecarClient()
+	r, c := newReconcilerWithSidecar(t, time.Now(), fakeSC, newGovUpgradeTask(), newRunningNode())
+
+	_, err := r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	taskID, _ := uuid.Parse(getTask(t, ctx, c).Status.Task.ID)
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	fakeSC.setResultPayload(taskID, sidecar.Failed, "inclusion unverifiable",
+		json.RawMessage(`{"txHash":"ABC","inclusionStatus":"unverifiable"}`))
+
+	_, err = r.Reconcile(ctx, req())
+	g.Expect(err).NotTo(HaveOccurred())
+	got := getTask(t, ctx, c)
+	g.Expect(got.Status.Phase).To(Equal(seiv1alpha1.SeiNodeTaskPhaseFailed))
+	g.Expect(failedReasonOf(got)).To(Equal("InclusionUnverifiable"))
+	// Not success: no Ready latch (the tx outcome is unknown, not confirmed).
+	g.Expect(readyReasonOf(got)).To(Equal(""))
+	// txHash is surfaced for the operator's out-of-band check, but height and
+	// proposalId are genuinely unknown → omitted (zero), never asserted as 0.
+	g.Expect(got.Status.Outputs).NotTo(BeNil())
+	g.Expect(got.Status.Outputs.GovSoftwareUpgrade.TxHash).To(Equal("ABC"))
+	g.Expect(got.Status.Outputs.GovSoftwareUpgrade.Height).To(BeZero())
+	g.Expect(got.Status.Outputs.GovSoftwareUpgrade.ProposalID).To(BeZero())
+}
+
 func TestReconcile_GovUpgrade_Pending_ReSubmits(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()


### PR DESCRIPTION
> **Draft — blocked on sei-protocol/seictl#237.** This consumes the new `wire.InclusionUnverifiable` enum member added there. It will not compile against the pinned `seictl v0.0.64`; land order is: merge + release seictl#237, then `go get github.com/sei-protocol/seictl@<tag>` + `go mod tidy` here, then mark ready. CI is red until that bump. Validated locally against the seictl branch (build + gov reconcile tests pass).

## What

Handle the new terminal gov inclusion state `wire.InclusionUnverifiable` in `handleFailure`: a gov tx that was **broadcast and accepted at CheckTx** but whose on-chain outcome **cannot be confirmed** because the target node's tx index is disabled (`tx_index.indexer = "null"`).

- New `case wire.InclusionUnverifiable` → `populateGovOutputs` + `markFailed(reason: "InclusionUnverifiable")`. Terminal (retrying the same node is futile), mirroring the adjacent `CommittedFailed` case.
- **Distinct from `TxFailed`**: the tx may have committed, so the reason + the sidecar's message steer the operator to **verify out-of-band before re-running**. This matters most for `GovSoftwareUpgrade`, where re-running a "Failed" task does not unschedule an on-chain upgrade.
- `status.outputs` carries the `txHash` for that manual check; `height`/`proposalId` are genuinely unknown and omitted (never asserted as 0).

## Why

Without this case, an unverifiable result falls through to the generic `TaskFailed` reason with no structured outputs — the operator loses the txHash and the distinct signal. (Before the seictl fix, this class didn't terminalize at all — it retried to the task timeout and surfaced an opaque `Timeout`.)

## Tests

`TestReconcile_GovUpgrade_Unverifiable` (mirrors `TestReconcile_GovUpgrade_CommittedFailed`): asserts `Phase=Failed`, `reason=InclusionUnverifiable`, `txHash` surfaced, `height`/`proposalId` zero, and **no `Ready` latch** (unverifiable is not success). Status/condition level only.

## Review

Reviewed by kubernetes-specialist + idiomatic-reviewer: phase/reason/naming/nil-safety confirmed conforming; the "verify-first" nuance was placed on the seictl sentinel message (single source) and the `handleFailure` doc comment updated to enumerate the outcome.

Depends on sei-protocol/seictl#237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
